### PR TITLE
feat: send custom headers on the WebSocket transport

### DIFF
--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -32,8 +32,8 @@ use std::{
 use monty_pool::{
     exceeds_max_value_depth,
     telemetry::{TelemetryAdapterHandle, TelemetryContext},
-    Checkout, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue,
-    TurnEvent,
+    Checkout, CheckoutOptions, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig,
+    ResumeValue, TurnEvent,
 };
 use monty_types::{
     AssertMessageAnnotations, ExcType, MontyException, MontyObject, NameLookupResult, PrintStream, StackFrame,
@@ -328,12 +328,13 @@ impl NativeSession {
                 .as_ref()
                 .map(Arc::clone)
                 .ok_or_else(|| invalid("the pool is not started — create it with Monty.create()"))?;
-            let checkout = if let Some(context) = telemetry_context {
-                pool.checkout_with_telemetry(&repl_config, context).await
-            } else {
-                pool.checkout(&repl_config).await
-            }
-            .map_err(pool_error)?;
+            let checkout = pool
+                .checkout_with(
+                    &repl_config,
+                    CheckoutOptions::default().with_telemetry(telemetry_context),
+                )
+                .await
+                .map_err(pool_error)?;
             *slot.lock().await = Some(checkout);
             Ok(())
         })

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -168,7 +168,8 @@ flushing the host exporter.
   never prewarmed or returned to the pool. Isolation is the remote host's responsibility —
   a remote crash is observed as the connection dropping. `Pool::checkout_with` takes
   `CheckoutOptions::connect_headers`, extra headers for that checkout's upgrade request —
-  e.g. a fresh `traceparent` so server-side spans join the caller's trace.
+  e.g. a fresh `traceparent` so server-side spans join the caller's trace. The request
+  carries `User-Agent: monty-pool/<version>` unless a header of that name replaces it.
 
 ## Monty crates
 

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -168,8 +168,10 @@ flushing the host exporter.
   never prewarmed or returned to the pool. Isolation is the remote host's responsibility —
   a remote crash is observed as the connection dropping. `Pool::checkout_with` takes
   `CheckoutOptions::connect_headers`, extra headers for that checkout's upgrade request —
-  e.g. a fresh `traceparent` so server-side spans join the caller's trace. The request
-  carries `User-Agent: monty-pool/<version>` unless a header of that name replaces it.
+  e.g. a token for a relay in front of the worker. The request carries
+  `User-Agent: monty-pool/<version>`, and with the `telemetry` feature the `traceparent`
+  (and `tracestate`) of `CheckoutOptions::telemetry`, so server-side spans join the
+  caller's trace; a `connect_headers` entry of the same name replaces either.
 
 ## Monty crates
 

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -166,7 +166,9 @@ flushing the host exporter.
 - **WebSocket** (`PoolConfig::websocket`) — dial a remote child (or a relay pairing the two
   ends) over `ws://`/`wss://`. These workers are single-use: dialed fresh per checkout,
   never prewarmed or returned to the pool. Isolation is the remote host's responsibility —
-  a remote crash is observed as the connection dropping.
+  a remote crash is observed as the connection dropping. `connect_headers` attaches extra
+  upgrade-request headers, computed per dial — e.g. a fresh `traceparent` for the server to
+  parent its session spans into.
 
 ## Monty crates
 

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -166,9 +166,9 @@ flushing the host exporter.
 - **WebSocket** (`PoolConfig::websocket`) — dial a remote child (or a relay pairing the two
   ends) over `ws://`/`wss://`. These workers are single-use: dialed fresh per checkout,
   never prewarmed or returned to the pool. Isolation is the remote host's responsibility —
-  a remote crash is observed as the connection dropping. `connect_headers` attaches extra
-  upgrade-request headers, computed per dial — e.g. a fresh `traceparent` for the server to
-  parent its session spans into.
+  a remote crash is observed as the connection dropping. `Pool::checkout_with` takes
+  `CheckoutOptions::connect_headers`, extra headers for that checkout's upgrade request —
+  e.g. a fresh `traceparent` so server-side spans join the caller's trace.
 
 ## Monty crates
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -4,6 +4,7 @@
 use std::time::Instant;
 use std::{
     borrow::Cow,
+    fmt,
     future::{Future, ready},
     mem,
     path::Path,
@@ -22,7 +23,7 @@ use monty_types::{
 use tokio::{task::spawn_blocking, time::timeout};
 
 #[cfg(feature = "telemetry")]
-use crate::telemetry::metrics::outcome;
+use crate::telemetry::{TelemetryContext, metrics::outcome};
 use crate::{
     CrashCause, PoolError,
     pool::{CapacityGuard, PoolInner},
@@ -62,6 +63,51 @@ impl Default for ReplConfig {
             type_check_config: TypeCheckingConfig::default(),
             assert_message_annotations: AssertMessageAnnotations::default(),
         }
+    }
+}
+
+/// Host-side context for one checkout, as opposed to the [`ReplConfig`] the
+/// worker is sent.
+// non_exhaustive: options may be added without breaking callers
+#[derive(Default)]
+#[non_exhaustive]
+pub struct CheckoutOptions {
+    /// Distributed trace context captured by a host adapter.
+    #[cfg(feature = "telemetry")]
+    pub telemetry: Option<TelemetryContext>,
+    /// Extra headers for this checkout's WebSocket upgrade request; the
+    /// subprocess transport makes no request and ignores them. Duplicate
+    /// names are last-wins, even against `host` and the other handshake
+    /// headers, and a malformed name or value fails the dial.
+    pub connect_headers: Vec<(String, String)>,
+}
+
+impl CheckoutOptions {
+    /// Sets the distributed trace context, if the host captured one.
+    #[cfg(feature = "telemetry")]
+    #[must_use]
+    pub fn with_telemetry(mut self, telemetry: Option<TelemetryContext>) -> Self {
+        self.telemetry = telemetry;
+        self
+    }
+
+    /// Sets the headers for this checkout's WebSocket upgrade request.
+    #[must_use]
+    pub fn with_connect_headers(mut self, connect_headers: Vec<(String, String)>) -> Self {
+        self.connect_headers = connect_headers;
+        self
+    }
+}
+
+/// Names each connect header, never its value: monty never interprets the
+/// values, but a caller may send e.g. a token for a proxy/relay in front of
+/// the worker, and options get logged.
+impl fmt::Debug for CheckoutOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let header_names: Vec<&str> = self.connect_headers.iter().map(|(name, _)| name.as_str()).collect();
+        f.debug_struct("CheckoutOptions")
+            .field("connect_headers", &header_names)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -72,14 +72,17 @@ impl Default for ReplConfig {
 #[derive(Default)]
 #[non_exhaustive]
 pub struct CheckoutOptions {
-    /// Distributed trace context captured by a host adapter.
+    /// Distributed trace context captured by a host adapter. Its span also
+    /// goes out as `traceparent`/`tracestate` on a WebSocket dial, so a remote
+    /// worker's own spans join the host's trace.
     #[cfg(feature = "telemetry")]
     pub telemetry: Option<TelemetryContext>,
     /// Extra headers for this checkout's WebSocket upgrade request; the
     /// subprocess transport makes no request and ignores them. Duplicate
     /// names are last-wins, even against the default `user-agent`
-    /// (`monty-pool/<version>`), `host` and the other handshake headers,
-    /// and a malformed name or value fails the dial.
+    /// (`monty-pool/<version>`), the `traceparent` from `telemetry`, `host`
+    /// and the other handshake headers, and a malformed name or value fails
+    /// the dial.
     pub connect_headers: Vec<(String, String)>,
 }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -77,8 +77,9 @@ pub struct CheckoutOptions {
     pub telemetry: Option<TelemetryContext>,
     /// Extra headers for this checkout's WebSocket upgrade request; the
     /// subprocess transport makes no request and ignores them. Duplicate
-    /// names are last-wins, even against `host` and the other handshake
-    /// headers, and a malformed name or value fails the dial.
+    /// names are last-wins, even against the default `user-agent`
+    /// (`monty-pool/<version>`), `host` and the other handshake headers,
+    /// and a malformed name or value fails the dial.
     pub connect_headers: Vec<(String, String)>,
 }
 

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -63,7 +63,9 @@ pub struct ConnectHeaders(Arc<dyn Fn() -> Vec<(String, String)> + Send + Sync>);
 impl ConnectHeaders {
     /// Wraps a callback producing `(name, value)` pairs for one dial.
     /// Duplicate names are last-wins, and a pair naming a handshake-generated
-    /// header (`host`, `sec-websocket-key`, ...) replaces it.
+    /// header (`host`, `sec-websocket-key`, ...) replaces it. The callback
+    /// runs synchronously on the dialing task, outside the dial timeout, so
+    /// keep it cheap and non-blocking.
     pub fn new(f: impl Fn() -> Vec<(String, String)> + Send + Sync + 'static) -> Self {
         Self(Arc::new(f))
     }

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -9,7 +9,9 @@ pub mod telemetry;
 pub use telemetry as telemetry_adapter;
 mod worker;
 
-use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
+use std::{
+    borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, sync::Arc, thread, time::Duration,
+};
 
 pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
 use monty_types::MontyException;
@@ -45,6 +47,39 @@ impl MontyTransport {
     /// single-use (dialed per checkout, never pooled idle or reused).
     pub(crate) fn is_websocket(&self) -> bool {
         matches!(self, Self::Websocket(_))
+    }
+}
+
+/// Extra headers for the WebSocket upgrade request, computed per dial.
+///
+/// A callback rather than a static list because the interesting headers are
+/// per-*session*: each dial runs inline on the checking-out caller's task, so
+/// the callback can render that caller's ambient context — e.g. the current
+/// OTel span as a `traceparent` for the server to parent its session spans
+/// into. The pool never interprets the values, it just sends them.
+#[derive(Clone)]
+pub struct ConnectHeaders(Arc<dyn Fn() -> Vec<(String, String)> + Send + Sync>);
+
+impl ConnectHeaders {
+    /// Wraps a callback producing `(name, value)` pairs for one dial.
+    /// Duplicate names are last-wins, and a pair naming a handshake-generated
+    /// header (`host`, `sec-websocket-key`, ...) replaces it.
+    pub fn new(f: impl Fn() -> Vec<(String, String)> + Send + Sync + 'static) -> Self {
+        Self(Arc::new(f))
+    }
+
+    /// Computes the headers for one dial.
+    #[must_use]
+    pub fn get(&self) -> Vec<(String, String)> {
+        (self.0)()
+    }
+}
+
+impl fmt::Debug for ConnectHeaders {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // the callback is opaque, and its output may be sensitive (auth
+        // headers) — name the type, never a computed value
+        f.write_str("ConnectHeaders(..)")
     }
 }
 
@@ -87,6 +122,9 @@ pub struct PoolConfig {
     /// pools that record into the same host meter.
     #[cfg(feature = "telemetry")]
     pub metrics: Option<Metrics>,
+    /// Extra headers for the WebSocket upgrade request, computed per dial.
+    /// Ignored by the subprocess transport (it makes no requests).
+    pub connect_headers: Option<ConnectHeaders>,
 }
 
 impl PoolConfig {
@@ -117,6 +155,7 @@ impl PoolConfig {
             max_checkouts_per_worker: None,
             #[cfg(feature = "telemetry")]
             metrics: None,
+            connect_headers: None,
         }
     }
 }

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -9,9 +9,7 @@ pub mod telemetry;
 pub use telemetry as telemetry_adapter;
 mod worker;
 
-use std::{
-    borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, sync::Arc, thread, time::Duration,
-};
+use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
 
 pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
 use monty_types::MontyException;
@@ -20,8 +18,8 @@ use monty_types::MontyException;
 use crate::telemetry::Metrics;
 pub use crate::{
     checkout::{
-        Checkout, MountSpec, MountSpecMode, OnPrint, OnRawEvent, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
-        on_print_sync,
+        Checkout, CheckoutOptions, MountSpec, MountSpecMode, OnPrint, OnRawEvent, PrintFuture, ReplConfig, ResumeValue,
+        TurnEvent, on_print_sync,
     },
     pool::Pool,
 };
@@ -47,42 +45,6 @@ impl MontyTransport {
     /// single-use (dialed per checkout, never pooled idle or reused).
     pub(crate) fn is_websocket(&self) -> bool {
         matches!(self, Self::Websocket(_))
-    }
-}
-
-/// Extra headers for the WebSocket upgrade request, computed per dial.
-///
-/// A callback rather than a static list because the interesting headers are
-/// per-*session*: each dial runs inline on the checking-out caller's task, so
-/// the callback can render that caller's ambient context — e.g. the current
-/// OTel span as a `traceparent` for the server to parent its session spans
-/// into. The pool never interprets the values, it just sends them.
-#[derive(Clone)]
-pub struct ConnectHeaders(Arc<dyn Fn() -> Vec<(String, String)> + Send + Sync>);
-
-impl ConnectHeaders {
-    /// Wraps a callback producing `(name, value)` pairs for one dial.
-    /// Duplicate names are last-wins, and a pair naming a handshake-generated
-    /// header (`host`, `sec-websocket-key`, ...) replaces it. The callback
-    /// runs synchronously on the dialing task, outside the dial timeout, so
-    /// keep it cheap and non-blocking.
-    pub fn new(f: impl Fn() -> Vec<(String, String)> + Send + Sync + 'static) -> Self {
-        Self(Arc::new(f))
-    }
-
-    /// Computes the headers for one dial.
-    #[must_use]
-    pub fn get(&self) -> Vec<(String, String)> {
-        (self.0)()
-    }
-}
-
-impl fmt::Debug for ConnectHeaders {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The callback is opaque and its output may be sensitive: monty never
-        // interprets the values, but a caller may send e.g. a token for a
-        // proxy/relay in front of the child. Name the type, never a value.
-        f.write_str("ConnectHeaders(..)")
     }
 }
 
@@ -125,9 +87,6 @@ pub struct PoolConfig {
     /// pools that record into the same host meter.
     #[cfg(feature = "telemetry")]
     pub metrics: Option<Metrics>,
-    /// Extra headers for the WebSocket upgrade request, computed per dial.
-    /// Ignored by the subprocess transport (it makes no requests).
-    pub connect_headers: Option<ConnectHeaders>,
 }
 
 impl PoolConfig {
@@ -158,7 +117,6 @@ impl PoolConfig {
             max_checkouts_per_worker: None,
             #[cfg(feature = "telemetry")]
             metrics: None,
-            connect_headers: None,
         }
     }
 }

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -79,8 +79,9 @@ impl ConnectHeaders {
 
 impl fmt::Debug for ConnectHeaders {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // the callback is opaque, and its output may be sensitive (auth
-        // headers) — name the type, never a computed value
+        // The callback is opaque and its output may be sensitive: monty never
+        // interprets the values, but a caller may send e.g. a token for a
+        // proxy/relay in front of the child. Name the type, never a value.
         f.write_str("ConnectHeaders(..)")
     }
 }

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -94,10 +94,16 @@ impl Pool {
     /// host context `options` carries.
     ///
     /// Takes an idle worker when one exists, spawns or dials a new one (with
-    /// `options.connect_headers`) while below `max_processes`, and otherwise
-    /// waits up to `checkout_timeout` (forever when `None`) before failing
-    /// with [`PoolError::Exhausted`].
-    pub async fn checkout_with(&self, repl: &ReplConfig, options: CheckoutOptions) -> Result<Checkout, PoolError> {
+    /// `options.connect_headers`, preceded by the W3C trace headers of
+    /// `options.telemetry`) while below `max_processes`, and otherwise waits
+    /// up to `checkout_timeout` (forever when `None`) before failing with
+    /// [`PoolError::Exhausted`].
+    pub async fn checkout_with(&self, repl: &ReplConfig, mut options: CheckoutOptions) -> Result<Checkout, PoolError> {
+        // ahead of the caller's headers, which stay last-wins
+        #[cfg(feature = "telemetry")]
+        if let Some(telemetry) = &options.telemetry {
+            options.connect_headers.splice(0..0, telemetry.propagation_headers());
+        }
         let worker = self.inner.acquire_worker(&options.connect_headers).await?;
         #[cfg(feature = "telemetry")]
         let worker = worker.with_adapter_context(options.telemetry);

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -14,8 +14,6 @@ use tokio::{
     time::{Instant, timeout_at},
 };
 
-#[cfg(feature = "telemetry")]
-use crate::telemetry::TelemetryContext;
 use crate::{
     PoolConfig, PoolError,
     checkout::{Checkout, CheckoutOptions, ReplConfig, request},
@@ -104,18 +102,6 @@ impl Pool {
         #[cfg(feature = "telemetry")]
         let worker = worker.with_adapter_context(options.telemetry);
         Checkout::create(worker, Arc::clone(&self.inner), repl).await
-    }
-
-    /// Checks out a session with distributed context captured by a host
-    /// adapter — shorthand for [`Self::checkout_with`].
-    #[cfg(feature = "telemetry")]
-    pub async fn checkout_with_telemetry(
-        &self,
-        repl: &ReplConfig,
-        context: TelemetryContext,
-    ) -> Result<Checkout, PoolError> {
-        self.checkout_with(repl, CheckoutOptions::default().with_telemetry(Some(context)))
-            .await
     }
 
     /// Asks idle workers to exit cleanly and reaps them, capping the wait per

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -18,7 +18,7 @@ use tokio::{
 use crate::telemetry::TelemetryContext;
 use crate::{
     PoolConfig, PoolError,
-    checkout::{Checkout, ReplConfig, request},
+    checkout::{Checkout, CheckoutOptions, ReplConfig, request},
     worker::Worker,
 };
 
@@ -70,7 +70,7 @@ impl Pool {
         let mut idle = Vec::with_capacity(config.min_processes);
         if !config.transport.is_websocket() {
             for _ in 0..config.min_processes {
-                idle.push(Worker::new(&config).await?);
+                idle.push(Worker::new(&config, &[]).await?);
             }
         }
         let total = idle.len();
@@ -86,26 +86,36 @@ impl Pool {
         Ok(pool)
     }
 
-    /// Dedicates a worker to one REPL session created from `repl`.
-    ///
-    /// Takes an idle worker when one exists, spawns a new one while below
-    /// `max_processes`, and otherwise waits up to `checkout_timeout`
-    /// (forever when `None`) before failing with [`PoolError::Exhausted`].
+    /// Dedicates a worker to one REPL session created from `repl`, with
+    /// default [`CheckoutOptions`] — see [`Self::checkout_with`].
     pub async fn checkout(&self, repl: &ReplConfig) -> Result<Checkout, PoolError> {
-        let worker = self.inner.acquire_worker().await?;
+        self.checkout_with(repl, CheckoutOptions::default()).await
+    }
+
+    /// Dedicates a worker to one REPL session created from `repl`, with the
+    /// host context `options` carries.
+    ///
+    /// Takes an idle worker when one exists, spawns or dials a new one (with
+    /// `options.connect_headers`) while below `max_processes`, and otherwise
+    /// waits up to `checkout_timeout` (forever when `None`) before failing
+    /// with [`PoolError::Exhausted`].
+    pub async fn checkout_with(&self, repl: &ReplConfig, options: CheckoutOptions) -> Result<Checkout, PoolError> {
+        let worker = self.inner.acquire_worker(&options.connect_headers).await?;
+        #[cfg(feature = "telemetry")]
+        let worker = worker.with_adapter_context(options.telemetry);
         Checkout::create(worker, Arc::clone(&self.inner), repl).await
     }
 
-    /// Checks out a session with distributed context captured by a host adapter.
+    /// Checks out a session with distributed context captured by a host
+    /// adapter — shorthand for [`Self::checkout_with`].
     #[cfg(feature = "telemetry")]
     pub async fn checkout_with_telemetry(
         &self,
         repl: &ReplConfig,
         context: TelemetryContext,
     ) -> Result<Checkout, PoolError> {
-        let mut worker = self.inner.acquire_worker().await?;
-        worker.set_adapter_context(context);
-        Checkout::create(worker, Arc::clone(&self.inner), repl).await
+        self.checkout_with(repl, CheckoutOptions::default().with_telemetry(Some(context)))
+            .await
     }
 
     /// Asks idle workers to exit cleanly and reaps them, capping the wait per
@@ -170,15 +180,15 @@ const SHUTDOWN_EXIT_GRACE: Duration = Duration::from_millis(500);
 
 impl PoolInner {
     /// Takes a worker, reusing/spawning a local one or connecting a fresh
-    /// remote one, waiting as capacity allows — and times that for
-    /// `monty.pool.checkout.wait`.
-    pub(crate) async fn acquire_worker(&self) -> Result<Worker, PoolError> {
+    /// remote one (with `connect_headers` on its upgrade request), waiting as
+    /// capacity allows — and times that for `monty.pool.checkout.wait`.
+    pub(crate) async fn acquire_worker(&self, connect_headers: &[(String, String)]) -> Result<Worker, PoolError> {
         #[cfg(feature = "telemetry")]
         let started = Instant::now();
         // set by the acquisition itself: only it can tell an idle reuse from a
         // spawn, or either from a wait for capacity
         let mut outcome = "idle";
-        let worker = self.acquire_worker_inner(&mut outcome).await;
+        let worker = self.acquire_worker_inner(connect_headers, &mut outcome).await;
         #[cfg(feature = "telemetry")]
         if let Some(metrics) = &self.config.metrics {
             let outcome = match &worker {
@@ -191,9 +201,14 @@ impl PoolInner {
         worker
     }
 
-    /// Reuses/spawns a local worker or connects a fresh remote one, waiting as
-    /// capacity allows, and reports through `outcome` how it got one.
-    async fn acquire_worker_inner(&self, outcome: &mut &'static str) -> Result<Worker, PoolError> {
+    /// Reuses/spawns a local worker or connects a fresh remote one (with
+    /// `connect_headers` on its upgrade request), waiting as capacity allows,
+    /// and reports through `outcome` how it got one.
+    async fn acquire_worker_inner(
+        &self,
+        connect_headers: &[(String, String)],
+        outcome: &mut &'static str,
+    ) -> Result<Worker, PoolError> {
         // WebSocket connections are single-use and never pooled idle, so the
         // idle-reuse step is skipped and each acquisition dials a fresh worker.
         let websocket = self.config.transport.is_websocket();
@@ -249,7 +264,7 @@ impl PoolInner {
                 // guard the reserved slot: a failed — or cancelled, for the
                 // WebSocket dial — spawn must release it or the pool shrinks
                 let capacity = CapacityGuard::new(self);
-                let worker = Worker::new(&self.config).await?;
+                let worker = Worker::new(&self.config, connect_headers).await?;
                 capacity.disarm();
                 return Ok(worker);
             }

--- a/crates/monty-pool/src/telemetry/mod.rs
+++ b/crates/monty-pool/src/telemetry/mod.rs
@@ -132,6 +132,27 @@ impl TelemetryContext {
         self.logfire.clone()
     }
 
+    /// W3C `traceparent` (and `tracestate`, when non-empty) headers naming the
+    /// propagated span, for a remote worker's WebSocket upgrade request; empty
+    /// when the host captured no span.
+    pub(crate) fn propagation_headers(&self) -> Vec<(String, String)> {
+        let Some(parent) = &self.parent else {
+            return Vec::new();
+        };
+        let traceparent = format!(
+            "00-{}-{}-{:02x}",
+            parent.trace_id(),
+            parent.span_id(),
+            parent.trace_flags().to_u8()
+        );
+        let mut headers = vec![("traceparent".to_owned(), traceparent)];
+        let tracestate = parent.trace_state().header();
+        if !tracestate.is_empty() {
+            headers.push(("tracestate".to_owned(), tracestate));
+        }
+        headers
+    }
+
     /// Converts the propagated span into the remote OTel parent context.
     pub(crate) fn into_parent(self) -> Option<Context> {
         self.parent

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -46,7 +46,7 @@ use tokio_tungstenite::{
     tungstenite::{
         Bytes, Error as WsError, Message,
         client::IntoClientRequest,
-        http::{HeaderName, HeaderValue},
+        http::{HeaderName, HeaderValue, header::USER_AGENT},
         protocol::WebSocketConfig,
     },
 };
@@ -240,6 +240,12 @@ impl Worker {
         let mut request = url
             .into_client_request()
             .map_err(|err| PoolError::Spawn(format!("{url}: {err}")))?;
+
+        // set before the caller's headers so a `user-agent` entry there overrides it
+        request
+            .headers_mut()
+            .insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+
         // a malformed name/value is a caller bug: fail the dial
         for (name, value) in connect_headers {
             let name = HeaderName::from_bytes(name.as_bytes())
@@ -615,6 +621,10 @@ fn ws_to_frame_error(err: WsError) -> FrameError {
         _ => FrameError::Truncated,
     }
 }
+
+/// `User-Agent` on every WebSocket upgrade request, identifying this crate to
+/// the server or relay it dials; a `connect_headers` entry replaces it.
+const USER_AGENT_VALUE: &str = concat!("monty-pool/", env!("CARGO_PKG_VERSION"));
 
 /// Fallback dial budget when the pool sets no `request_timeout` (which otherwise
 /// also bounds the WebSocket dial). Generous, since it only guards a stuck dial.

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -43,12 +43,17 @@ use tokio::{
 };
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async_tls_with_config,
-    tungstenite::{Bytes, Error as WsError, Message, protocol::WebSocketConfig},
+    tungstenite::{
+        Bytes, Error as WsError, Message,
+        client::IntoClientRequest,
+        http::{HeaderName, HeaderValue},
+        protocol::WebSocketConfig,
+    },
 };
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{TelemetryContext, metrics::TurnMetrics, tracing::Recorder};
-use crate::{MontyTransport, PoolConfig, PoolError};
+use crate::{ConnectHeaders, MontyTransport, PoolConfig, PoolError};
 
 /// The async WebSocket stream type for a remote worker.
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -149,7 +154,12 @@ impl Worker {
             // Bound the dial by `request_timeout` (see `websocket`); a missing
             // one falls back to a generous fixed budget.
             MontyTransport::Websocket(url) => {
-                Self::websocket(url, config.request_timeout.unwrap_or(DEFAULT_DIAL_TIMEOUT)).await
+                Self::websocket(
+                    url,
+                    config.request_timeout.unwrap_or(DEFAULT_DIAL_TIMEOUT),
+                    config.connect_headers.as_ref(),
+                )
+                .await
             }
         };
         #[cfg(feature = "telemetry")]
@@ -216,12 +226,31 @@ impl Worker {
     /// hung dial would otherwise stall the checkout forever. Frame/message
     /// limits are raised to monty's [`MAX_FRAME_LEN`] so the transport never
     /// rejects a frame the protocol itself would accept.
-    async fn websocket(url: &str, dial_timeout: Duration) -> Result<Self, PoolError> {
+    async fn websocket(
+        url: &str,
+        dial_timeout: Duration,
+        connect_headers: Option<&ConnectHeaders>,
+    ) -> Result<Self, PoolError> {
         install_crypto_provider();
         let ws_config = WebSocketConfig::default()
             .max_frame_size(Some(MAX_FRAME_LEN as usize))
             .max_message_size(Some(MAX_FRAME_LEN as usize));
-        let dial = connect_async_tls_with_config(url, Some(ws_config), true, None);
+        // The dial runs inline on the checking-out caller's task (see
+        // `acquire_worker`), as [`ConnectHeaders`] promises. A malformed
+        // name/value is a caller bug that fails the dial loudly.
+        let mut request = url
+            .into_client_request()
+            .map_err(|err| PoolError::Spawn(format!("{url}: {err}")))?;
+        if let Some(headers) = connect_headers {
+            for (name, value) in headers.get() {
+                let name = HeaderName::from_bytes(name.as_bytes())
+                    .map_err(|err| PoolError::Spawn(format!("{url}: connect header {name:?}: {err}")))?;
+                let value = HeaderValue::from_str(&value)
+                    .map_err(|err| PoolError::Spawn(format!("{url}: connect header {name:?} value: {err}")))?;
+                request.headers_mut().insert(name, value);
+            }
+        }
+        let dial = connect_async_tls_with_config(request, Some(ws_config), true, None);
         let (stream, _response) = timeout(dial_timeout, dial)
             .await
             .map_err(|_| PoolError::Spawn(format!("{url}: connect timed out after {dial_timeout:?}")))?

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -53,7 +53,7 @@ use tokio_tungstenite::{
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{TelemetryContext, metrics::TurnMetrics, tracing::Recorder};
-use crate::{ConnectHeaders, MontyTransport, PoolConfig, PoolError};
+use crate::{MontyTransport, PoolConfig, PoolError};
 
 /// The async WebSocket stream type for a remote worker.
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -147,8 +147,9 @@ async fn send_close(sink: &mut SplitSink<WsStream, Message>) {
 }
 
 impl Worker {
-    /// Creates a worker for `config`'s transport.
-    pub(crate) async fn new(config: &PoolConfig) -> Result<Self, PoolError> {
+    /// Creates a worker for `config`'s transport. `connect_headers` go on the
+    /// WebSocket upgrade request; a subprocess makes no request and ignores them.
+    pub(crate) async fn new(config: &PoolConfig, connect_headers: &[(String, String)]) -> Result<Self, PoolError> {
         let worker = match &config.transport {
             MontyTransport::Subprocess(binary_path) => Self::subprocess(binary_path),
             // Bound the dial by `request_timeout` (see `websocket`); a missing
@@ -157,7 +158,7 @@ impl Worker {
                 Self::websocket(
                     url,
                     config.request_timeout.unwrap_or(DEFAULT_DIAL_TIMEOUT),
-                    config.connect_headers.as_ref(),
+                    connect_headers,
                 )
                 .await
             }
@@ -219,7 +220,8 @@ impl Worker {
     }
 
     /// Connects to a remote child over a WebSocket, dialing `url` verbatim. Any
-    /// session/rendezvous routing the URL needs is the caller's responsibility.
+    /// session/rendezvous routing the URL needs is the caller's responsibility;
+    /// `connect_headers` go on the upgrade request (see [`crate::CheckoutOptions`]).
     ///
     /// `dial_timeout` bounds the whole dial (DNS + TCP connect + TLS/WS
     /// handshake): `checkout_timeout` only covers waiting for capacity, so a
@@ -229,26 +231,22 @@ impl Worker {
     async fn websocket(
         url: &str,
         dial_timeout: Duration,
-        connect_headers: Option<&ConnectHeaders>,
+        connect_headers: &[(String, String)],
     ) -> Result<Self, PoolError> {
         install_crypto_provider();
         let ws_config = WebSocketConfig::default()
             .max_frame_size(Some(MAX_FRAME_LEN as usize))
             .max_message_size(Some(MAX_FRAME_LEN as usize));
-        // The dial runs inline on the checking-out caller's task (see
-        // `acquire_worker`), as [`ConnectHeaders`] promises. A malformed
-        // name/value is a caller bug that fails the dial loudly.
         let mut request = url
             .into_client_request()
             .map_err(|err| PoolError::Spawn(format!("{url}: {err}")))?;
-        if let Some(headers) = connect_headers {
-            for (name, value) in headers.get() {
-                let name = HeaderName::from_bytes(name.as_bytes())
-                    .map_err(|err| PoolError::Spawn(format!("{url}: connect header {name:?}: {err}")))?;
-                let value = HeaderValue::from_str(&value)
-                    .map_err(|err| PoolError::Spawn(format!("{url}: connect header {name:?} value: {err}")))?;
-                request.headers_mut().insert(name, value);
-            }
+        // a malformed name/value is a caller bug: fail the dial
+        for (name, value) in connect_headers {
+            let name = HeaderName::from_bytes(name.as_bytes())
+                .map_err(|err| PoolError::Spawn(format!("{url}: connect header {name:?}: {err}")))?;
+            let value = HeaderValue::from_str(value)
+                .map_err(|err| PoolError::Spawn(format!("{url}: connect header {name:?} value: {err}")))?;
+            request.headers_mut().insert(name, value);
         }
         let dial = connect_async_tls_with_config(request, Some(ws_config), true, None);
         let (stream, _response) = timeout(dial_timeout, dial)
@@ -328,13 +326,17 @@ impl Worker {
         result.map(drop)
     }
 
-    /// Assigns propagated host context before this worker starts a checkout.
+    /// Attaches the host's trace context, if it captured one, before this
+    /// worker starts a checkout.
     #[cfg(feature = "telemetry")]
-    pub(crate) fn set_adapter_context(&mut self, context: TelemetryContext) {
-        let worker_pid = self.pid();
-        self.recorder
-            .get_or_insert_with(|| Box::new(Recorder::new(worker_pid)))
-            .set_adapter_context(context);
+    pub(crate) fn with_adapter_context(mut self, context: Option<TelemetryContext>) -> Self {
+        if let Some(context) = context {
+            let worker_pid = self.pid();
+            self.recorder
+                .get_or_insert_with(|| Box::new(Recorder::new(worker_pid)))
+                .set_adapter_context(context);
+        }
+        self
     }
 
     /// Receives one event. EOF/close is an error here because within a

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -3,6 +3,8 @@
 //! session. This exercises `Worker::websocket` (the async dial) and the WS
 //! send/recv path end-to-end without needing a real remote child.
 
+#[cfg(feature = "telemetry")]
+use std::sync::Arc;
 use std::{
     fs,
     future::ready,
@@ -12,12 +14,18 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "telemetry")]
+use monty_pool::telemetry::{TelemetryAdapter, configure_telemetry_adapter};
 use monty_pool::{
     Checkout, CheckoutOptions, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig,
     ResumeValue, TurnEvent,
 };
 use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, WireObject, decode_frame, encode_to_capped_vec, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits};
+#[cfg(feature = "telemetry")]
+use opentelemetry::trace::{SpanId, TraceId};
+#[cfg(feature = "telemetry")]
+use opentelemetry_sdk::{logs::SdkLogRecord, trace::SpanData};
 use tokio::task::spawn_blocking;
 #[cfg(not(windows))]
 use tokio::time::timeout;
@@ -56,25 +64,54 @@ fn answer_requests(socket: &mut WebSocket<TcpStream>) {
     }
 }
 
-/// A mock child that also reports `header`'s value from each of `connections`
-/// upgrade requests — the handshake callback is where a server reads them.
-fn serve_capturing_header(listener: &TcpListener, header: &str, connections: usize, tx: &mpsc::Sender<Option<String>>) {
+/// A mock child that also reports each of `headers`' values (in order, `None`
+/// when absent) from each of `connections` upgrade requests — the handshake
+/// callback is where a server reads them.
+fn serve_capturing_headers(
+    listener: &TcpListener,
+    headers: &[&str],
+    connections: usize,
+    tx: &mpsc::Sender<Vec<Option<String>>>,
+) {
     for _ in 0..connections {
         let (stream, _peer) = listener.accept().expect("accept");
         // the Err type (an ErrorResponse) is tungstenite's callback contract
         #[expect(clippy::result_large_err)]
         let callback = |req: &Request, resp: Response| {
-            let seen = req
-                .headers()
-                .get(header)
-                .and_then(|v| v.to_str().ok())
-                .map(str::to_owned);
-            tx.send(seen).expect("send captured header");
+            let seen = headers
+                .iter()
+                .map(|header| {
+                    req.headers()
+                        .get(*header)
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_owned)
+                })
+                .collect();
+            tx.send(seen).expect("send captured headers");
             Ok(resp)
         };
         let mut socket = tungstenite::accept_hdr(stream, callback).expect("ws handshake");
         answer_requests(&mut socket);
     }
+}
+
+/// A telemetry adapter accepting every record, for tests that only care what
+/// an installed adapter makes the pool do (e.g. the headers it dials with).
+#[cfg(feature = "telemetry")]
+struct AcceptAll;
+
+#[cfg(feature = "telemetry")]
+impl TelemetryAdapter for AcceptAll {
+    fn start_span(&self, _: &SpanData) -> bool {
+        true
+    }
+    fn end_span(&self, _: &SpanData) -> bool {
+        true
+    }
+    fn emit_log(&self, _: SpanId, _: &SdkLogRecord) -> bool {
+        true
+    }
+    fn disable_root(&self, _: TraceId, _: SpanId) {}
 }
 
 /// A discard-everything print callback, coercible to `OnPrint` at each callsite.
@@ -136,7 +173,7 @@ async fn drives_a_session_over_websocket() {
 async fn connect_headers_are_per_checkout() {
     let (header_tx, header_rx) = mpsc::channel();
     let (listener, mut config) = ws_pool_config();
-    let server = thread::spawn(move || serve_capturing_header(&listener, "traceparent", 2, &header_tx));
+    let server = thread::spawn(move || serve_capturing_headers(&listener, &["traceparent"], 2, &header_tx));
 
     config.request_timeout = Some(Duration::from_secs(10));
     let pool = Pool::new(config).await.expect("pool");
@@ -150,8 +187,8 @@ async fn connect_headers_are_per_checkout() {
             CheckoutOptions::default().with_connect_headers(vec![("traceparent".to_owned(), trace.to_owned())]);
         let mut checkout = pool.checkout_with(&repl, options).await.expect("checkout");
         assert_eq!(
-            header_rx.recv().expect("captured header"),
-            Some(trace.to_owned()),
+            header_rx.recv().expect("captured headers"),
+            vec![Some(trace.to_owned())],
             "each dial must carry the headers of the checkout that made it"
         );
         // the session still works normally with extra headers on the dial
@@ -173,7 +210,7 @@ async fn connect_headers_are_per_checkout() {
 async fn duplicate_connect_headers_are_last_wins() {
     let (header_tx, header_rx) = mpsc::channel();
     let (listener, mut config) = ws_pool_config();
-    let server = thread::spawn(move || serve_capturing_header(&listener, "traceparent", 1, &header_tx));
+    let server = thread::spawn(move || serve_capturing_headers(&listener, &["traceparent"], 1, &header_tx));
     config.request_timeout = Some(Duration::from_secs(10));
     let pool = Pool::new(config).await.expect("pool");
 
@@ -185,7 +222,10 @@ async fn duplicate_connect_headers_are_last_wins() {
         .checkout_with(&ReplConfig::default(), options)
         .await
         .expect("checkout");
-    assert_eq!(header_rx.recv().expect("captured header").as_deref(), Some("second"));
+    assert_eq!(
+        header_rx.recv().expect("captured headers"),
+        vec![Some("second".to_owned())]
+    );
     checkout.finish().await.expect("finish");
     join_server(server).await;
 }
@@ -197,14 +237,14 @@ async fn duplicate_connect_headers_are_last_wins() {
 async fn user_agent_is_set_and_overridable() {
     let (header_tx, header_rx) = mpsc::channel();
     let (listener, mut config) = ws_pool_config();
-    let server = thread::spawn(move || serve_capturing_header(&listener, "user-agent", 2, &header_tx));
+    let server = thread::spawn(move || serve_capturing_headers(&listener, &["user-agent"], 2, &header_tx));
     config.request_timeout = Some(Duration::from_secs(10));
     let pool = Pool::new(config).await.expect("pool");
 
     let checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
     assert_eq!(
-        header_rx.recv().expect("captured header"),
-        Some(format!("monty-pool/{}", env!("CARGO_PKG_VERSION")))
+        header_rx.recv().expect("captured headers"),
+        vec![Some(format!("monty-pool/{}", env!("CARGO_PKG_VERSION")))]
     );
     checkout.finish().await.expect("finish");
 
@@ -215,8 +255,62 @@ async fn user_agent_is_set_and_overridable() {
         .await
         .expect("checkout");
     assert_eq!(
-        header_rx.recv().expect("captured header").as_deref(),
-        Some("my-app/1.0")
+        header_rx.recv().expect("captured headers"),
+        vec![Some("my-app/1.0".to_owned())]
+    );
+    checkout.finish().await.expect("finish");
+    join_server(server).await;
+}
+
+/// A host trace context captured through the telemetry adapter goes out as
+/// W3C `traceparent`/`tracestate` on the dial, so a remote worker's spans join
+/// the host's trace with no header plumbing by the binding; an explicit
+/// `connect_headers` entry still wins.
+#[cfg(feature = "telemetry")]
+#[tokio::test]
+async fn telemetry_context_is_propagated_on_the_dial() {
+    let handle = configure_telemetry_adapter(Arc::new(AcceptAll)).expect("configure");
+    let context = || {
+        handle
+            .context(
+                "0af7651916cd43dd8448eb211c80319c",
+                "b7ad6b7169203331",
+                1,
+                "congo=t61rcWkgMzE",
+            )
+            .expect("context")
+    };
+    let (header_tx, header_rx) = mpsc::channel();
+    let (listener, mut config) = ws_pool_config();
+    let server =
+        thread::spawn(move || serve_capturing_headers(&listener, &["traceparent", "tracestate"], 2, &header_tx));
+    config.request_timeout = Some(Duration::from_secs(10));
+    let pool = Pool::new(config).await.expect("pool");
+
+    let options = CheckoutOptions::default().with_telemetry(Some(context()));
+    let checkout = pool
+        .checkout_with(&ReplConfig::default(), options)
+        .await
+        .expect("checkout");
+    assert_eq!(
+        header_rx.recv().expect("captured headers"),
+        vec![
+            Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".to_owned()),
+            Some("congo=t61rcWkgMzE".to_owned()),
+        ]
+    );
+    checkout.finish().await.expect("finish");
+
+    let options = CheckoutOptions::default()
+        .with_telemetry(Some(context()))
+        .with_connect_headers(vec![("traceparent".to_owned(), "00-explicit".to_owned())]);
+    let checkout = pool
+        .checkout_with(&ReplConfig::default(), options)
+        .await
+        .expect("checkout");
+    assert_eq!(
+        header_rx.recv().expect("captured headers"),
+        vec![Some("00-explicit".to_owned()), Some("congo=t61rcWkgMzE".to_owned())]
     );
     checkout.finish().await.expect("finish");
     join_server(server).await;

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -203,6 +203,28 @@ async fn malformed_connect_headers_fail_the_dial() {
     }
 }
 
+/// A URL that cannot form an upgrade request fails the dial with the same
+/// `{url}: {err}` shape as every other dial failure.
+#[tokio::test]
+async fn an_unparseable_url_fails_the_dial() {
+    let pool = Pool::new(PoolConfig::websocket("not a url")).await.expect("pool");
+    let Err(err) = pool.checkout(&ReplConfig::default()).await else {
+        panic!("unparseable URL must fail the dial");
+    };
+    let PoolError::Spawn(msg) = err else {
+        panic!("expected Spawn error, got {err:?}");
+    };
+    assert_eq!(msg, "not a url: HTTP format error: invalid uri character");
+}
+
+/// `Debug` for [`ConnectHeaders`] names the type and never a computed value —
+/// header values may carry auth material, and configs get logged.
+#[test]
+fn connect_headers_debug_is_redacted() {
+    let headers = ConnectHeaders::new(|| vec![("authorization".to_owned(), "Bearer secret".to_owned())]);
+    assert_eq!(format!("{headers:?}"), "ConnectHeaders(..)");
+}
+
 /// Binds a listener and returns it with a websocket pool config pointing at it.
 fn ws_pool_config() -> (TcpListener, PoolConfig) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -206,10 +206,10 @@ async fn malformed_connect_headers_fail_the_dial() {
 /// A URL that cannot form an upgrade request fails the dial with the same
 /// `{url}: {err}` shape as every other dial failure.
 #[tokio::test]
-async fn an_unparseable_url_fails_the_dial() {
+async fn an_unparsable_url_fails_the_dial() {
     let pool = Pool::new(PoolConfig::websocket("not a url")).await.expect("pool");
     let Err(err) = pool.checkout(&ReplConfig::default()).await else {
-        panic!("unparseable URL must fail the dial");
+        panic!("unparsable URL must fail the dial");
     };
     let PoolError::Spawn(msg) = err else {
         panic!("expected Spawn error, got {err:?}");

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -3,32 +3,44 @@
 //! session. This exercises `Worker::websocket` (the async dial) and the WS
 //! send/recv path end-to-end without needing a real remote child.
 
-// only the windows-gated capacity test wedges a socket with a blocked channel
-#[cfg(not(windows))]
-use std::sync::mpsc;
 use std::{
     fs,
     future::ready,
     net::{TcpListener, TcpStream},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
     thread,
     time::Duration,
 };
 
 use monty_pool::{
-    Checkout, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
+    Checkout, ConnectHeaders, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig,
+    ResumeValue, TurnEvent,
 };
 use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, WireObject, decode_frame, encode_to_capped_vec, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits};
 use tokio::task::spawn_blocking;
 #[cfg(not(windows))]
 use tokio::time::timeout;
-use tungstenite::{Message, WebSocket};
+use tungstenite::{
+    Message, WebSocket,
+    handshake::server::{Request, Response},
+};
 
 /// A mock child: accepts one WebSocket connection and answers each request with
 /// the obvious turn-ender (`Ok` for control requests, `Complete(42)` for a feed).
 fn serve_mock_child(listener: &TcpListener) {
     let (stream, _peer) = listener.accept().expect("accept");
     let mut socket = tungstenite::accept(stream).expect("ws handshake");
+    answer_requests(&mut socket);
+}
+
+/// Answers each request on an accepted socket with the obvious turn-ender
+/// (`Ok` for control requests, `Complete(42)` for a feed) until the peer
+/// disconnects.
+fn answer_requests(socket: &mut WebSocket<TcpStream>) {
     while let Ok(Message::Binary(data)) = socket.read() {
         let request = decode_frame::<pb::ParentRequest>(data.as_ref()).expect("decode request");
         let kind = match request.kind.expect("request kind") {
@@ -96,6 +108,99 @@ async fn drives_a_session_over_websocket() {
 
     checkout.finish().await.expect("finish");
     join_server(server).await;
+}
+
+/// The `connect_headers` callback runs afresh for every dial: WebSocket
+/// workers are single-use, so two checkouts are two dials, and each upgrade
+/// request must carry the value rendered for *that* dial (a `traceparent`
+/// rendered at checkout time is the motivating case).
+#[tokio::test]
+async fn connect_headers_are_computed_per_dial() {
+    // Capture each upgrade request's traceparent from the handshake callback —
+    // the exact place a server extracts trace context.
+    let (header_tx, header_rx) = mpsc::channel::<Option<String>>();
+    let (listener, mut config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        for _ in 0..2 {
+            let (stream, _peer) = listener.accept().expect("accept");
+            // the Err type (an ErrorResponse) is tungstenite's callback contract
+            #[expect(clippy::result_large_err)]
+            let callback = |req: &Request, resp: Response| {
+                let seen = req
+                    .headers()
+                    .get("traceparent")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned);
+                header_tx.send(seen).expect("send captured header");
+                Ok(resp)
+            };
+            let mut socket = tungstenite::accept_hdr(stream, callback).expect("ws handshake");
+            answer_requests(&mut socket);
+        }
+    });
+
+    config.request_timeout = Some(Duration::from_secs(10));
+    let dials = AtomicUsize::new(0);
+    config.connect_headers = Some(ConnectHeaders::new(move || {
+        let dial = dials.fetch_add(1, Ordering::Relaxed) + 1;
+        vec![("traceparent".to_owned(), format!("00-dial-{dial}"))]
+    }));
+    let pool = Pool::new(config).await.expect("pool");
+
+    for dial in 1..=2 {
+        let mut checkout = pool
+            .checkout(&ReplConfig {
+                script_name: "test.py".to_owned(),
+                ..ReplConfig::default()
+            })
+            .await
+            .expect("checkout");
+        assert_eq!(
+            header_rx.recv().expect("captured header"),
+            Some(format!("00-dial-{dial}")),
+            "each dial must carry the value computed for it"
+        );
+        // the session still works normally with extra headers on the dial
+        let event = checkout
+            .feed("1 + 1", vec![], vec![], false, &mut no_print)
+            .await
+            .expect("feed");
+        assert!(
+            matches!(event, TurnEvent::Complete(MontyObject::Int(42))),
+            "got {event:?}"
+        );
+        checkout.finish().await.expect("finish");
+    }
+    join_server(server).await;
+}
+
+/// A malformed header name or value is validated before any I/O, so no server
+/// is needed: the checkout fails loudly with the promised dial error instead
+/// of the pair being silently dropped.
+#[tokio::test]
+async fn malformed_connect_headers_fail_the_dial() {
+    let cases = [
+        (
+            ("bad name", "v"),
+            "ws://127.0.0.1:9: connect header \"bad name\": invalid HTTP header name",
+        ),
+        (
+            ("traceparent", "line\nbreak"),
+            "ws://127.0.0.1:9: connect header \"traceparent\" value: failed to parse header value",
+        ),
+    ];
+    for ((name, value), expected) in cases {
+        let mut config = PoolConfig::websocket("ws://127.0.0.1:9");
+        config.connect_headers = Some(ConnectHeaders::new(move || vec![(name.to_owned(), value.to_owned())]));
+        let pool = Pool::new(config).await.expect("pool");
+        let Err(err) = pool.checkout(&ReplConfig::default()).await else {
+            panic!("malformed header must fail the dial");
+        };
+        let PoolError::Spawn(msg) = err else {
+            panic!("expected Spawn error, got {err:?}");
+        };
+        assert_eq!(msg, expected);
+    }
 }
 
 /// Binds a listener and returns it with a websocket pool config pointing at it.

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -190,6 +190,38 @@ async fn duplicate_connect_headers_are_last_wins() {
     join_server(server).await;
 }
 
+/// Every dial carries a `User-Agent` naming this crate and its version, and a
+/// `connect_headers` entry of the same name replaces it rather than being
+/// appended, so a caller can identify their own product instead.
+#[tokio::test]
+async fn user_agent_is_set_and_overridable() {
+    let (header_tx, header_rx) = mpsc::channel();
+    let (listener, mut config) = ws_pool_config();
+    let server = thread::spawn(move || serve_capturing_header(&listener, "user-agent", 2, &header_tx));
+    config.request_timeout = Some(Duration::from_secs(10));
+    let pool = Pool::new(config).await.expect("pool");
+
+    let checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    assert_eq!(
+        header_rx.recv().expect("captured header"),
+        Some(format!("monty-pool/{}", env!("CARGO_PKG_VERSION")))
+    );
+    checkout.finish().await.expect("finish");
+
+    let options =
+        CheckoutOptions::default().with_connect_headers(vec![("User-Agent".to_owned(), "my-app/1.0".to_owned())]);
+    let checkout = pool
+        .checkout_with(&ReplConfig::default(), options)
+        .await
+        .expect("checkout");
+    assert_eq!(
+        header_rx.recv().expect("captured header").as_deref(),
+        Some("my-app/1.0")
+    );
+    checkout.finish().await.expect("finish");
+    join_server(server).await;
+}
+
 /// A malformed header name or value is validated before any I/O, so no server
 /// is needed: the checkout fails loudly with the promised dial error instead
 /// of the pair being silently dropped.

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -7,16 +7,13 @@ use std::{
     fs,
     future::ready,
     net::{TcpListener, TcpStream},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        mpsc,
-    },
+    sync::mpsc,
     thread,
     time::Duration,
 };
 
 use monty_pool::{
-    Checkout, ConnectHeaders, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig,
+    Checkout, CheckoutOptions, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig,
     ResumeValue, TurnEvent,
 };
 use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, WireObject, decode_frame, encode_to_capped_vec, pb};
@@ -56,6 +53,27 @@ fn answer_requests(socket: &mut WebSocket<TcpStream>) {
         };
         let body = encode_to_capped_vec(&event).expect("encode event");
         socket.send(Message::Binary(body.into())).expect("send event");
+    }
+}
+
+/// A mock child that also reports `header`'s value from each of `connections`
+/// upgrade requests — the handshake callback is where a server reads them.
+fn serve_capturing_header(listener: &TcpListener, header: &str, connections: usize, tx: &mpsc::Sender<Option<String>>) {
+    for _ in 0..connections {
+        let (stream, _peer) = listener.accept().expect("accept");
+        // the Err type (an ErrorResponse) is tungstenite's callback contract
+        #[expect(clippy::result_large_err)]
+        let callback = |req: &Request, resp: Response| {
+            let seen = req
+                .headers()
+                .get(header)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned);
+            tx.send(seen).expect("send captured header");
+            Ok(resp)
+        };
+        let mut socket = tungstenite::accept_hdr(stream, callback).expect("ws handshake");
+        answer_requests(&mut socket);
     }
 }
 
@@ -110,55 +128,31 @@ async fn drives_a_session_over_websocket() {
     join_server(server).await;
 }
 
-/// The `connect_headers` callback runs afresh for every dial: WebSocket
-/// workers are single-use, so two checkouts are two dials, and each upgrade
-/// request must carry the value rendered for *that* dial (a `traceparent`
-/// rendered at checkout time is the motivating case).
+/// Each checkout's `CheckoutOptions::connect_headers` reach that checkout's
+/// own upgrade request. WebSocket workers are single-use, so two checkouts
+/// are two dials, and a `traceparent` rendered at checkout time — the
+/// motivating case — must not land on the wrong one.
 #[tokio::test]
-async fn connect_headers_are_computed_per_dial() {
-    // Capture each upgrade request's traceparent from the handshake callback —
-    // the exact place a server extracts trace context.
-    let (header_tx, header_rx) = mpsc::channel::<Option<String>>();
+async fn connect_headers_are_per_checkout() {
+    let (header_tx, header_rx) = mpsc::channel();
     let (listener, mut config) = ws_pool_config();
-    let server = thread::spawn(move || {
-        for _ in 0..2 {
-            let (stream, _peer) = listener.accept().expect("accept");
-            // the Err type (an ErrorResponse) is tungstenite's callback contract
-            #[expect(clippy::result_large_err)]
-            let callback = |req: &Request, resp: Response| {
-                let seen = req
-                    .headers()
-                    .get("traceparent")
-                    .and_then(|v| v.to_str().ok())
-                    .map(str::to_owned);
-                header_tx.send(seen).expect("send captured header");
-                Ok(resp)
-            };
-            let mut socket = tungstenite::accept_hdr(stream, callback).expect("ws handshake");
-            answer_requests(&mut socket);
-        }
-    });
+    let server = thread::spawn(move || serve_capturing_header(&listener, "traceparent", 2, &header_tx));
 
     config.request_timeout = Some(Duration::from_secs(10));
-    let dials = AtomicUsize::new(0);
-    config.connect_headers = Some(ConnectHeaders::new(move || {
-        let dial = dials.fetch_add(1, Ordering::Relaxed) + 1;
-        vec![("traceparent".to_owned(), format!("00-dial-{dial}"))]
-    }));
     let pool = Pool::new(config).await.expect("pool");
 
-    for dial in 1..=2 {
-        let mut checkout = pool
-            .checkout(&ReplConfig {
-                script_name: "test.py".to_owned(),
-                ..ReplConfig::default()
-            })
-            .await
-            .expect("checkout");
+    for trace in ["00-checkout-1", "00-checkout-2"] {
+        let repl = ReplConfig {
+            script_name: "test.py".to_owned(),
+            ..ReplConfig::default()
+        };
+        let options =
+            CheckoutOptions::default().with_connect_headers(vec![("traceparent".to_owned(), trace.to_owned())]);
+        let mut checkout = pool.checkout_with(&repl, options).await.expect("checkout");
         assert_eq!(
             header_rx.recv().expect("captured header"),
-            Some(format!("00-dial-{dial}")),
-            "each dial must carry the value computed for it"
+            Some(trace.to_owned()),
+            "each dial must carry the headers of the checkout that made it"
         );
         // the session still works normally with extra headers on the dial
         let event = checkout
@@ -171,6 +165,28 @@ async fn connect_headers_are_computed_per_dial() {
         );
         checkout.finish().await.expect("finish");
     }
+    join_server(server).await;
+}
+
+/// Duplicate header names are last-wins, as [`CheckoutOptions`] promises.
+#[tokio::test]
+async fn duplicate_connect_headers_are_last_wins() {
+    let (header_tx, header_rx) = mpsc::channel();
+    let (listener, mut config) = ws_pool_config();
+    let server = thread::spawn(move || serve_capturing_header(&listener, "traceparent", 1, &header_tx));
+    config.request_timeout = Some(Duration::from_secs(10));
+    let pool = Pool::new(config).await.expect("pool");
+
+    let options = CheckoutOptions::default().with_connect_headers(vec![
+        ("traceparent".to_owned(), "first".to_owned()),
+        ("traceparent".to_owned(), "second".to_owned()),
+    ]);
+    let checkout = pool
+        .checkout_with(&ReplConfig::default(), options)
+        .await
+        .expect("checkout");
+    assert_eq!(header_rx.recv().expect("captured header").as_deref(), Some("second"));
+    checkout.finish().await.expect("finish");
     join_server(server).await;
 }
 
@@ -189,11 +205,12 @@ async fn malformed_connect_headers_fail_the_dial() {
             "ws://127.0.0.1:9: connect header \"traceparent\" value: failed to parse header value",
         ),
     ];
+    let pool = Pool::new(PoolConfig::websocket("ws://127.0.0.1:9"))
+        .await
+        .expect("pool");
     for ((name, value), expected) in cases {
-        let mut config = PoolConfig::websocket("ws://127.0.0.1:9");
-        config.connect_headers = Some(ConnectHeaders::new(move || vec![(name.to_owned(), value.to_owned())]));
-        let pool = Pool::new(config).await.expect("pool");
-        let Err(err) = pool.checkout(&ReplConfig::default()).await else {
+        let options = CheckoutOptions::default().with_connect_headers(vec![(name.to_owned(), value.to_owned())]);
+        let Err(err) = pool.checkout_with(&ReplConfig::default(), options).await else {
             panic!("malformed header must fail the dial");
         };
         let PoolError::Spawn(msg) = err else {
@@ -217,13 +234,15 @@ async fn an_unparsable_url_fails_the_dial() {
     assert_eq!(msg, "not a url: HTTP format error: invalid uri character");
 }
 
-/// `Debug` for [`ConnectHeaders`] names the type and never a computed value —
-/// monty's protocol has no auth, but a caller may send tokens for
-/// authenticating infrastructure in front of the child, and configs get logged.
+/// `Debug` for [`CheckoutOptions`] names each connect header, never its value.
 #[test]
 fn connect_headers_debug_is_redacted() {
-    let headers = ConnectHeaders::new(|| vec![("authorization".to_owned(), "Bearer secret".to_owned())]);
-    assert_eq!(format!("{headers:?}"), "ConnectHeaders(..)");
+    let options =
+        CheckoutOptions::default().with_connect_headers(vec![("authorization".to_owned(), "Bearer secret".to_owned())]);
+    assert_eq!(
+        format!("{options:?}"),
+        r#"CheckoutOptions { connect_headers: ["authorization"], .. }"#
+    );
 }
 
 /// Binds a listener and returns it with a websocket pool config pointing at it.

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -218,7 +218,8 @@ async fn an_unparseable_url_fails_the_dial() {
 }
 
 /// `Debug` for [`ConnectHeaders`] names the type and never a computed value —
-/// header values may carry auth material, and configs get logged.
+/// monty's protocol has no auth, but a caller may send tokens for
+/// authenticating infrastructure in front of the child, and configs get logged.
 #[test]
 fn connect_headers_debug_is_redacted() {
     let headers = ConnectHeaders::new(|| vec![("authorization".to_owned(), "Bearer secret".to_owned())]);

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -887,12 +887,13 @@ class AsyncMontyWebsocket:
             connect_headers: Called once per session, as it is entered and before
                 any wait for pool capacity, to produce extra `str` to `str`
                 headers for that connection's WebSocket upgrade request — e.g. a
-                `traceparent` so server-side spans join the caller's trace, or a
                 token for infrastructure in front of the worker. It runs
                 synchronously on the checking-out task, so it sees that task's
                 contextvars and must not block. Monty never interprets the
-                values; duplicate names are last-wins, and a malformed name or
-                value raises `RuntimeError` as the session is entered.
+                values; duplicate names are last-wins, also over the default
+                `user-agent` and the `traceparent` the Logfire integration
+                adds, and a malformed name or value raises `RuntimeError` as
+                the session is entered.
         """
 
     async def __aenter__(self) -> Self: ...

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Literal, NoReturn, final
 
@@ -858,6 +859,7 @@ class AsyncMontyWebsocket:
         max_processes: int | None = None,
         checkout_timeout: float | None = None,
         request_timeout: float | None = 10.0,
+        connect_headers: Callable[[], Mapping[str, str]] | None = None,
     ) -> Self:
         """
         Configure a remote worker pool; connections are made by `async with` and
@@ -882,6 +884,15 @@ class AsyncMontyWebsocket:
                 10.0 is often too low for it — a real `uv pip install` can exceed
                 it. Raise `request_timeout` (or pass `None`) when installing
                 dependencies over the WebSocket transport.
+            connect_headers: Called once per session, as it is entered and before
+                any wait for pool capacity, to produce extra `str` to `str`
+                headers for that connection's WebSocket upgrade request — e.g. a
+                `traceparent` so server-side spans join the caller's trace, or a
+                token for infrastructure in front of the worker. It runs
+                synchronously on the checking-out task, so it sees that task's
+                contextvars and must not block. Monty never interprets the
+                values; duplicate names are last-wins, and a malformed name or
+                value raises `RuntimeError` as the session is entered.
         """
 
     async def __aenter__(self) -> Self: ...

--- a/crates/monty-python/src/build.rs
+++ b/crates/monty-python/src/build.rs
@@ -7,7 +7,7 @@
 //! than leaking raw PyO3 errors.
 
 use monty_proto::python::{InstanceStore, exc_py_to_monty, py_to_monty_value};
-use monty_types::{ExcType, MontyException, MontyObject};
+use monty_types::{ExcType, MontyException, MontyObject, StringRepr};
 use pyo3::{
     exceptions::PyTypeError,
     prelude::*,
@@ -105,7 +105,8 @@ pub(crate) fn extract_connect_headers(py: Python<'_>, callback: &Py<PyAny>) -> P
     } else {
         let t = result.get_type().name()?;
         Err(PyTypeError::new_err(format!(
-            "connect_headers must return a mapping of str to str, got '{t}'"
+            "connect_headers must return a mapping of str to str, got {}",
+            StringRepr(&t.to_string_lossy())
         )))
     }
 }
@@ -117,7 +118,9 @@ fn header_str(part: &Bound<'_, PyAny>, side: &str) -> PyResult<String> {
     } else {
         let t = part.get_type().name()?;
         Err(PyTypeError::new_err(format!(
-            "connect_headers must return a mapping of str to str, got '{t}' header {side}"
+            "connect_headers must return a mapping of str to str, got {} header {}",
+            StringRepr(&t.to_string_lossy()),
+            side
         )))
     }
 }

--- a/crates/monty-python/src/build.rs
+++ b/crates/monty-python/src/build.rs
@@ -9,8 +9,9 @@
 use monty_proto::python::{InstanceStore, exc_py_to_monty, py_to_monty_value};
 use monty_types::{ExcType, MontyException, MontyObject};
 use pyo3::{
+    exceptions::PyTypeError,
     prelude::*,
-    types::{PyDict, PyString},
+    types::{PyDict, PyMapping, PyString},
 };
 
 use crate::exceptions::{MontyConversionError, MontyError};
@@ -85,4 +86,38 @@ pub(crate) fn extract_repl_inputs(
             Ok((name, obj))
         })
         .collect::<PyResult<_>>()
+}
+
+/// Calls the `connect_headers` callback and extracts its `str -> str` mapping.
+/// The GIL is held on the caller's task, so the callback sees the caller's
+/// contextvars.
+pub(crate) fn extract_connect_headers(py: Python<'_>, callback: &Py<PyAny>) -> PyResult<Vec<(String, String)>> {
+    let result = callback.bind(py).call0()?;
+    if let Ok(mapping) = result.cast::<PyMapping>() {
+        mapping
+            .items()?
+            .iter()
+            .map(|item| {
+                let (name, value): (Bound<'_, PyAny>, Bound<'_, PyAny>) = item.extract()?;
+                Ok((header_str(&name, "name")?, header_str(&value, "value")?))
+            })
+            .collect()
+    } else {
+        let t = result.get_type().name()?;
+        Err(PyTypeError::new_err(format!(
+            "connect_headers must return a mapping of str to str, got '{t}'"
+        )))
+    }
+}
+
+/// Extracts one header name or value, naming which side was not a `str`.
+fn header_str(part: &Bound<'_, PyAny>, side: &str) -> PyResult<String> {
+    if let Ok(s) = part.cast::<PyString>() {
+        Ok(s.to_cow()?.into_owned())
+    } else {
+        let t = part.get_type().name()?;
+        Err(PyTypeError::new_err(format!(
+            "connect_headers must return a mapping of str to str, got '{t}' header {side}"
+        )))
+    }
 }

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -40,7 +40,8 @@ use std::{
 };
 
 use monty_pool::{
-    Checkout, MountSpec, OnPrint, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
+    Checkout, CheckoutOptions, MountSpec, OnPrint, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue,
+    TurnEvent,
 };
 use monty_proto::python::{InstanceStore, exc_py_to_monty, monty_to_py, py_to_monty_value};
 use monty_types::{
@@ -62,7 +63,7 @@ use tokio::{
 
 use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
-    build::{extract_repl_inputs, extract_source_code, extract_type_check_stubs},
+    build::{extract_connect_headers, extract_repl_inputs, extract_source_code, extract_type_check_stubs},
     exceptions::{MontyCrashedError, MontyDisconnectError, MontyError, MontyShutdown, MontyTypingError},
     external::{CallResult, ExternalLookup, dispatch_object_call, resolve_object_attr},
     get_not_handled,
@@ -233,15 +234,10 @@ impl PyMontySession {
         let pool = active_pool(&this.pool)?;
         let repl_config = this.repl_config.clone();
         let slot = Arc::clone(&this.checkout);
-        let telemetry = capture_telemetry_context(py);
+        let options = CheckoutOptions::default().with_telemetry(capture_telemetry_context(py));
         py.detach(move || {
             block_on_sync(async move {
-                let checkout = if let Some(telemetry) = telemetry {
-                    pool.checkout_with_telemetry(&repl_config, telemetry).await?
-                } else {
-                    pool.checkout(&repl_config).await?
-                };
-                *slot.lock().await = Some(checkout);
+                *slot.lock().await = Some(pool.checkout_with(&repl_config, options).await?);
                 Ok(())
             })
         })?
@@ -385,7 +381,7 @@ impl PyMontySession {
         // extract args before committing the session, so a bad-args error
         // leaves it loadable (a failed load is not retryable — checkout a fresh
         // session — matching the async path)
-        check_os_callable(py, os.as_ref())?;
+        check_callable(py, os.as_ref())?;
         let mounts = extract_mount_specs(mount)?;
         let print_target = PrintTarget::from_py(print_callback)?;
         let ext = external_lookup.map(|d| d.clone().unbind());
@@ -578,6 +574,7 @@ impl PyAsyncMonty {
             )?,
             instances: InstanceStore::new(py),
             checkout: Arc::new(AsyncMutex::new(None)),
+            connect_headers: None,
             used: AtomicBool::new(false),
             drive_abandoned: Arc::new(AtomicBool::new(false)),
         })
@@ -598,6 +595,9 @@ impl PyAsyncMonty {
 pub struct PyAsyncMontyWebsocket {
     config: PoolConfig,
     pool: SharedPool,
+    /// The `connect_headers` callback, handed to every session so it runs on
+    /// the checking-out task (see [`PyAsyncMontySession::__aenter__`]).
+    connect_headers: Option<Py<PyAny>>,
 }
 
 #[pymethods]
@@ -621,16 +621,21 @@ impl PyAsyncMontyWebsocket {
         max_processes = None,
         checkout_timeout = None,
         request_timeout = 10.0,
+        connect_headers = None,
     ))]
     fn new(
+        py: Python<'_>,
         url: String,
         max_processes: Option<usize>,
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
+        connect_headers: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
+        check_callable(py, connect_headers.as_ref())?;
         Ok(Self {
             config: parse_websocket_config(url, max_processes, checkout_timeout, request_timeout)?,
             pool: Arc::new(Mutex::new(None)),
+            connect_headers,
         })
     }
 
@@ -697,6 +702,7 @@ impl PyAsyncMontyWebsocket {
             )?,
             instances: InstanceStore::new(py),
             checkout: Arc::new(AsyncMutex::new(None)),
+            connect_headers: self.connect_headers.as_ref().map(|cb| cb.clone_ref(py)),
             used: AtomicBool::new(false),
             drive_abandoned: Arc::new(AtomicBool::new(false)),
         })
@@ -711,6 +717,9 @@ pub struct PyAsyncMontySession {
     repl_config: ReplConfig,
     instances: InstanceStore,
     checkout: SharedCheckout,
+    /// A WebSocket pool's `connect_headers` callback, called by `__aenter__`;
+    /// `None` for subprocess pools, which make no request.
+    connect_headers: Option<Py<PyAny>>,
     /// Set once the session has been fed or restored; `load_session` /
     /// `load_snapshot` are valid only while unset. See
     /// [`PyMontySession::load_snapshot`].
@@ -724,20 +733,29 @@ pub struct PyAsyncMontySession {
 impl PyAsyncMontySession {
     /// Checks a worker out of the pool (spawning one if needed) and creates
     /// the REPL session in it.
+    ///
+    /// Whatever must see the caller's contextvars (telemetry, `connect_headers`)
+    /// is captured here, on the caller's task with the GIL held, before the
+    /// future moves to tokio.
     fn __aenter__(slf: Py<Self>, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         let this = slf.get();
-        let pool_slot = Arc::clone(&this.pool);
+        let pool = active_pool(&this.pool)?;
         let repl_config = this.repl_config.clone();
         let slot = Arc::clone(&this.checkout);
-        let telemetry = capture_telemetry_context(py);
+        let connect_headers = this
+            .connect_headers
+            .as_ref()
+            .map(|cb| extract_connect_headers(py, cb))
+            .transpose()?
+            .unwrap_or_default();
+        let options = CheckoutOptions::default()
+            .with_telemetry(capture_telemetry_context(py))
+            .with_connect_headers(connect_headers);
         future_into_py(py, async move {
-            let pool = active_pool(&pool_slot)?;
-            let checkout = if let Some(telemetry) = telemetry {
-                pool.checkout_with_telemetry(&repl_config, telemetry).await
-            } else {
-                pool.checkout(&repl_config).await
-            }
-            .map_err(|e| Python::attach(|py| pool_err_to_py(py, e)))?;
+            let checkout = pool
+                .checkout_with(&repl_config, options)
+                .await
+                .map_err(|e| Python::attach(|py| pool_err_to_py(py, e)))?;
             *slot.lock().await = Some(checkout);
             Ok(slf)
         })
@@ -869,7 +887,7 @@ impl PyAsyncMontySession {
     ) -> PyResult<Bound<'py, PyAny>> {
         // extract args before committing the session (a bad-args error leaves
         // it loadable), then claim it in the synchronous prologue
-        check_os_callable(py, os.as_ref())?;
+        check_callable(py, os.as_ref())?;
         let mounts = extract_mount_specs(mount)?;
         let print_target = PrintTarget::from_py(print_callback)?;
         let ext = external_lookup.map(|d| d.clone().unbind());
@@ -973,17 +991,18 @@ fn parse_pool_config(
     Ok(config)
 }
 
-/// Rejects a non-callable `os=` handler with the same `TypeError` for every
-/// entry point that accepts one (`feed_run` / `feed_start` via
-/// [`FeedArgs::extract`], and `load_snapshot`).
-fn check_os_callable(py: Python<'_>, os: Option<&Py<PyAny>>) -> PyResult<()> {
-    if let Some(os_cb) = os
-        && !os_cb.bind(py).is_callable()
+/// Rejects a non-callable optional callback with CPython's own `TypeError`
+/// text, so every entry point that accepts one (`os=` on `feed_run` /
+/// `feed_start` / `load_snapshot`, `connect_headers=`) fails the same way.
+fn check_callable(py: Python<'_>, callback: Option<&Py<PyAny>>) -> PyResult<()> {
+    if let Some(cb) = callback
+        && !cb.bind(py).is_callable()
     {
-        let t = os_cb.bind(py).get_type().name()?;
-        return Err(PyTypeError::new_err(format!("'{t}' object is not callable")));
+        let t = cb.bind(py).get_type().name()?;
+        Err(PyTypeError::new_err(format!("'{t}' object is not callable")))
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 /// The error raised when `load_session` / `load_snapshot` is called on a
@@ -1215,7 +1234,7 @@ impl FeedArgs {
         os: Option<Py<PyAny>>,
         skip_type_check: bool,
     ) -> PyResult<Self> {
-        check_os_callable(py, os.as_ref())?;
+        check_callable(py, os.as_ref())?;
         Ok(Self {
             code: extract_source_code(py, code)?,
             inputs: extract_repl_inputs(inputs, instances)?,

--- a/crates/monty-python/tests/test_websocket.py
+++ b/crates/monty-python/tests/test_websocket.py
@@ -11,12 +11,19 @@ external-function suspension through the public Python class.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import sys
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from contextvars import ContextVar
 from pathlib import Path
+from types import MappingProxyType, ModuleType
+from typing import Any
 
 import pytest
 from inline_snapshot import snapshot
+from websockets.asyncio.server import ServerConnection, serve
+from websockets.datastructures import Headers
+from websockets.http11 import Request
 
 from pydantic_monty import AsyncMontyWebsocket, MontyRuntimeError
 from pydantic_monty._binary import find_monty_binary
@@ -26,10 +33,10 @@ _RELAY_SCRIPT = Path(__file__).resolve().parents[3] / 'scripts' / 'websocket_rel
 
 @pytest.fixture
 async def ws_url() -> AsyncIterator[str]:
-    """Starts the relay on an ephemeral port and yields its `ws://` URL.
+    """Starts the relay script on an ephemeral port and yields its `ws://` URL.
 
-    Runs the standalone script with the test interpreter (so it picks up the
-    `websockets` dev dependency) and reads back the URL it prints once listening.
+    Runs the script as a subprocess, the way it ships, and reads back the URL
+    it prints once listening.
     """
     relay = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -49,6 +56,38 @@ async def ws_url() -> AsyncIterator[str]:
     finally:
         relay.terminate()
         await relay.wait()
+
+
+@pytest.fixture
+async def ws_url_capturing_headers() -> AsyncIterator[tuple[str, list[Headers]]]:
+    """Serves the relay's bridge in-process on an ephemeral port and yields its
+    `ws://` URL plus the headers of every upgrade request it receives.
+
+    The same bridge as `ws_url` (each connection gets a real `monty subprocess`
+    child), hosted here so `process_request` can record what each dial sent.
+    """
+    relay = _load_relay_script()
+    monty_bin = find_monty_binary()
+    captured: list[Headers] = []
+
+    def capture(_connection: ServerConnection, request: Request) -> None:
+        captured.append(request.headers)
+
+    async def handler(websocket: ServerConnection) -> None:
+        await relay.bridge_connection(websocket, monty_bin)
+
+    async with serve(handler, '127.0.0.1', 0, process_request=capture, max_size=None) as server:
+        host, port = server.sockets[0].getsockname()[:2]
+        yield relay.format_ws_url(host, port), captured
+
+
+def _load_relay_script() -> ModuleType:
+    """Imports `scripts/websocket_relay.py`, which is a standalone script, not a package."""
+    spec = importlib.util.spec_from_file_location('websocket_relay', _RELAY_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 async def test_feed_run_over_websocket(ws_url: str):
@@ -84,3 +123,145 @@ async def test_separate_checkouts_are_isolated(ws_url: str):
             with pytest.raises(MontyRuntimeError) as exc_info:
                 await session.feed_run('leaked')
     assert exc_info.value.display(format='msg') == snapshot("name 'leaked' is not defined")
+
+
+async def test_connect_headers_sent_per_checkout(ws_url_capturing_headers: tuple[str, list[Headers]]):
+    """`connect_headers` is called once per checkout, on the checking-out task,
+    so it sees that task's contextvars — the `traceparent` use case."""
+    url, captured = ws_url_capturing_headers
+    trace_id: ContextVar[str] = ContextVar('trace_id')
+    calls = 0
+
+    def connect_headers() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {'traceparent': trace_id.get()}
+
+    async def checkout_as(trace: str) -> int:
+        # a task's contextvar assignment is invisible to its siblings, so distinct
+        # traceparents on the two dials prove the callback ran in each checkout's own task
+        trace_id.set(trace)
+        async with pool.checkout() as session:
+            return await session.feed_run('1 + 1')
+
+    async with AsyncMontyWebsocket(url, request_timeout=30.0, connect_headers=connect_headers) as pool:
+        results = await asyncio.gather(checkout_as('00-aaa-111-01'), checkout_as('00-bbb-222-01'))
+    assert results == snapshot([2, 2])
+    assert calls == snapshot(2)
+    assert sorted(headers['traceparent'] for headers in captured) == snapshot(['00-aaa-111-01', '00-bbb-222-01'])
+
+
+async def test_connect_headers_accepts_any_mapping(ws_url_capturing_headers: tuple[str, list[Headers]]):
+    """Any `Mapping` is accepted, not just `dict`."""
+    url, captured = ws_url_capturing_headers
+
+    def connect_headers() -> MappingProxyType[str, str]:
+        return MappingProxyType({'x-token': 't'})
+
+    async with AsyncMontyWebsocket(url, request_timeout=30.0, connect_headers=connect_headers) as pool:
+        async with pool.checkout() as session:
+            assert await session.feed_run('1 + 1') == snapshot(2)
+    (upgrade_headers,) = captured
+    assert upgrade_headers.get('x-token') == snapshot('t')
+
+
+def test_connect_headers_not_callable():
+    not_callable: Any = {'x-token': 't'}
+    with pytest.raises(TypeError) as exc_info:
+        AsyncMontyWebsocket('ws://127.0.0.1:9', connect_headers=not_callable)
+    assert exc_info.value.args[0] == snapshot("'dict' object is not callable")
+
+
+async def test_connect_headers_failure_leaves_the_pool_usable(
+    ws_url_capturing_headers: tuple[str, list[Headers]],
+):
+    """A failing callback checks nothing out, so the next checkout works normally."""
+    url, captured = ws_url_capturing_headers
+    attempts = 0
+
+    def connect_headers() -> dict[str, str]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ValueError('no token yet')
+        return {'x-token': 't'}
+
+    async with AsyncMontyWebsocket(url, request_timeout=30.0, connect_headers=connect_headers) as pool:
+        with pytest.raises(ValueError) as exc_info:
+            async with pool.checkout():
+                pass
+        async with pool.checkout() as session:
+            assert await session.feed_run('1 + 1') == snapshot(2)
+    assert exc_info.value.args[0] == snapshot('no token yet')
+    assert [headers.get('x-token') for headers in captured] == snapshot(['t'])
+
+
+async def test_connect_headers_not_called_on_an_inactive_pool():
+    """The pool is checked before the callback runs, so a pool that was never
+    entered raises without calling it."""
+    calls = 0
+
+    def connect_headers() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {}
+
+    pool = AsyncMontyWebsocket('ws://127.0.0.1:9', connect_headers=connect_headers)
+    with pytest.raises(RuntimeError) as exc_info:
+        async with pool.checkout():
+            pass
+    assert exc_info.value.args[0] == snapshot(
+        'the pool is not active — enter the Monty / AsyncMonty context manager first'
+    )
+    assert calls == snapshot(0)
+
+
+def raise_no_token() -> dict[str, str]:
+    raise ValueError('no token available')
+
+
+@pytest.mark.parametrize(
+    'connect_headers, exc_type, message',
+    [
+        (
+            lambda: [('x-token', 't')],
+            TypeError,
+            snapshot("connect_headers must return a mapping of str to str, got 'list'"),
+        ),
+        (
+            lambda: {1: 't'},
+            TypeError,
+            snapshot("connect_headers must return a mapping of str to str, got 'int' header name"),
+        ),
+        (
+            lambda: {'x-token': 1},
+            TypeError,
+            snapshot("connect_headers must return a mapping of str to str, got 'int' header value"),
+        ),
+        (
+            lambda: {'bad header': 't'},
+            RuntimeError,
+            snapshot(
+                'failed to spawn monty worker: ws://127.0.0.1:9: connect header "bad header": invalid HTTP header name'
+            ),
+        ),
+        (
+            lambda: {'x-token': 'a\nb'},
+            RuntimeError,
+            snapshot(
+                'failed to spawn monty worker: ws://127.0.0.1:9: connect header "x-token" value: failed to parse header value'
+            ),
+        ),
+        (raise_no_token, ValueError, snapshot('no token available')),
+    ],
+)
+async def test_connect_headers_errors_raise_on_entry(
+    connect_headers: Callable[[], Any], exc_type: type[Exception], message: str
+):
+    """The callback runs and its result is checked as the session is entered,
+    before any dial, so an unreachable URL is fine."""
+    async with AsyncMontyWebsocket('ws://127.0.0.1:9', connect_headers=connect_headers) as pool:
+        with pytest.raises(exc_type) as exc_info:
+            async with pool.checkout():
+                pass
+    assert exc_info.value.args[0] == message

--- a/crates/monty-python/tests/test_websocket.py
+++ b/crates/monty-python/tests/test_websocket.py
@@ -253,6 +253,12 @@ def raise_no_token() -> dict[str, str]:
             ),
         ),
         (raise_no_token, ValueError, snapshot('no token available')),
+        # a `str` that is not encodable — a lone surrogate — cannot become a header
+        (
+            lambda: {'x-token': '\udc80'},
+            UnicodeEncodeError,
+            snapshot("'utf-8' codec can't encode character '\\udc80' in position 0: surrogates not allowed"),
+        ),
     ],
 )
 async def test_connect_headers_errors_raise_on_entry(
@@ -264,4 +270,14 @@ async def test_connect_headers_errors_raise_on_entry(
         with pytest.raises(exc_type) as exc_info:
             async with pool.checkout():
                 pass
-    assert exc_info.value.args[0] == message
+    assert str(exc_info.value) == message
+
+
+async def test_checkout_rejects_unknown_limits():
+    """`checkout()` validates its arguments up front, before any dial, like `Monty.checkout`."""
+    async with AsyncMontyWebsocket('ws://127.0.0.1:9') as pool:
+        with pytest.raises(ValueError) as exc_info:
+            pool.checkout(limits={'max_memroy': 10_000_000})  # pyright: ignore[reportArgumentType]
+    assert exc_info.value.args[0] == snapshot(
+        "unknown limits key 'max_memroy'; accepted keys are 'max_duration_secs', 'max_memory', 'gc_interval', 'max_recursion_depth', 'max_suspensions'"
+    )

--- a/packages/pydantic-monty/README.md
+++ b/packages/pydantic-monty/README.md
@@ -338,7 +338,9 @@ The Python Logfire integration instruments the pool through a private adapter
 hook. It propagates the active Python OTel context into each checkout, which
 becomes one session span with nested feed and suspension spans recording code,
 inputs, external calls, exceptions, and `print` output. Session dumps and
-restores are recorded by size only.
+restores are recorded by size only. An `AsyncMontyWebsocket` checkout also
+sends that context as W3C `traceparent`/`tracestate` headers on its upgrade
+request, so a server that honours them can join the same trace.
 
 The same adapter also receives pool metrics — live, immediately available and
 host-blocked worker counts, checkout waits, worker deaths by reason, run


### PR DESCRIPTION
This PR adds `PoolConfig::connect_headers`, a way to send `connect_headers` to the WS server. I need this to send custom headers, e.g. `"traceparent": "00-abc-abc-01"`. 

Tested with `monty-server` which don't need any upstream patch. 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-checkout custom headers to the WebSocket transport via `CheckoutOptions::connect_headers`, so each dial can attach context like a fresh `traceparent` for the server. `checkout_with` carries the headers plus the telemetry context, now propagated as W3C `traceparent`/`tracestate` on the dial; caller-provided pairs override handshake-generated ones when named the same, `checkout` stays a wrapper, `checkout_with_telemetry` is removed, and monty-js moves to `checkout_with`.

- Every upgrade request carries `User-Agent: monty-pool/<version>`, overridable by a `connect_headers` entry of that name.
- Python `AsyncMontyWebsocket` takes a `connect_headers` callback, called once per checkout on the checking-out task so it sees that task's contextvars; it must return a `str`-to-`str` mapping and must not block.
- Malformed header names/values, unencodable values, and unparsable URLs fail the dial with a `Spawn` error naming the URL before any I/O; duplicates are last-wins and `Debug` output shows header names only.
- Tests cover per-checkout recomputation, telemetry propagation, malformed headers, unparsable URLs, redaction, and Python callback failure leaving the pool usable; the README documents callback timing and redaction rationale.
- No migration required; the subprocess transport ignores `connect_headers`.

<sup>Written for commit 1bd296d98a96ca443e9420d09263fc41dab81e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



