### PR TITLE
Raise instead of aborting when the async scheduler stalls

### DIFF
--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -828,6 +828,10 @@ impl<'h> VM<'h> {
     /// 2. Attempt to resume the current task (or fail it if any future resolution caused it to fail)
     /// 3. Load a ready task if needed (current task still blocked)
     /// 4. If no task is ready, return `ResolveFutures` with remaining pending call IDs
+    ///
+    /// # Errors
+    /// Returns [`RunError::Internal`] if nothing is ready to run and nothing is
+    /// pending: unreachable by design, but ends the turn rather than the worker.
     pub fn resume_with_resolved_futures(&mut self, results: Vec<(u32, ExtFunctionResult)>) -> RunResult<FrameExit> {
         for (call_id, ext_result) in results {
             match ext_result {
@@ -887,12 +891,14 @@ impl<'h> VM<'h> {
 
         let pending_call_ids = self.get_pending_call_ids();
 
-        assert!(
-            !pending_call_ids.is_empty(),
-            "resume_with_resolved_futures called but no pending calls and no ready tasks"
-        );
-
-        Ok(FrameExit::ResolveFutures(pending_call_ids))
+        if pending_call_ids.is_empty() {
+            // A stalled turn loses one `feed_run`, aborting loses the session.
+            Err(RunError::internal(
+                "asyncio scheduler stalled: no ready tasks and no pending external calls",
+            ))
+        } else {
+            Ok(FrameExit::ResolveFutures(pending_call_ids))
+        }
     }
 }
 

--- a/crates/monty/src/heap/stable_heap.rs
+++ b/crates/monty/src/heap/stable_heap.rs
@@ -223,7 +223,6 @@ impl<T> StableHeap<T> {
 }
 
 /// Allocates a new page of uninitialized slots directly on the heap.
-#[expect(clippy::unnecessary_box_returns, reason = "entire intent is to heap-allocate")]
 fn create_page<T>() -> Box<[Slot<T>; PAGE_SIZE]> {
     let raw = Box::into_raw(Box::<[Slot<T>]>::new_uninit_slice(PAGE_SIZE)).cast();
     // SAFETY: [DH] - allocation is known to be exactly PAGE_SIZE slots, so

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -1091,6 +1091,22 @@ await main()
     MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap()
 }
 
+/// Drives the runner above to the suspension where both externals are pending,
+/// returning their call ids keyed by name: the order the scheduler hands them
+/// over is not part of the contract under test, so positions must not be relied on.
+fn orphan_and_live_ids(progress: RunProgress) -> (ResolveFutures, u32, u32) {
+    let (state, calls) = drive_collecting_calls(progress);
+    assert_eq!(calls.len(), 2, "orphaned foo() and live bar() should both be pending");
+
+    let id_of = |name: &str| {
+        calls
+            .iter()
+            .find_map(|(id, called)| (called == name).then_some(*id))
+            .unwrap_or_else(|| panic!("{name}() should be pending"))
+    };
+    (state, id_of("foo"), id_of("bar"))
+}
+
 #[test]
 fn orphaned_external_resolved_alongside_live_one() {
     let runner = create_orphaned_external_runner();
@@ -1098,18 +1114,13 @@ fn orphaned_external_resolved_alongside_live_one() {
         .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
         .unwrap();
 
-    let (state, call_ids) = drive_to_resolve_futures(progress);
-    assert_eq!(
-        call_ids.len(),
-        2,
-        "orphaned foo() and live bar() should both be pending"
-    );
+    let (state, orphan, live) = orphan_and_live_ids(progress);
 
-    // One resolution readies `main`, the other is discarded; the scheduler must
-    // still find `main` to run.
+    // Resolving `bar()` readies `main`, `foo()`'s result is discarded; the
+    // scheduler must still find `main` to run.
     let results = vec![
-        (call_ids[0], ExtFunctionResult::Return(MontyObject::Int(1))),
-        (call_ids[1], ExtFunctionResult::Return(MontyObject::Int(7))),
+        (orphan, ExtFunctionResult::Return(MontyObject::Int(1))),
+        (live, ExtFunctionResult::Return(MontyObject::Int(7))),
     ];
 
     let progress = state.resume(results, PrintWriter::Stdout).unwrap();
@@ -1124,17 +1135,17 @@ fn orphaned_external_failed_alongside_live_one() {
         .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
         .unwrap();
 
-    let (state, call_ids) = drive_to_resolve_futures(progress);
+    let (state, orphan, live) = orphan_and_live_ids(progress);
 
     // The orphan's awaiter chain terminates at a cancelled task, so it fails
     // nothing; only `bar()`'s failure reaches a task.
     let results = vec![
         (
-            call_ids[0],
+            orphan,
             ExtFunctionResult::Error(MontyException::new(ExcType::RuntimeError, Some("orphan".to_string()))),
         ),
         (
-            call_ids[1],
+            live,
             ExtFunctionResult::Error(MontyException::new(ExcType::RuntimeError, Some("live".to_string()))),
         ),
     ];

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -1063,3 +1063,84 @@ caught
     let result = runner.run_no_limits(vec![]).expect("should complete");
     assert_eq!(result, MontyObject::Bool(true));
 }
+
+// === Test: orphaned external whose awaiting task was already cancelled ===
+
+/// Leaves a pending external with no live awaiter: `boom()` raises
+/// synchronously, failing the gather and cancelling `slow()` while its external
+/// call is outstanding, so the host's answer has nobody to deliver to.
+fn create_orphaned_external_runner() -> MontyRun {
+    let code = r"
+import asyncio
+
+async def slow():
+    return await foo()
+
+async def boom():
+    raise ValueError('cancels slow')
+
+async def main():
+    try:
+        await asyncio.gather(slow(), boom())
+    except ValueError:
+        pass
+    return await bar()
+
+await main()
+";
+    MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap()
+}
+
+#[test]
+fn orphaned_external_resolved_alongside_live_one() {
+    let runner = create_orphaned_external_runner();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let (state, call_ids) = drive_to_resolve_futures(progress);
+    assert_eq!(
+        call_ids.len(),
+        2,
+        "orphaned foo() and live bar() should both be pending"
+    );
+
+    // One resolution readies `main`, the other is discarded; the scheduler must
+    // still find `main` to run.
+    let results = vec![
+        (call_ids[0], ExtFunctionResult::Return(MontyObject::Int(1))),
+        (call_ids[1], ExtFunctionResult::Return(MontyObject::Int(7))),
+    ];
+
+    let progress = state.resume(results, PrintWriter::Stdout).unwrap();
+    let result = progress.into_complete().expect("should complete");
+    assert_eq!(result, MontyObject::Int(7));
+}
+
+#[test]
+fn orphaned_external_failed_alongside_live_one() {
+    let runner = create_orphaned_external_runner();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let (state, call_ids) = drive_to_resolve_futures(progress);
+
+    // The orphan's awaiter chain terminates at a cancelled task, so it fails
+    // nothing; only `bar()`'s failure reaches a task.
+    let results = vec![
+        (
+            call_ids[0],
+            ExtFunctionResult::Error(MontyException::new(ExcType::RuntimeError, Some("orphan".to_string()))),
+        ),
+        (
+            call_ids[1],
+            ExtFunctionResult::Error(MontyException::new(ExcType::RuntimeError, Some("live".to_string()))),
+        ),
+    ];
+
+    let err = state
+        .resume(results, PrintWriter::Stdout)
+        .expect_err("the live failure should surface");
+    assert_eq!(err.message(), Some("live"));
+}

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -54,6 +54,11 @@ every branch is blocked on an external call, hands the pending calls to the
 host, and resumes when the host returns results. There is no preemption, no
 threads, and no in-sandbox scheduler.
 
+If the scheduler ends a resume with nothing ready to run and no external calls
+outstanding, the turn fails with `RuntimeError: Internal error in monty:
+asyncio scheduler stalled: no ready tasks and no pending external calls`, which
+`try`/`except` cannot catch.
+
 ### A failing `gather` cancels its siblings
 
 When one child of a `gather` raises, every sibling still running is cancelled where it is blocked and never resumes.

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -54,11 +54,6 @@ every branch is blocked on an external call, hands the pending calls to the
 host, and resumes when the host returns results. There is no preemption, no
 threads, and no in-sandbox scheduler.
 
-If the scheduler ends a resume with nothing ready to run and no external calls
-outstanding, the turn fails with `RuntimeError: Internal error in monty:
-asyncio scheduler stalled: no ready tasks and no pending external calls`, which
-`try`/`except` cannot catch.
-
 ### A failing `gather` cancels its siblings
 
 When one child of a `gather` raises, every sibling still running is cancelled where it is blocked and never resumes.


### PR DESCRIPTION
Closes pydantic/monty#732.

Return an exception here as the invariant was reached by users. Meaning
**now**: end the turn as a RuntimeError
**before**: panic aborts the worker process so the pool has to replace it

VM::resume_with_resolved_futures` ended with an `assert!` that no ready tasks implies at least one pending external call; it now returns `RunError::Internal`, which the host receives as `RuntimeError: Internal error in monty: asyncio scheduler stalled: no ready tasks and no pending external calls`.

Note: 
Two tests covered previously untested adjacent code paths — an external orphaned by a cancelled task, resolved and failed alongside a live one. **However, a situation to reproduce the error is was not identified.** 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `RunError::Internal` instead of aborting the worker when the asyncio scheduler stalls. Before: an assert in `resume_with_resolved_futures` killed the worker and session; now only the current turn ends and the host sees `RuntimeError: Internal error in monty: asyncio scheduler stalled: no ready tasks and no pending external calls` (uncatchable by user code).

- `VM::resume_with_resolved_futures` returns `RunError::Internal` when no ready tasks and no pending externals; otherwise returns `ResolveFutures`. Worker and session stay alive.
- Adds order-independent tests for an orphaned external resolved or failed alongside a live one; keys call IDs by function name.
- Documents the stalled-turn `RuntimeError` in `limitations/asyncio.md`.
- Removes a dead Clippy `unnecessary_box_returns` expectation in `stable_heap::create_page` to fix a `-D warnings` build error.

<sup>Written for commit 3f8fc9c9b19e185cd438d0e0580876d984ab7d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

