### PR TITLE
Fix class-body comprehension scope

### DIFF
--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -269,6 +269,8 @@ struct FunctionState {
     locals: NameMap,
     /// Names declared `global` in this function — resolve to module globals.
     global_names: AHashSet<StringId>,
+    /// Names declared `nonlocal` in this function — resolve to enclosing cells.
+    nonlocal_names: AHashSet<StringId>,
     /// Names bound in THIS scope (params + body-assigned, minus globals).
     /// A read of any of these resolves to `NameScope::Local`.
     assigned_names: AHashSet<StringId>,
@@ -628,6 +630,7 @@ impl<'i, 'g> Prepare<'i, 'g> {
             state: PrepareState::Function(Box::new(FunctionState {
                 locals,
                 global_names,
+                nonlocal_names: nonlocal_names.clone(),
                 assigned_names,
                 enclosing_locals,
                 free_var_map,
@@ -2179,13 +2182,11 @@ impl<'i, 'g> Prepare<'i, 'g> {
             return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Global));
         }
 
-        // A class member bound earlier in the body keeps class-namespace
-        // semantics even when the same name also has a comprehension capture.
-        if self.is_class_scope && !self.skip_class_scope && self.bound_class_members.contains(&name_id) {
-            let slot = fn_state
-                .locals
-                .get(name_id)
-                .expect("bound class member has a local slot");
+        // Class-body stores always bind the class namespace, even when a
+        // nested comprehension has already captured the same name. Explicit
+        // `nonlocal` stores remain cell stores, as in CPython.
+        if !is_read && self.is_class_scope && !self.skip_class_scope && !fn_state.nonlocal_names.contains(&name_id) {
+            let slot = fn_state.locals.ensure_slot(name_id, position)?;
             return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Local));
         }
 

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -2130,13 +2130,9 @@ impl<'i, 'g> Prepare<'i, 'g> {
                 return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Cell));
             }
             if fn_state.enclosing_locals.contains(&name_id) {
-                let name = self.interner.get_str(name_id);
-                return Err(ParseError::not_implemented(
-                    format!(
-                        "class member '{name}' that shadows a captured variable of the same name from an enclosing scope"
-                    ),
-                    position,
-                ));
+                let slot = fn_state.locals.push_aliased_slot(name_id, position)?;
+                fn_state.free_var_map.insert(name_id, slot);
+                return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Cell));
             }
             let slot = self.globals.ensure_slot(name_id, position)?;
             return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Global));
@@ -2181,6 +2177,16 @@ impl<'i, 'g> Prepare<'i, 'g> {
         if fn_state.global_names.contains(&name_id) {
             let slot = self.globals.ensure_slot(name_id, position)?;
             return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Global));
+        }
+
+        // A class member bound earlier in the body keeps class-namespace
+        // semantics even when the same name also has a comprehension capture.
+        if self.is_class_scope && !self.skip_class_scope && self.bound_class_members.contains(&name_id) {
+            let slot = fn_state
+                .locals
+                .get(name_id)
+                .expect("bound class member has a local slot");
+            return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Local));
         }
 
         // 2. Captured from enclosing scope (nonlocal declaration or implicit capture).

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -193,6 +193,10 @@ struct Prepare<'i, 'g> {
     /// variables by bare name. [`Self::child_enclosing_locals`] honours this by
     /// excluding our own (class-member) locals when this flag is set.
     is_class_scope: bool,
+    /// True while preparing the nested portion of a comprehension in a class
+    /// body. The first iterable is evaluated in the class body itself; filters,
+    /// later iterables, and result expressions skip the class namespace.
+    skip_class_scope: bool,
     /// Class members whose binding statement has already been prepared, in
     /// source order (only populated when `is_class_scope`).
     ///
@@ -522,6 +526,7 @@ impl<'i, 'g> Prepare<'i, 'g> {
             comp_var_depth: 0,
             comp_name_scopes: Vec::new(),
             is_class_scope: false,
+            skip_class_scope: false,
             bound_class_members: AHashSet::new(),
         }
     }
@@ -633,6 +638,7 @@ impl<'i, 'g> Prepare<'i, 'g> {
             comp_var_depth: 0,
             comp_name_scopes: Vec::new(),
             is_class_scope: false,
+            skip_class_scope: false,
             bound_class_members: AHashSet::new(),
         })
     }
@@ -1360,6 +1366,14 @@ impl<'i, 'g> Prepare<'i, 'g> {
             remaining_targets.push(self.prepare_unpack_target_for_comprehension(generator.target.clone())?);
         }
 
+        // Everything after the first iterable executes in the comprehension's
+        // nested lexical scope. In a class body that scope can see comprehension
+        // targets and scopes enclosing the class, but not class members.
+        let saved_skip_class_scope = self.skip_class_scope;
+        if self.is_class_scope {
+            self.skip_class_scope = true;
+        }
+
         // Now prepare the first generator's filters (with full comp scope visible),
         // then the remaining generators' iter + filters, then the body element.
         let first_ifs = first_gen
@@ -1398,6 +1412,7 @@ impl<'i, 'g> Prepare<'i, 'g> {
             Some((k, v)) => Some((self.prepare_expression(k)?, self.prepare_expression(v)?)),
             None => None,
         };
+        self.skip_class_scope = saved_skip_class_scope;
 
         // The scope preserves lexical allocation order while keeping each name unique.
         let comp_scope = self.comp_name_scopes.pop().expect("comprehension scope was pushed");
@@ -2098,6 +2113,33 @@ impl<'i, 'g> Prepare<'i, 'g> {
                     NameScope::CompVar,
                 ));
             }
+        }
+
+        // The nested portion of a class-body comprehension skips the class
+        // namespace. Captures from a function enclosing the class have already
+        // been registered in `free_var_map` by the scope-analysis pass.
+        if is_read && self.is_class_scope && self.skip_class_scope {
+            let PrepareState::Function(fn_state) = &mut self.state else {
+                unreachable!("a class scope is represented by a function state");
+            };
+            if fn_state.global_names.contains(&name_id) {
+                let slot = self.globals.ensure_slot(name_id, position)?;
+                return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Global));
+            }
+            if let Some(&slot) = fn_state.free_var_map.get(&name_id) {
+                return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Cell));
+            }
+            if fn_state.enclosing_locals.contains(&name_id) {
+                let name = self.interner.get_str(name_id);
+                return Err(ParseError::not_implemented(
+                    format!(
+                        "class member '{name}' that shadows a captured variable of the same name from an enclosing scope"
+                    ),
+                    position,
+                ));
+            }
+            let slot = self.globals.ensure_slot(name_id, position)?;
+            return Ok(Identifier::new_with_scope(name_id, position, slot, NameScope::Global));
         }
 
         // In a class body, a READ of a member that has not been bound yet

--- a/crates/monty/test_cases/class__scope.py
+++ b/crates/monty/test_cases/class__scope.py
@@ -232,3 +232,23 @@ def make_capturing_comprehension(comp_outer_value):
 
 
 assert make_capturing_comprehension(30).body_lookup == [30]
+
+
+# A class member may shadow an enclosing function local without changing what
+# the nested comprehension captures. Comprehensions skip the class namespace,
+# so all three reads resolve to the enclosing function's cell.
+def make_shadowing_comprehension(outer_value):
+    class Shadowing:
+        outer_value = 10
+        body_lookup = [outer_value for _ in range(1)]
+        filter_lookup = [outer_value for _ in range(1) if outer_value == 30]
+        later_iterable = [x for _ in range(1) for x in [outer_value]]
+
+    return Shadowing
+
+
+shadowing = make_shadowing_comprehension(30)
+assert shadowing.outer_value == 10
+assert shadowing.body_lookup == [30]
+assert shadowing.filter_lookup == [30]
+assert shadowing.later_iterable == [30]

--- a/crates/monty/test_cases/class__scope.py
+++ b/crates/monty/test_cases/class__scope.py
@@ -203,3 +203,32 @@ try:
     assert False, 'expected NameError'
 except NameError as e:
     assert str(e) == "name 'missing_name' is not defined"
+
+
+# === Comprehensions skip the class namespace after evaluating the first
+# iterable, matching the nested-scope behavior used by CPython. ===
+comp_scope_value = 10
+
+
+class ComprehensionScope:
+    comp_scope_value = 20
+    first_iterable = [value for value in [comp_scope_value]]
+    body_lookup = [comp_scope_value for _ in range(1)]
+    filter_lookup = [comp_scope_value for _ in range(1) if comp_scope_value == 10]
+    later_iterable = [value for _ in range(1) for value in [comp_scope_value]]
+
+
+assert ComprehensionScope.first_iterable == [20]
+assert ComprehensionScope.body_lookup == [10]
+assert ComprehensionScope.filter_lookup == [10]
+assert ComprehensionScope.later_iterable == [10]
+
+
+def make_capturing_comprehension(comp_outer_value):
+    class Inner:
+        body_lookup = [comp_outer_value for _ in range(1)]
+
+    return Inner
+
+
+assert make_capturing_comprehension(30).body_lookup == [30]

--- a/crates/monty/test_cases/class__scope.py
+++ b/crates/monty/test_cases/class__scope.py
@@ -252,3 +252,33 @@ assert shadowing.outer_value == 10
 assert shadowing.body_lookup == [30]
 assert shadowing.filter_lookup == [30]
 assert shadowing.later_iterable == [30]
+
+
+# A class-body store after a comprehension capture still creates a class
+# member; the comprehension keeps the enclosing function's value.
+def make_post_capture_class(outer_value):
+    class PostCapture:
+        body_lookup = [outer_value for _ in range(1)]
+        outer_value = 10
+
+    return PostCapture
+
+
+post_capture = make_post_capture_class(30)
+assert post_capture.body_lookup == [30]
+assert post_capture.outer_value == 10
+
+
+# A comprehension target is isolated from a later class-body store of the
+# same name.
+def make_target_store():
+    class TargetStore:
+        body_lookup = [target for target in range(1)]
+        target = 5
+
+    return TargetStore
+
+
+target_store = make_target_store()
+assert target_store.body_lookup == [0]
+assert target_store.target == 5

--- a/docs/limitations/classes.md
+++ b/docs/limitations/classes.md
@@ -136,12 +136,6 @@ order and error wording, but with these divergences:
     evaluation such as `map()`, `filter()`, `sorted()`/`list.sort(key=...)`,
     `min()`/`max(key=...)`, and exotic `__init__` recursion (see the "Recursion"
     section of [resource_limits.md](resource_limits.md)).
-- **Comprehensions in the class body** can see class variables, because Monty
-    inlines comprehensions into the enclosing scope. In CPython a comprehension
-    has its own scope that skips the class scope, so only the *leftmost iterable*
-    is evaluated in class scope and the body cannot see class variables
-    (`[n + offset for n in nums]` referencing a class variable `offset` raises
-    `NameError` in CPython but succeeds in Monty).
 - **Same-name collision is rejected, not resolved.** When an enclosing-function
     local and a class variable share a name *and* a method captures the enclosing
     one, CPython keeps the two distinct (a class-dict entry vs. a closure cell).


### PR DESCRIPTION
Fixes #755

## Summary

- evaluate only the first iterable of a class-body comprehension in the class namespace
- resolve filters, later iterables, and result expressions through the comprehension's nested scope
- keep enclosing-function captures distinct from same-name class members, including a class assignment after the capture

## Root cause

Monty prepared comprehensions inline with the surrounding class-body preparer. Later comprehension reads therefore continued through the class namespace instead of skipping it as CPython does.

After the initial scope fix, a comprehension could allocate a free-variable slot for an enclosing local before a later same-name class assignment. That store then reused the capture slot and failed to create the class member. Class-body stores now allocate a class-local slot before free-variable lookup; explicit `nonlocal` stores continue to use their cell.

## Validation

- class-scope CPython/Monty differential test: passed, including the reported post-capture class assignment and a same-name comprehension target
- `cargo test -p monty --lib`: 45 passed
- full datatest: 1,183 passed; the only failure is the pre-existing CPython `sequence__search_bounds` mismatch
- `make format-rs`: passed
- both workspace Clippy invocations from `make lint-rs`: passed with `-D warnings`
- `scripts/check_imports.py`: passed from the Windows worktree
- `git diff --check`: passed

The latest head passes the repository's full GitHub Actions matrix, including lint, Rust/Python/JS tests, coverage, Miri, fuzz, browser, and both benchmark jobs. CodSpeed separately flags one simulated benchmark at -11.17%, while warning that the comparison used different runtime environments; its external performance check remains red for maintainer review.

## AI assistance

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
