### PR TITLE
Add the `functools` module with `reduce`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ What Monty **can** do:
 - Control resource usage - Monty can track memory usage, stack depth, and execution time and cancel execution if it exceeds preset limits
 - Collect stdout and stderr and return it to the caller
 - Run async or sync sandboxed code, calling async or sync functions on the host
-- Use a small subset of the standard library: `asyncio`, `collections`, `dataclasses`, `datetime`, `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing`, `unicodedata`
+- Use a small subset of the standard library: `asyncio`, `collections`, `dataclasses`, `datetime`, `functools`, `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing`, `unicodedata`
 
 What Monty **cannot** do:
 

--- a/crates/monty-typeshed/custom/functools.pyi
+++ b/crates/monty-typeshed/custom/functools.pyi
@@ -1,0 +1,19 @@
+# Based on python/typeshed's `stdlib/functools.pyi`, stripped down to the
+# callables Monty actually implements at runtime.
+#
+# Everything else (`partial`, `cache`, `lru_cache`, `wraps`, `partialmethod`,
+# `cached_property`, `total_ordering`, `singledispatch`, `cmp_to_key`,
+# `Placeholder`, ...) is deliberately absent so type checking rejects it up
+# front, rather than passing and then raising `AttributeError` at runtime.
+# Extend this in lockstep with `crates/monty/src/modules/functools.rs`.
+
+from collections.abc import Callable, Iterable
+from typing import TypeVar, overload
+
+_T = TypeVar('_T')
+_S = TypeVar('_S')
+
+@overload
+def reduce(function: Callable[[_T, _S], _T], iterable: Iterable[_S], /, initial: _T) -> _T: ...
+@overload
+def reduce(function: Callable[[_T, _T], _T], iterable: Iterable[_T], /) -> _T: ...

--- a/crates/monty-typeshed/update.py
+++ b/crates/monty-typeshed/update.py
@@ -148,7 +148,7 @@ builtins: 3.0-
 collections: 3.0-
 dataclasses: 3.7-
 datetime: 3.0-
-functools: 3.2-
+functools: 3.0-
 itertools: 3.0-
 json: 3.0-
 math: 3.0-

--- a/crates/monty-typeshed/update.py
+++ b/crates/monty-typeshed/update.py
@@ -148,6 +148,7 @@ builtins: 3.0-
 collections: 3.0-
 dataclasses: 3.7-
 datetime: 3.0-
+functools: 3.2-
 itertools: 3.0-
 json: 3.0-
 math: 3.0-

--- a/crates/monty-typeshed/vendor/typeshed/stdlib/VERSIONS
+++ b/crates/monty-typeshed/vendor/typeshed/stdlib/VERSIONS
@@ -11,6 +11,7 @@ builtins: 3.0-
 collections: 3.0-
 dataclasses: 3.7-
 datetime: 3.0-
+functools: 3.2-
 itertools: 3.0-
 json: 3.0-
 math: 3.0-

--- a/crates/monty-typeshed/vendor/typeshed/stdlib/VERSIONS
+++ b/crates/monty-typeshed/vendor/typeshed/stdlib/VERSIONS
@@ -11,7 +11,7 @@ builtins: 3.0-
 collections: 3.0-
 dataclasses: 3.7-
 datetime: 3.0-
-functools: 3.2-
+functools: 3.0-
 itertools: 3.0-
 json: 3.0-
 math: 3.0-

--- a/crates/monty-typeshed/vendor/typeshed/stdlib/functools.pyi
+++ b/crates/monty-typeshed/vendor/typeshed/stdlib/functools.pyi
@@ -1,0 +1,19 @@
+# Based on python/typeshed's `stdlib/functools.pyi`, stripped down to the
+# callables Monty actually implements at runtime.
+#
+# Everything else (`partial`, `cache`, `lru_cache`, `wraps`, `partialmethod`,
+# `cached_property`, `total_ordering`, `singledispatch`, `cmp_to_key`,
+# `Placeholder`, ...) is deliberately absent so type checking rejects it up
+# front, rather than passing and then raising `AttributeError` at runtime.
+# Extend this in lockstep with `crates/monty/src/modules/functools.rs`.
+
+from collections.abc import Callable, Iterable
+from typing import TypeVar, overload
+
+_T = TypeVar('_T')
+_S = TypeVar('_S')
+
+@overload
+def reduce(function: Callable[[_T, _S], _T], iterable: Iterable[_S], /, initial: _T) -> _T: ...
+@overload
+def reduce(function: Callable[[_T, _T], _T], iterable: Iterable[_T], /) -> _T: ...

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -196,7 +196,7 @@ mod tests {
         );
         assert_eq!(
             static_strings_fingerprint(),
-            0xb1f0_7be6_ebf1_9607,
+            0xe6e1_7655_c3fa_47e3,
             "static strings changed for dump version {DUMP_VERSION}"
         );
         assert_eq!(

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -932,6 +932,20 @@ pub(crate) trait ExcTypeExt: Sized {
         Self::value_error("Step for islice() must be a positive integer or None.")
     }
 
+    /// Creates the TypeError `functools.reduce` raises when the iterable is
+    /// empty and no `initial` was given, so there is nothing to return.
+    #[must_use]
+    fn reduce_empty_iterable() -> RunError {
+        Self::type_error("reduce() of empty iterable with no initial value")
+    }
+
+    /// Creates the TypeError `functools.reduce` raises for a second argument
+    /// that cannot be iterated, replacing the generic not-iterable wording.
+    #[must_use]
+    fn reduce_not_iterable() -> RunError {
+        Self::type_error("reduce() arg 2 must support iteration")
+    }
+
     /// Creates a TypeError for the right operand of `in` / `not in` supporting
     /// neither `__contains__` nor iteration.
     ///

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -975,6 +975,16 @@ pub enum StaticStrings {
     Filterfalse,
     /// `itertools.starmap()` function.
     Starmap,
+
+    // ==========================
+    // functools module strings
+    // Appended, per the "new variants go at the end" rule above.
+    /// Module name for `import functools`.
+    Functools,
+    /// `functools.reduce()` function.
+    Reduce,
+    /// `initial` keyword argument of `functools.reduce()`.
+    Initial,
 }
 
 /// Computes an FNV-1a hash over static-string identities and serialization.

--- a/crates/monty/src/modules/functools.rs
+++ b/crates/monty/src/modules/functools.rs
@@ -1,0 +1,125 @@
+//! Implementation of Python's `functools` module.
+//!
+//! A subset so far, currently just `reduce`. See
+//! `limitations/functools.md` for what diverges from CPython. Unimplemented
+//! names are absent from the namespace rather than stubbed, so they raise
+//! `AttributeError` up front.
+
+use std::mem;
+
+use crate::{
+    args::{ArgValues, FromArgs},
+    bytecode::VM,
+    defer_drop,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
+    heap::{DropGuard, HeapData, HeapId},
+    intern::StaticStrings,
+    modules::ModuleFunctions,
+    types::Module,
+    value::Value,
+};
+
+/// `functools` module functions, each a Python-visible callable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::Display, serde::Serialize, serde::Deserialize)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum FunctoolsFunctions {
+    Reduce,
+}
+
+/// Creates the `functools` module on the heap.
+///
+/// # Panics
+/// Panics if the required strings have not been pre-interned during prepare phase.
+pub fn create_module(vm: &mut VM<'_>) -> HeapId {
+    let mut module = Module::new(StaticStrings::Functools);
+
+    module.set_attr(
+        StaticStrings::Reduce,
+        Value::ModuleFunction(ModuleFunctions::Functools(FunctoolsFunctions::Reduce)),
+        vm,
+    );
+
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
+}
+
+/// Dispatches a call to a `functools` module function.
+pub(super) fn call(vm: &mut VM<'_>, function: FunctoolsFunctions, args: ArgValues) -> RunResult<Value> {
+    match function {
+        FunctoolsFunctions::Reduce => call_reduce(vm, args),
+    }
+}
+
+/// Argument shape for `reduce(function, iterable, /[, initial])`.
+///
+/// CPython's Argument Clinic signature makes the first two positional-only
+/// while `initial` is also accepted by keyword, and counts positionals plus
+/// keywords together for the maximum (`at_most_total`): `reduce(f, x, 0,
+/// initial=1)` reports four arguments.
+#[derive(FromArgs)]
+#[from_args(name = "reduce", at_most_total)]
+struct ReduceArgs {
+    #[from_args(pos_only)]
+    function: Value,
+    #[from_args(pos_only)]
+    iterable: Value,
+    #[from_args(default)]
+    initial: Option<Value>,
+}
+
+/// `functools.reduce(function, iterable, /[, initial])` — fold `function` over
+/// `iterable` from the left.
+///
+/// `function` is called through [`VM::evaluate_function`], which cannot suspend
+/// to the host, so an external function or `os` callback used here raises
+/// `NotImplementedError` as it does under `map()`.
+fn call_reduce(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let ReduceArgs {
+        function,
+        iterable,
+        initial,
+    } = ReduceArgs::from_args(args, vm)?;
+    defer_drop!(function, vm);
+
+    // `into_py_iter` consumes `iterable`, so `initial` is guarded across the
+    // conversion and reclaimed once it succeeds.
+    let mut guard = DropGuard::new(initial, vm);
+    let iter = iterable.into_py_iter(guard.ctx()).map_err(not_iterable_error)?;
+    let (initial, vm) = guard.into_parts();
+    defer_drop!(iter, vm);
+    let mut iter = iter.read(vm);
+
+    let accumulator = match initial {
+        Some(initial) => initial,
+        // Without `initial` the first item seeds the fold, so a one-item
+        // iterable returns that item without ever calling `function`.
+        None => match iter.py_next(vm)? {
+            Some(first) => first,
+            None => return Err(ExcType::reduce_empty_iterable()),
+        },
+    };
+
+    let mut acc_guard = DropGuard::new(accumulator, vm);
+    {
+        let (accumulator, vm) = acc_guard.as_parts_mut();
+        while let Some(item) = iter.py_next(vm)? {
+            // Move the accumulator into the call rather than cloning it: on
+            // error `evaluate_function` releases the arguments, and the
+            // placeholder left behind needs no cleanup.
+            let previous = mem::replace(accumulator, Value::None);
+            *accumulator = vm.evaluate_function("reduce()", function, ArgValues::Two(previous, item))?;
+        }
+    }
+    Ok(acc_guard.into_inner())
+}
+
+/// Rewrites the `TypeError` from a second argument that is not iterable.
+///
+/// CPython only replaces a `TypeError` here, so an `__iter__` that raises
+/// anything else propagates unchanged.
+#[cold]
+fn not_iterable_error(error: RunError) -> RunError {
+    match &error {
+        RunError::Exc(raise) if raise.exc.exc_type() == ExcType::TypeError => ExcType::reduce_not_iterable(),
+        _ => error,
+    }
+}

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod asyncio;
 pub(crate) mod collections;
 pub(crate) mod dataclasses;
 pub(crate) mod datetime;
+pub(crate) mod functools;
 #[cfg(feature = "test-hooks")]
 pub(crate) mod gc;
 pub(crate) mod itertools;
@@ -63,6 +64,8 @@ pub(crate) enum StandardLib {
     /// The `collections` module providing container datatypes: `deque`,
     /// `namedtuple`, `defaultdict`, and `Counter`.
     Collections,
+    /// The `functools` module providing `reduce`.
+    Functools,
     /// The `gc` module exposing a single `collect()` for tests. Only present
     /// under the `test-hooks` feature so production sandboxes never see it.
     ///
@@ -91,6 +94,7 @@ impl StandardLib {
             StaticStrings::Itertools => Some(Self::Itertools),
             StaticStrings::Dataclasses => Some(Self::Dataclasses),
             StaticStrings::Collections => Some(Self::Collections),
+            StaticStrings::Functools => Some(Self::Functools),
             #[cfg(feature = "test-hooks")]
             StaticStrings::Gc => Some(Self::Gc),
             _ => None,
@@ -117,6 +121,7 @@ impl StandardLib {
             Self::Itertools => itertools::create_module(vm),
             Self::Dataclasses => dataclasses::create_module(vm),
             Self::Collections => collections::create_module(vm),
+            Self::Functools => functools::create_module(vm),
             #[cfg(feature = "test-hooks")]
             Self::Gc => gc::create_module(vm),
         }
@@ -135,6 +140,7 @@ pub(crate) enum ModuleFunctions {
     Unicodedata(unicodedata::UnicodedataFunctions),
     Itertools(itertools::ItertoolsFunctions),
     Dataclasses(dataclasses::DataclassesFunctions),
+    Functools(functools::FunctoolsFunctions),
     /// `gc` module functions — only present under the `test-hooks` feature.
     /// See [`gc`] for why it is gated; as in [`StandardLib`], the gated block
     /// goes last and new variants are appended ahead of it.
@@ -160,6 +166,7 @@ impl fmt::Display for ModuleFunctions {
             Self::Unicodedata(func) => write!(f, "{func}"),
             Self::Itertools(func) => write!(f, "{func}"),
             Self::Dataclasses(func) => write!(f, "{func}"),
+            Self::Functools(func) => write!(f, "{func}"),
             #[cfg(feature = "test-hooks")]
             Self::Gc(func) => write!(f, "{func}"),
             #[cfg(feature = "test-hooks")]
@@ -184,6 +191,7 @@ impl ModuleFunctions {
             Self::Unicodedata(functions) => unicodedata::call(vm, functions, args).map(CallResult::Value),
             Self::Itertools(functions) => itertools::call(vm, functions, args).map(CallResult::Value),
             Self::Dataclasses(functions) => dataclasses::call(vm, functions, args).map(CallResult::Value),
+            Self::Functools(functions) => functools::call(vm, functions, args).map(CallResult::Value),
             #[cfg(feature = "test-hooks")]
             Self::Gc(functions) => gc::call(vm, functions, args).map(CallResult::Value),
             #[cfg(feature = "test-hooks")]

--- a/crates/monty/test_cases/functools__reduce.py
+++ b/crates/monty/test_cases/functools__reduce.py
@@ -1,0 +1,82 @@
+import functools
+
+# === reduce ===
+assert functools.reduce(lambda a, b: a + b, [1, 2, 3, 4]) == 10
+assert functools.reduce(lambda a, b: a + b, [1, 2, 3], 10) == 16
+assert functools.reduce(lambda a, b: a + b, [], 5) == 5
+assert functools.reduce(lambda a, b: a * b, range(1, 6)) == 120
+assert functools.reduce(lambda a, b: a + b, 'abc') == 'abc'
+assert functools.reduce(lambda a, b: a + b, {'x': 1, 'y': 2}) == 'xy'
+
+# a one-item iterable returns that item without calling the function
+assert functools.reduce(lambda a, b: 1 / 0, [7]) == 7
+assert functools.reduce(lambda a, b: 1 / 0, [], 7) == 7
+
+# `initial` is also accepted by keyword
+assert functools.reduce(lambda a, b: a + b, [1, 2], initial=10) == 13
+
+# the accumulator is threaded left to right
+assert functools.reduce(lambda a, b: (a, b), [1, 2, 3]) == ((1, 2), 3)
+assert functools.reduce(lambda a, b: a + [b], [1, 2], []) == [1, 2]
+
+
+# an exception from the function propagates unchanged
+def raiser(a, b):
+    raise ValueError('inner')
+
+
+try:
+    functools.reduce(raiser, [1, 2])
+    assert False, 'expected reduce to fail'
+except ValueError as exc:
+    assert str(exc) == 'inner'
+
+try:
+    functools.reduce(lambda a, b: a, [])
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == 'reduce() of empty iterable with no initial value'
+
+# the callable is never checked up front, so an empty iterable wins
+try:
+    functools.reduce(5, [])
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == 'reduce() of empty iterable with no initial value'
+
+try:
+    functools.reduce(5, [1, 2])
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == "'int' object is not callable"
+
+try:
+    functools.reduce(lambda a, b: a, 5)
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == 'reduce() arg 2 must support iteration'
+
+try:
+    functools.reduce(lambda a, b: a)
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == 'reduce() takes at least 2 positional arguments (1 given)'
+
+try:
+    functools.reduce(lambda a, b: a, [1], 2, 3)
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == 'reduce() takes at most 3 arguments (4 given)'
+
+try:
+    functools.reduce(lambda a, b: a, [1], bogus=1)
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == "reduce() got an unexpected keyword argument 'bogus'"
+
+# `function` and `iterable` are positional-only, so the arity error comes first
+try:
+    functools.reduce(function=lambda a, b: a, iterable=[1])
+    assert False, 'expected reduce to fail'
+except TypeError as exc:
+    assert str(exc) == 'reduce() takes at least 2 positional arguments (0 given)'

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -128,6 +128,33 @@ fn external_function_as_init_raises_not_implemented() {
     );
 }
 
+/// `functools.reduce` calls its function through `evaluate_function`, which
+/// cannot suspend, so an external one raises `NotImplementedError` (documented
+/// in `limitations/functools.md`). Rust-side for the same reason as
+/// `external_function_as_init_raises_not_implemented`: on CPython the external
+/// is a real function and the reduction would succeed.
+#[test]
+fn external_function_in_reduce_raises_not_implemented() {
+    let code = "import functools\n\nfunctools.reduce(ext_fn, [1, 2, 3])";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let err = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Traceback (most recent call last):\n  File \"test.py\", line 3, in <module>\n    functools.reduce(ext_fn, [1, 2, 3])\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\nNotImplementedError: reduce(): external function 'ext_fn' is not yet supported in this context"
+    );
+}
+
 /// A user `__next__` calling an external function cannot suspend: like
 /// `__repr__`/`__str__` it runs synchronously via `evaluate_function`, so the
 /// call raises `NotImplementedError` (see `limitations/classes.md`). Rust-side

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,9 +58,9 @@ Monty is that place, without a container or a sandboxing service in the loop.
 
 ## What Monty cannot do
 
-- **Most of the standard library.** Only `asyncio`, `collections`, `dataclasses`, `datetime`, `itertools`, `json`,
-  `math`, `os`, `pathlib`, `re`, `sys`, `typing` and `unicodedata` are importable, and each covers only part of its
-  CPython surface.
+- **Most of the standard library.** Only `asyncio`, `collections`, `dataclasses`, `datetime`, `functools`,
+  `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing` and `unicodedata` are importable, and each
+  covers only part of its CPython surface.
 - **Third-party packages.** There is no `sys.path` and no site-packages inside the sandbox; supporting PyPI packages is
   not a goal.
 - **Class inheritance.** `class Foo(Bar):` is rejected at parse time, and so are method decorators like `@classmethod`,

--- a/docs/python-subset.md
+++ b/docs/python-subset.md
@@ -58,7 +58,7 @@ the repository, and that directory — not this page — is the source of truth.
 
 ## Standard library
 
-Thirteen modules are importable.
+Fourteen modules are importable.
 Anything else raises `ModuleNotFoundError`.
 
 | Module | Divergences |
@@ -67,6 +67,7 @@ Anything else raises `ModuleNotFoundError`.
 | `collections` | [collections.md](https://github.com/pydantic/monty/blob/main/limitations/collections.md) |
 | `dataclasses` | [dataclasses.md](https://github.com/pydantic/monty/blob/main/limitations/dataclasses.md) |
 | `datetime` | [datetime.md](https://github.com/pydantic/monty/blob/main/limitations/datetime.md) |
+| `functools` | [functools.md](https://github.com/pydantic/monty/blob/main/limitations/functools.md) |
 | `itertools` | [itertools.md](https://github.com/pydantic/monty/blob/main/limitations/itertools.md) |
 | `json` | [json.md](https://github.com/pydantic/monty/blob/main/limitations/json.md) |
 | `math` | [math.md](https://github.com/pydantic/monty/blob/main/limitations/math.md) |
@@ -81,7 +82,7 @@ Each covers only part of its CPython surface — often a small part.
 The absent names are missing from the module namespace rather than stubbed, so they fail type checking as well as
 raising `AttributeError` at runtime.
 
-Notably absent: `functools`, `enum`, `contextlib`, `random`, `time`, `io`, `copy`, `string`, `struct`, `operator`,
+Notably absent: `enum`, `contextlib`, `random`, `time`, `io`, `copy`, `string`, `struct`, `operator`,
 `inspect`, `logging`, `traceback`, `base64`, `hashlib`, `uuid`, `urllib`.
 Some of those are absent by design — `socket`, `subprocess`, `multiprocessing`, `threading` and `ctypes` would breach
 the sandbox — and others are simply not implemented yet.

--- a/docs/type-checking.md
+++ b/docs/type-checking.md
@@ -24,7 +24,7 @@ The snippet does not run, and the session survives — fix the code and feed aga
 ## Why it matters more here than usual
 
 Monty implements a [deliberately small subset](python-subset.md) of Python.
-A model that writes `import functools` produces code that is perfectly valid CPython and completely unrunnable here.
+A model that writes `import random` produces code that is perfectly valid CPython and completely unrunnable here.
 
 Type checking closes that gap, because Monty does not check against CPython's typeshed.
 It checks against [`monty-typeshed`](https://crates.io/crates/monty-typeshed), a trimmed typeshed describing *Monty's*

--- a/limitations/functools.md
+++ b/limitations/functools.md
@@ -20,5 +20,7 @@ These names are absent from the module namespace rather than stubbed, so they ar
 ## Behavioural divergences
 
 - **`reduce()` cannot call a host function.** The reduction function runs through the same synchronous path as
-  `map()`'s, which cannot suspend the VM, so an external function or one that performs an `os` call raises
-  `NotImplementedError: reduce(): external function 'f' is not yet supported in this context`.
+  `map()`'s, which cannot suspend the VM. An external function raises `NotImplementedError: reduce(): external
+  function 'f' is not yet supported in this context`; one that touches the filesystem raises the same error naming
+  the OS function it maps to, e.g. `reduce(): OS function 'Path.iterdir' is not yet supported in this context` for
+  `os.listdir()`.

--- a/limitations/functools.md
+++ b/limitations/functools.md
@@ -1,0 +1,24 @@
+# `functools` module
+
+Monty implements a small subset of `functools`.
+The implemented callables match CPython 3.14 for arguments, values, `repr()` and error messages, apart from the notes
+below.
+
+## Implemented
+
+`reduce(function, iterable, /[, initial])`.
+
+## Not implemented
+
+Everything else: `partial`, `cache`, `lru_cache`, `cached_property`, `wraps`, `update_wrapper`, `partialmethod`,
+`total_ordering`, `singledispatch`, `singledispatchmethod`, `cmp_to_key`, `get_cache_token`, `Placeholder`,
+`WRAPPER_ASSIGNMENTS`, `WRAPPER_UPDATES`.
+
+These names are absent from the module namespace rather than stubbed, so they are rejected at type-check time (`Module
+'functools' has no member 'lru_cache'`) and raise `AttributeError` at runtime.
+
+## Behavioural divergences
+
+- **`reduce()` cannot call a host function.** The reduction function runs through the same synchronous path as
+  `map()`'s, which cannot suspend the VM, so an external function or one that performs an `os` call raises
+  `NotImplementedError: reduce(): external function 'f' is not yet supported in this context`.

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -12,6 +12,7 @@ and no way for sandboxed code to load additional modules.
 | `collections`  | ./collections.md |
 | `dataclasses`  | ./dataclasses.md |
 | `datetime`     | ./datetime.md    |
+| `functools`    | ./functools.md   |
 | `itertools`    | ./itertools.md   |
 | `json`         | ./json.md        |
 | `math`         | ./math.md        |
@@ -34,7 +35,7 @@ production sandboxes never see it.
 
 Common modules that are *not* importable in Monty (non-exhaustive):
 `abc`, `argparse`, `array`, `base64`, `bisect`, `contextlib`, `copy`, `csv`,
-`ctypes`, `decimal`, `enum`, `fractions`, `functools`,
+`ctypes`, `decimal`, `enum`, `fractions`,
 `hashlib`, `heapq`, `hmac`, `http`, `inspect`, `io`,
 `logging`, `multiprocessing`, `operator`, `pickle`, `queue`, `random`,
 `socket`, `string`, `struct`, `subprocess`, `tempfile`, `threading`,
@@ -42,14 +43,15 @@ Common modules that are *not* importable in Monty (non-exhaustive):
 `zipfile`, `zlib`.
 
 `socket`, `subprocess`, `multiprocessing`, `threading` and `ctypes` are
-excluded because they would breach the sandbox. Others (`functools`, `enum`)
+excluded because they would breach the sandbox. Others (`enum`, `operator`)
 are unimplemented and may appear over time.
 
 Some available modules cover only part of their CPython surface: `itertools`
-implements seven of its callables, and `collections` only the four types
-above. The absent names are missing from the module namespace rather than
-stubbed, so they fail type checking as well as raising `AttributeError` at
-runtime; see each module's page for the specifics.
+implements eleven of its callables, `functools` only `reduce`, and
+`collections` only the four types above. The absent names are missing from
+the module namespace rather than stubbed, so they fail type checking as well
+as raising `AttributeError` at runtime; see each module's page for the
+specifics.
 
 ## Modules the type checker resolves but the runtime does not
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ exclude = [
     "crates/monty/test_cases/loop__continue_in_function_error.py",
     "crates/monty/test_cases/loop__break_in_if_error.py",
     "crates/monty/test_cases/loop__continue_in_if_error.py",
+    # deliberately calls `reduce` with wrong arity and types to pin its
+    # TypeError messages
+    "crates/monty/test_cases/functools__reduce.py",
     "scripts/startup_performance.py",
     "examples/web_scraper/example_code.py",
 ]


### PR DESCRIPTION
## Adds functionality

Implements the `functools` module, so far holding only `reduce(function, iterable, /[, initial])`:

- The fold itself: `initial` optional, positionally or by keyword, the accumulator threaded left to right, and a one-item iterable returning that item without ever calling the function.
- `functools__reduce.py` passes identically on Monty and CPython 3.14 — values, every error message, and the arity and positional-only orderings. Messages diffed against CPython, including `reduce() takes at least 2 positional arguments (1 given)` against `reduce() takes at most 3 arguments (4 given)`.

## Limitations

- Not implemented: `partial`, `cache`, `lru_cache`, `cached_property`, `wraps`, `update_wrapper`, `partialmethod`, `total_ordering`, `singledispatch`, `singledispatchmethod`, `cmp_to_key`, `get_cache_token`, `Placeholder`, `WRAPPER_ASSIGNMENTS`, `WRAPPER_UPDATES`.
- `reduce()` cannot call a host function. The reduction function runs through `evaluate_function`, which cannot suspend the VM, so an external function raises `NotImplementedError` as it does under `map()`. Covered Rust-side, since on CPython the external is a real function and the fold would succeed.
- Stubs are narrowed to what runs, so `functools.lru_cache(...)` fails type checking rather than passing and raising `AttributeError`.

## Implementation details

- `ReduceArgs` uses `#[derive(FromArgs)]` with `at_most_total`, matching the Argument Clinic signature that counts positionals and keywords together: `reduce(f, x, 0, initial=1)` reports four arguments.
- The not-iterable rewrite replaces only a `TypeError`, so an `__iter__` raising anything else propagates unchanged, as CPython does.
- The accumulator is moved into each call rather than cloned. On error `evaluate_function` releases the arguments, and the placeholder left behind needs no cleanup.
- `StaticStrings`, `StandardLib` and `ModuleFunctions` are appended to, never inserted into, since all are dump-encoded by discriminant; the fingerprint is updated without a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the stdlib `functools` module exposing only `reduce(function, iterable, /[, initial])`, matching CPython 3.14 behavior and error messages. Previously `functools` was unavailable; code can now import it and use `reduce`.

- Signature/behavior: `function` and `iterable` are positional-only; `initial` is optional and allowed by keyword; arity counts positionals+keywords (“at_most_total”); a one-item iterable returns the item without calling the reducer.
- Errors/runtime: empty iterable without `initial` raises "reduce() of empty iterable with no initial value"; non-iterable second arg raises "reduce() arg 2 must support iteration"; other `__iter__` exceptions pass through. The reducer runs via `evaluate_function`; external or OS-bound reducers raise `NotImplementedError`, naming the mapped OS function (e.g., `Path.iterdir`).
- Wiring/typeshed/docs: registered `functools` in `StandardLib`; added interned strings and updated the static-strings fingerprint without a dump version bump. Added minimal `functools.pyi` for `reduce`; set `functools: 3.0-` in vendored `VERSIONS` and `update.py`; omitted unimplemented names to fail type checking early. Updated README and docs to list `functools`; added `limitations/functools.md`; added and excluded a test that pins `TypeError` texts.

<sup>Written for commit ed3ba5f2df3f80a7cc455168f4205d05e5322d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

