### PR TITLE
use `HeapObjectRead` to reduce `self_id` passing

### DIFF
--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -534,32 +534,19 @@ macro_rules! heap_read_output_py_trait_forward {
     };
 }
 
-/// Subscripts the heap value `id`, routing a `defaultdict` miss through
-/// `__missing__` and everything else — Counter included — to `py_getitem`.
+/// Subscripts a heap value, routing a `defaultdict` miss through `__missing__`
+/// and everything else — Counter included — to `py_getitem`.
 ///
-/// A defaultdict's miss stores `factory()`, and calling the factory re-enters
-/// the VM, which is impossible both while a `HeapRead` handle is alive and
-/// behind [`PyTrait::py_getitem`]'s `&self`. Taking the [`HeapId`] here keeps
-/// that one mutating case out of the read-only trait; `Value::py_getitem`'s
-/// `Ref` arm calls this instead of reading the heap itself.
-pub(crate) fn heap_subscript(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
-    if matches!(vm.heap.get(id), HeapData::Dict(d) if d.is_defaultdict()) {
-        // The read handle is scoped to the lookup: `defaultdict_missing` runs the
-        // factory, which re-enters the VM and can drop the last reference to this
-        // dict — and `dec_ref` asserts that an entry has no active readers when it
-        // is freed.
-        let found = {
-            let HeapReadOutput::Dict(dict) = vm.heap.read(id) else {
-                unreachable!("a defaultdict is a dict");
-            };
-            dict.dict_get(key, vm)?
-        };
-        match found {
+/// A defaultdict's miss stores `factory()`, so that mutating case stays outside
+/// [`PyTrait::py_getitem`]'s read-only interface while retaining the identity-aware
+/// object handle supplied by `Value::py_getitem`.
+pub(crate) fn heap_subscript<'h>(value: HeapReadOutput<'h>, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    match value {
+        HeapReadOutput::Dict(mut dict) if dict.get(vm.heap).is_defaultdict() => match dict.dict_get(key, vm)? {
             Some(value) => Ok(value),
-            None => defaultdict_missing(id, key, vm),
-        }
-    } else {
-        vm.heap.read(id).py_getitem(key, vm)
+            None => defaultdict_missing(&mut dict, key, vm),
+        },
+        value => value.py_getitem(key, vm),
     }
 }
 

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -908,7 +908,7 @@ fn counter_retain_positive<'h>(counter: &mut HeapObjectRead<'h, Dict>, vm: &mut 
             defer_drop_mut!(count, vm);
             let mut key_guard = DropGuard::new(key, vm);
             if !count_is_positive(count, key_guard.ctx())? {
-                let (key, vm) = key_guard.into_parts();
+                let key = key_guard.into_inner();
                 remove.push(key);
             }
         }

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -1,9 +1,10 @@
 //! Runtime behaviour for `collections.Counter`.
 //!
 //! A Counter is a `dict` tagged with a `Counter` [`DictKind`](crate::types::DictKind);
-//! everything here operates on that dict through the VM by [`HeapId`] rather than
-//! on `Dict`'s internals, which is why it lives beside the module surface instead
-//! of in `types/dict.rs`. The dict method surface is inherited as-is — only the
+//! operations receive the Counter's heap object handle but re-read its dictionary
+//! through the VM whenever Python execution can intervene. This is why the logic
+//! lives beside the module surface instead of in `types/dict.rs`. The dict method
+//! surface is inherited as-is — only the
 //! missing-key read (`0`, no insert), `most_common`/`elements`/`total`/`update`/
 //! `subtract`, and the `+ - & |` algebra are added on top.
 
@@ -16,7 +17,7 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapReadOutput},
+    heap::{DropGuard, DropWithContext, HeapData, HeapObjectRead, HeapReadOutput},
     resource_checks::check_repeat_size,
     types::{Dict, List, PyTrait, allocate_tuple, iter::collect_owned_iterable, py_trait::CmpOrder},
     value::{VALUE_SIZE, Value},
@@ -138,8 +139,8 @@ fn count_repeat_len(value: &Value, vm: &mut VM<'_>) -> RunResult<usize> {
     }
 }
 
-/// Adds `delta` to the count for `key` in the Counter `dict_id` (creating the
-/// key at `0 + delta` if absent). Takes ownership of `key`, which the dict keeps
+/// Adds `delta` to the count for `key` in `counter` (creating the key at
+/// `0 + delta` if absent). Takes ownership of `key`, which the dict keeps
 /// on success; `delta` is only read, so the caller retains it.
 ///
 /// `delta_first` selects the operand order for the addition: CPython's mapping
@@ -147,23 +148,20 @@ fn count_repeat_len(value: &Value, vm: &mut VM<'_>) -> RunResult<usize> {
 /// `self.get(elem, 0) + 1`. The two agree numerically, but the left operand is
 /// the one named in a `TypeError`. Ignored when `subtract` is set, which is
 /// always `self.get(elem, 0) - count`.
-fn counter_bump(
-    dict_id: HeapId,
+fn counter_bump<'h>(
+    counter: &mut HeapObjectRead<'h, Dict>,
     key: Value,
     delta: &Value,
     subtract: bool,
     delta_first: bool,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<()> {
-    let HeapReadOutput::Dict(mut dict) = vm.heap.read(dict_id) else {
-        unreachable!("counter_bump on a non-dict heap entry");
-    };
     // Either failure below — `dict_get` hashing an unhashable key (e.g.
     // `Counter([[1]])`), or the arithmetic on a non-numeric count — releases the
     // key through the guard; only the store at the end takes it out again.
     let mut key_guard = DropGuard::new(key, vm);
     let (key, vm) = key_guard.as_parts_mut();
-    let base = dict.dict_get(key, vm)?.unwrap_or(Value::Int(0));
+    let base = counter.dict_get(key, vm)?.unwrap_or(Value::Int(0));
     let total = if subtract || !delta_first {
         count_arith(&base, delta, subtract, vm)
     } else {
@@ -172,7 +170,7 @@ fn counter_bump(
     base.drop_with(vm);
     let total = total?;
     let (key, vm) = key_guard.into_parts();
-    if let Some(old) = dict.set(key, total, vm)? {
+    if let Some(old) = counter.set(key, total, vm)? {
         old.drop_with(vm);
     }
     Ok(())
@@ -180,15 +178,15 @@ fn counter_bump(
 
 /// Implements `Counter.update`/`subtract` and construction: folds counts from
 /// `source` (a mapping adds its values; any other iterable counts occurrences)
-/// and from `kwargs` into the Counter `dict_id`. `subtract` negates the deltas.
+/// and from `kwargs` into `counter`. `subtract` negates the deltas.
 ///
 /// Consumes `source` and `kwargs`.
-pub(crate) fn counter_update(
-    dict_id: HeapId,
+pub(crate) fn counter_update<'h>(
+    counter: &mut HeapObjectRead<'h, Dict>,
     source: Option<Value>,
     kwargs: KwargsValues,
     subtract: bool,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<()> {
     // An explicit `None` source is a no-op (CPython skips it before dispatch), so
     // `Counter(None)` and `c.update(None)` only apply the keyword counts below.
@@ -211,7 +209,7 @@ pub(crate) fn counter_update(
                     .collect()
             };
             source.drop_with(vm);
-            counter_merge_mapping(dict_id, pairs, subtract, vm)?;
+            counter_merge_mapping(counter, pairs, subtract, vm)?;
         } else {
             // `_count_elements`: `self[elem] = self_get(elem, 0) + 1`, so the
             // existing count is the left operand here.
@@ -220,7 +218,7 @@ pub(crate) fn counter_update(
             // items it never reached.
             defer_drop_mut!(items, vm);
             for item in items.by_ref() {
-                counter_bump(dict_id, item, &Value::Int(1), subtract, false, vm)?;
+                counter_bump(counter, item, &Value::Int(1), subtract, false, vm)?;
             }
         }
     }
@@ -229,11 +227,11 @@ pub(crate) fn counter_update(
     // via `self.update(kwds)`, so these follow the mapping path — including the
     // empty-Counter fast path, re-evaluated after the iterable was folded in.
     let kwarg_pairs = counter_kwarg_deltas(kwargs);
-    counter_merge_mapping(dict_id, kwarg_pairs, subtract, vm)?;
+    counter_merge_mapping(counter, kwarg_pairs, subtract, vm)?;
     Ok(())
 }
 
-/// Folds mapping `(key, count)` pairs into the Counter `dict_id`.
+/// Folds mapping `(key, count)` pairs into `counter`.
 ///
 /// Mirrors `Counter.update`'s mapping branch: into a **non-empty** Counter each
 /// count is added as `count + self.get(elem, 0)` (the incoming count is the left
@@ -241,18 +239,13 @@ pub(crate) fn counter_update(
 /// one CPython takes a `super().update()` fast path that stores values verbatim
 /// — which is why `Counter({'a': True})` keeps `True` rather than `1`.
 /// `subtract` has no fast path and always computes `self.get(elem, 0) - count`.
-fn counter_merge_mapping(
-    dict_id: HeapId,
+fn counter_merge_mapping<'h>(
+    counter: &mut HeapObjectRead<'h, Dict>,
     pairs: Vec<(Value, Value)>,
     subtract: bool,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<()> {
-    let is_empty = {
-        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-            unreachable!("counter_merge_mapping on a non-dict heap entry");
-        };
-        dict.get(vm.heap).is_empty()
-    };
+    let is_empty = counter.get(vm.heap).is_empty();
     // A merge can fail on an unhashable key or a non-numeric count; the guard
     // releases the pairs it never reached.
     let pairs = pairs.into_iter();
@@ -261,9 +254,11 @@ fn counter_merge_mapping(
         // The fast path stores `count` itself, while a bump only reads it — so
         // that branch owns the release.
         if is_empty && !subtract {
-            counter_set(dict_id, key, count, vm)?;
+            if let Some(old) = counter.set(key, count, vm)? {
+                old.drop_with(vm);
+            }
         } else {
-            let outcome = counter_bump(dict_id, key, &count, subtract, true, vm);
+            let outcome = counter_bump(counter, key, &count, subtract, true, vm);
             count.drop_with(vm);
             outcome?;
         }
@@ -289,11 +284,11 @@ fn counter_kwarg_deltas(kwargs: KwargsValues) -> Vec<(Value, Value)> {
 /// `self` (`Counter.update() takes from 1 to 2 positional arguments but 3 were
 /// given`), which the derive's `def` family — positional-only, no receiver —
 /// cannot express. The `+ 1`s below re-introduce that `self`.
-pub(crate) fn counter_update_method(
-    dict_id: HeapId,
+pub(crate) fn counter_update_method<'h>(
+    counter: &mut HeapObjectRead<'h, Dict>,
     args: ArgValues,
     subtract: bool,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<Value> {
     let (mut pos, kwargs) = args.into_parts();
     let total = pos.len();
@@ -306,7 +301,7 @@ pub(crate) fn counter_update_method(
         kwargs.drop_with(vm);
         return Err(ExcType::type_error_too_many_positional_range(name, 1, 2, total + 1, 0));
     }
-    counter_update(dict_id, source, kwargs, subtract, vm)?;
+    counter_update(counter, source, kwargs, subtract, vm)?;
     Ok(Value::None)
 }
 
@@ -314,8 +309,13 @@ pub(crate) fn counter_update_method(
 ///
 /// Sums with real numeric addition (CPython's `sum(self.values())`), so a
 /// float or big-int count is preserved in the total rather than truncated.
-pub(crate) fn counter_total(dict_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value> {
-    let counts = counter_count_snapshot(dict_id, vm).into_iter();
+pub(crate) fn counter_total<'h>(counter: &HeapObjectRead<'h, Dict>, vm: &mut VM<'h>) -> RunResult<Value> {
+    let counts = counter
+        .get(vm.heap)
+        .iter()
+        .map(|(_, count)| count.clone_with_heap(vm.heap))
+        .collect::<Vec<_>>()
+        .into_iter();
     // A count that cannot be added raises mid-fold, so both the counts not yet
     // folded in and the running total are held by guards that release them.
     defer_drop_mut!(counts, vm);
@@ -362,20 +362,14 @@ pub(crate) fn counter_order(counts: Vec<Value>, vm: &mut VM<'_>) -> RunResult<Ve
     }
 }
 
-/// Snapshots a Counter's counts as owned clones, releasing the heap borrow so
-/// the caller can run arithmetic that needs `&mut VM`.
-fn counter_count_snapshot(dict_id: HeapId, vm: &mut VM<'_>) -> Vec<Value> {
-    let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-        unreachable!("counter_count_snapshot on a non-dict heap entry");
-    };
-    let dict = dict.get(vm.heap);
-    dict.iter().map(|(_, v)| v.clone_with_heap(vm.heap)).collect()
-}
-
 /// `Counter.most_common([n])` — a list of `(element, count)` tuples ordered by
 /// count descending (ties in insertion order). `n` omitted/`None` returns all;
 /// a non-positive `n` returns an empty list.
-pub(crate) fn counter_most_common(dict_id: HeapId, args: ArgValues, vm: &mut VM<'_>) -> RunResult<Value> {
+pub(crate) fn counter_most_common<'h>(
+    counter: &HeapObjectRead<'h, Dict>,
+    args: ArgValues,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
     let n_arg = args.get_zero_one_arg("most_common", vm.heap)?;
     // `n` goes through `__index__`, so a bool counts as `0`/`1` and a big int is
     // accepted (clamped): a huge positive returns every item, a negative none.
@@ -403,15 +397,17 @@ pub(crate) fn counter_most_common(dict_id: HeapId, args: ArgValues, vm: &mut VM<
         }
     };
 
-    let order = counter_order(counter_count_snapshot(dict_id, vm), vm)?;
+    let counts = counter
+        .get(vm.heap)
+        .iter()
+        .map(|(_, count)| count.clone_with_heap(vm.heap))
+        .collect();
+    let order = counter_order(counts, vm)?;
     let take = limit.unwrap_or(order.len()).min(order.len());
 
     let mut items: Vec<Value> = Vec::with_capacity(take);
     for &i in &order[..take] {
-        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-            unreachable!("counter_most_common on a non-dict heap entry");
-        };
-        let dict = dict.get(vm.heap);
+        let dict = counter.get(vm.heap);
         let key = dict.key_at(i).expect("index in range").clone_with_heap(vm.heap);
         let count = dict.value_at(i).expect("index in range").clone_with_heap(vm.heap);
         let pair = allocate_tuple(smallvec![key, count], vm.heap);
@@ -423,19 +419,20 @@ pub(crate) fn counter_most_common(dict_id: HeapId, args: ArgValues, vm: &mut VM<
 /// `Counter.elements()` — a list repeating each element by its count, skipping
 /// zero and negative counts (Monty's eager iterator convention returns a list
 /// rather than CPython's lazy iterator).
-pub(crate) fn counter_elements(dict_id: HeapId, args: ArgValues, vm: &mut VM<'_>) -> RunResult<Value> {
+pub(crate) fn counter_elements<'h>(
+    counter: &HeapObjectRead<'h, Dict>,
+    args: ArgValues,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
     args.check_zero_args("elements", vm.heap)?;
-    let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-        unreachable!("counter_elements on a non-dict heap entry");
-    };
-    let n = dict.get(vm.heap).len();
+    let n = counter.get(vm.heap).len();
 
     // Resolve every repetition length up front: a count that `itertools.repeat`
     // rejects — non-integer (TypeError) or outside `ssize_t` (OverflowError) —
     // must raise before anything is built.
     let mut lengths = Vec::with_capacity(n);
     for i in 0..n {
-        let count = dict
+        let count = counter
             .get(vm.heap)
             .value_at(i)
             .expect("index in range")
@@ -457,7 +454,7 @@ pub(crate) fn counter_elements(dict_id: HeapId, args: ArgValues, vm: &mut VM<'_>
     let mut items: Vec<Value> = Vec::new();
     for (i, &count) in lengths.iter().enumerate() {
         for _ in 0..count {
-            let key = dict
+            let key = counter
                 .get(vm.heap)
                 .key_at(i)
                 .expect("index in range")
@@ -483,7 +480,12 @@ pub(crate) enum CounterOp {
 
 /// Computes a binary `Counter` operation, returning a new Counter that keeps
 /// only positive counts (CPython's `Counter.__add__` etc.).
-pub(crate) fn counter_binary_op(l_id: HeapId, r_id: HeapId, op: CounterOp, vm: &mut VM<'_>) -> RunResult<Value> {
+pub(crate) fn counter_binary_op<'h>(
+    lhs: &HeapObjectRead<'h, Dict>,
+    rhs: &HeapObjectRead<'h, Dict>,
+    op: CounterOp,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
     let mut result = Dict::new();
     result.make_counter();
     let result_id = vm.heap.allocate(HeapData::Dict(result));
@@ -492,28 +494,32 @@ pub(crate) fn counter_binary_op(l_id: HeapId, r_id: HeapId, op: CounterOp, vm: &
     // free it, which the bare `?` early-returns would otherwise leak.
     let mut result_guard = DropGuard::new(Value::Ref(result_id), vm);
     let vm = result_guard.ctx();
+    let HeapReadOutput::Dict(mut result) = vm.heap.read(result_id) else {
+        unreachable!("just allocated a Counter dict");
+    };
 
     // Each operand is snapshotted only when it is about to be consumed: taking
     // the right snapshot up front would leak it if folding the left one raised.
     match op {
         CounterOp::Add => {
-            let l_pairs = counter_snapshot(l_id, vm);
-            counter_bump_all(result_id, l_pairs, false, vm)?;
-            let r_pairs = counter_snapshot(r_id, vm);
-            counter_bump_all(result_id, r_pairs, false, vm)?;
+            let l_pairs = lhs.clone_all_pairs(vm)?;
+            counter_bump_all(&mut result, l_pairs, false, vm)?;
+            let r_pairs = rhs.clone_all_pairs(vm)?;
+            counter_bump_all(&mut result, r_pairs, false, vm)?;
         }
         CounterOp::Sub => {
-            let l_pairs = counter_snapshot(l_id, vm);
-            counter_bump_all(result_id, l_pairs, false, vm)?;
-            let r_pairs = counter_snapshot(r_id, vm);
-            counter_bump_all(result_id, r_pairs, true, vm)?;
+            let l_pairs = lhs.clone_all_pairs(vm)?;
+            counter_bump_all(&mut result, l_pairs, false, vm)?;
+            let r_pairs = rhs.clone_all_pairs(vm)?;
+            counter_bump_all(&mut result, r_pairs, true, vm)?;
         }
         // `|` keeps the larger count over the union of keys (see `counter_binary_extreme`).
-        CounterOp::Or => counter_binary_extreme(result_id, l_id, r_id, ExtremeOp::Max, vm)?,
+        CounterOp::Or => counter_binary_extreme(&mut result, lhs, rhs, ExtremeOp::Max, vm)?,
         // `&` keeps the smaller count over shared keys (see `counter_binary_extreme`).
-        CounterOp::And => counter_binary_extreme(result_id, l_id, r_id, ExtremeOp::Min, vm)?,
+        CounterOp::And => counter_binary_extreme(&mut result, lhs, rhs, ExtremeOp::Min, vm)?,
     }
-    counter_retain_positive(result_id, vm)?;
+    counter_retain_positive(&mut result, vm)?;
+    drop(result);
     Ok(result_guard.into_inner())
 }
 
@@ -526,7 +532,7 @@ enum ExtremeOp {
     Max,
 }
 
-/// Folds a binary `&`/`|` into the fresh `result_id`.
+/// Folds a binary `&`/`|` into the fresh `result`.
 ///
 /// Both walk the *left* operand's keys and pick the extreme of `count` and the
 /// right's `other[elem]` (a missing right key reads as `0`), comparing exactly as
@@ -535,21 +541,21 @@ enum ExtremeOp {
 /// right-only keys across. The caller's final `retain_positive` performs the
 /// `> 0` strip (and raises the `> 0` `TypeError` for an unorderable right-only
 /// key, matching CPython's second-loop wording).
-fn counter_binary_extreme(
-    result_id: HeapId,
-    l_id: HeapId,
-    r_id: HeapId,
+fn counter_binary_extreme<'h>(
+    result: &mut HeapObjectRead<'h, Dict>,
+    lhs: &HeapObjectRead<'h, Dict>,
+    rhs: &HeapObjectRead<'h, Dict>,
     op: ExtremeOp,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<()> {
     // Two guards cover every failure below, so each one is a plain `?`: the outer
     // releases the entries the loop never reached, the inner the one in flight.
-    let l_pairs = counter_snapshot(l_id, vm).into_iter();
+    let l_pairs = lhs.clone_all_pairs(vm)?.into_iter();
     defer_drop_mut!(l_pairs, vm);
     for entry in l_pairs.by_ref() {
         let mut entry = DropGuard::new(entry, vm);
         let ((key, count), vm) = entry.as_parts_mut();
-        let other = counter_lookup(r_id, key, vm)?.unwrap_or(Value::Int(0));
+        let other = rhs.dict_get(key, vm)?.unwrap_or(Value::Int(0));
         let mut other = DropGuard::new(other, vm);
         let (other_count, vm) = other.as_parts_mut();
         // `count < other`: `|` keeps `count` when it is *not* smaller, `&` keeps
@@ -568,23 +574,26 @@ fn counter_binary_extreme(
             count.drop_with(vm);
             other
         };
-        // `counter_set` consumes both, releasing them itself if the store fails.
-        counter_set(result_id, key, picked, vm)?;
+        if let Some(old) = result.set(key, picked, vm)? {
+            old.drop_with(vm);
+        }
     }
 
     if matches!(op, ExtremeOp::Max) {
-        let r_pairs = counter_snapshot(r_id, vm).into_iter();
+        let r_pairs = rhs.clone_all_pairs(vm)?.into_iter();
         defer_drop_mut!(r_pairs, vm);
         for entry in r_pairs.by_ref() {
             let mut entry = DropGuard::new(entry, vm);
             let ((key, _), vm) = entry.as_parts_mut();
             // Shared keys were already resolved in the left pass, so the guard
             // releases this entry; only a right-only key reaches the result.
-            if let Some(existing) = counter_lookup(l_id, key, vm)? {
+            if let Some(existing) = lhs.dict_get(key, vm)? {
                 existing.drop_with(vm);
             } else {
                 let ((key, count), vm) = entry.into_parts();
-                counter_set(result_id, key, count, vm)?;
+                if let Some(old) = result.set(key, count, vm)? {
+                    old.drop_with(vm);
+                }
             }
         }
     }
@@ -611,7 +620,12 @@ pub(crate) enum CounterCmp {
 /// present in only one operand still constrains the result. The strict forms
 /// are defined in terms of the loose ones: `<` is `<= and !=`, `>` is
 /// `>= and !=`.
-pub(crate) fn counter_compare(l_id: HeapId, r_id: HeapId, cmp: CounterCmp, vm: &mut VM<'_>) -> RunResult<bool> {
+pub(crate) fn counter_compare<'h>(
+    lhs: &HeapObjectRead<'h, Dict>,
+    rhs: &HeapObjectRead<'h, Dict>,
+    cmp: CounterCmp,
+    vm: &mut VM<'h>,
+) -> RunResult<bool> {
     // `<` is `<= and !=` and `>` is `>= and !=`, so both strict forms run the
     // loose comparison — whose operator is what an unorderable pair reports — and
     // add the inequality via the separately tracked `equal`.
@@ -628,7 +642,7 @@ pub(crate) fn counter_compare(l_id: HeapId, r_id: HeapId, cmp: CounterCmp, vm: &
     // `counter_union_counts` hands back owned pairs the caller must drop. The
     // guard covers every exit — a short-circuit (`!holds`), a failing comparison,
     // and normal exhaustion — releasing whatever the loop never compared.
-    let pairs = counter_union_counts(l_id, r_id, vm)?.into_iter();
+    let pairs = counter_union_counts(lhs, rhs, vm)?.into_iter();
     defer_drop_mut!(pairs, vm);
     for pair in pairs.by_ref() {
         defer_drop!(pair, vm);
@@ -666,19 +680,23 @@ pub(crate) fn counter_compare(l_id: HeapId, r_id: HeapId, cmp: CounterCmp, vm: &
 ///
 /// Returns owned clones so the caller can run comparisons that need `&mut VM`.
 /// Every returned pair must be dropped by the caller.
-fn counter_union_counts(l_id: HeapId, r_id: HeapId, vm: &mut VM<'_>) -> RunResult<Vec<(Value, Value)>> {
+fn counter_union_counts<'h>(
+    lhs: &HeapObjectRead<'h, Dict>,
+    rhs: &HeapObjectRead<'h, Dict>,
+    vm: &mut VM<'h>,
+) -> RunResult<Vec<(Value, Value)>> {
     // Three guards, so a failing lookup is a plain `?`: the pairs accumulated so
     // far, the entries not yet visited, and the entry in flight all get released.
     let mut pairs = DropGuard::new(Vec::new(), vm);
     // Left keys against their right counterparts, then the right-only keys.
-    for (keys_id, other_id, flip) in [(l_id, r_id, false), (r_id, l_id, true)] {
+    for (keys, other, flip) in [(lhs, rhs, false), (rhs, lhs, true)] {
         let (collected, vm) = pairs.as_parts_mut();
-        let entries = counter_snapshot(keys_id, vm).into_iter();
+        let entries = keys.clone_all_pairs(vm)?.into_iter();
         defer_drop_mut!(entries, vm);
         for entry in entries.by_ref() {
             let mut entry = DropGuard::new(entry, vm);
             let ((key, _), vm) = entry.as_parts_mut();
-            let other = counter_lookup(other_id, key, vm)?;
+            let other = other.dict_get(key, vm)?;
             // On the second pass only keys absent from the left are new; the
             // shared ones were already paired, so skip them (the guard releases
             // the entry); otherwise the count moves into `collected`.
@@ -700,7 +718,7 @@ fn counter_union_counts(l_id: HeapId, r_id: HeapId, vm: &mut VM<'_>) -> RunResul
     Ok(pairs.into_inner())
 }
 
-/// Applies a `Counter` algebra operator **in place**, mutating `l_id`.
+/// Applies a `Counter` algebra operator **in place**, mutating `counter`.
 ///
 /// CPython's `__iadd__`/`__isub__`/`__iand__`/`__ior__` mutate `self` and return
 /// it, so `c += other` keeps the object identity and any alias observes the
@@ -715,22 +733,33 @@ fn counter_union_counts(l_id: HeapId, r_id: HeapId, vm: &mut VM<'_>) -> RunResul
 /// Note the asymmetry CPython has between the directions: `+=` / `-=` walk
 /// *other*'s keys (so new keys can appear), whereas `&=` walks *self*'s keys
 /// (so no key is ever added), and `|=` walks *other*'s keys keeping the larger.
-pub(crate) fn counter_inplace_op(l_id: HeapId, rhs: &Value, op: CounterOp, vm: &mut VM<'_>) -> RunResult<()> {
+pub(crate) fn counter_inplace_op<'h>(
+    counter: &mut HeapObjectRead<'h, Dict>,
+    rhs: &Value,
+    op: CounterOp,
+    vm: &mut VM<'h>,
+) -> RunResult<()> {
     match op {
         // `for elem, count in other.items(): self[elem] += count`
-        CounterOp::Add => counter_bump_all(l_id, counter_snapshot(counter_require_mapping(rhs, vm)?, vm), false, vm)?,
-        CounterOp::Sub => counter_bump_all(l_id, counter_snapshot(counter_require_mapping(rhs, vm)?, vm), true, vm)?,
+        CounterOp::Add => {
+            let rhs = counter_require_mapping(rhs, vm)?;
+            counter_bump_all(counter, rhs.clone_all_pairs(vm)?, false, vm)?;
+        }
+        CounterOp::Sub => {
+            let rhs = counter_require_mapping(rhs, vm)?;
+            counter_bump_all(counter, rhs.clone_all_pairs(vm)?, true, vm)?;
+        }
         // `for elem, other_count in other.items(): if other_count > self[elem]:
         //     self[elem] = other_count` — walks *other*, so new keys can appear.
         CounterOp::Or => {
-            let r_id = counter_require_mapping(rhs, vm)?;
-            let r_pairs = counter_snapshot(r_id, vm).into_iter();
+            let rhs = counter_require_mapping(rhs, vm)?;
+            let r_pairs = rhs.clone_all_pairs(vm)?.into_iter();
             defer_drop_mut!(r_pairs, vm);
             for entry in r_pairs.by_ref() {
                 let mut entry = DropGuard::new(entry, vm);
                 let ((key, other_count), vm) = entry.as_parts_mut();
                 // A key absent from `self` reads as 0 (`self[elem]`).
-                let count = counter_lookup(l_id, key, vm)?.unwrap_or(Value::Int(0));
+                let count = counter.dict_get(key, vm)?.unwrap_or(Value::Int(0));
                 // `other_count > self[elem]`: other first, so the TypeError names it first.
                 let bigger = count_holds(other_count, &count, CountCmp::Gt, vm);
                 count.drop_with(vm);
@@ -738,14 +767,16 @@ pub(crate) fn counter_inplace_op(l_id: HeapId, rhs: &Value, op: CounterOp, vm: &
                 // releases the entry — as it does if the comparison raised.
                 if bigger? {
                     let ((key, other_count), vm) = entry.into_parts();
-                    counter_set(l_id, key, other_count, vm)?;
+                    if let Some(old) = counter.set(key, other_count, vm)? {
+                        old.drop_with(vm);
+                    }
                 }
             }
         }
         // `for elem, count in self.items(): if other[elem] < count:
         //     self[elem] = other[elem]` — walks *self*, subscripting `other`.
         CounterOp::And => {
-            let pairs = counter_snapshot(l_id, vm).into_iter();
+            let pairs = counter.clone_all_pairs(vm)?.into_iter();
             defer_drop_mut!(pairs, vm);
             for entry in pairs.by_ref() {
                 let mut entry = DropGuard::new(entry, vm);
@@ -766,19 +797,25 @@ pub(crate) fn counter_inplace_op(l_id: HeapId, rhs: &Value, op: CounterOp, vm: &
                     let smaller = other_count.into_inner();
                     let ((key, count), vm) = entry.into_parts();
                     count.drop_with(vm);
-                    counter_set(l_id, key, smaller, vm)?;
+                    if let Some(old) = counter.set(key, smaller, vm)? {
+                        old.drop_with(vm);
+                    }
                 }
             }
         }
     }
-    counter_retain_positive(l_id, vm)
+    counter_retain_positive(counter, vm)
 }
 
 /// Computes a unary `Counter` operation. `+c` keeps the counts that are `> 0`;
 /// `-c` keeps the *strictly negative* counts, storing their negation (CPython's
 /// `{elem: -count for elem, count in self.items() if count < 0}`). Both leave
 /// only positive counts, so the result is a valid Counter.
-pub(crate) fn counter_unary_op(id: HeapId, negate: bool, vm: &mut VM<'_>) -> RunResult<Value> {
+pub(crate) fn counter_unary_op<'h>(
+    counter: &HeapObjectRead<'h, Dict>,
+    negate: bool,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
     let mut result = Dict::new();
     result.make_counter();
     let result_id = vm.heap.allocate(HeapData::Dict(result));
@@ -787,10 +824,13 @@ pub(crate) fn counter_unary_op(id: HeapId, negate: bool, vm: &mut VM<'_>) -> Run
     // early-returns would otherwise leak.
     let mut result_guard = DropGuard::new(Value::Ref(result_id), vm);
     let vm = result_guard.ctx();
+    let HeapReadOutput::Dict(mut result) = vm.heap.read(result_id) else {
+        unreachable!("just allocated a Counter dict");
+    };
     // Scoped so the iterator guard releases its borrow of `result_guard` before
     // the result is handed back.
     {
-        let pairs = counter_snapshot(id, vm).into_iter();
+        let pairs = counter.clone_all_pairs(vm)?.into_iter();
         defer_drop_mut!(pairs, vm);
         for entry in pairs.by_ref() {
             let mut entry = DropGuard::new(entry, vm);
@@ -815,85 +855,60 @@ pub(crate) fn counter_unary_op(id: HeapId, negate: bool, vm: &mut VM<'_>) -> Run
                 }
                 None => count,
             };
-            counter_set(result_id, key, stored, vm)?;
+            if let Some(old) = result.set(key, stored, vm)? {
+                old.drop_with(vm);
+            }
         }
     }
-    counter_retain_positive(result_id, vm)?;
+    counter_retain_positive(&mut result, vm)?;
+    drop(result);
     Ok(result_guard.into_inner())
 }
 
-/// Folds a batch of `(key, delta)` pairs into the Counter `id`, releasing any
-/// pairs left unconsumed when a bump fails.
-fn counter_bump_all(id: HeapId, pairs: Vec<(Value, Value)>, subtract: bool, vm: &mut VM<'_>) -> RunResult<()> {
+/// Folds a batch of `(key, delta)` pairs into `counter`, releasing any pairs
+/// left unconsumed when a bump fails.
+fn counter_bump_all<'h>(
+    counter: &mut HeapObjectRead<'h, Dict>,
+    pairs: Vec<(Value, Value)>,
+    subtract: bool,
+    vm: &mut VM<'h>,
+) -> RunResult<()> {
     let pairs = pairs.into_iter();
     defer_drop_mut!(pairs, vm);
     for (key, delta) in pairs.by_ref() {
         // `counter_bump` borrows the delta, so each one is released here.
-        let outcome = counter_bump(id, key, &delta, subtract, false, vm);
+        let outcome = counter_bump(counter, key, &delta, subtract, false, vm);
         delta.drop_with(vm);
         outcome?;
     }
     Ok(())
 }
 
-/// Snapshots a Counter's entries as `(cloned key, count)` pairs, releasing the
-/// heap borrow so the caller can mutate a different dict.
-fn counter_snapshot(id: HeapId, vm: &mut VM<'_>) -> Vec<(Value, Value)> {
-    let HeapReadOutput::Dict(dict) = vm.heap.read(id) else {
-        unreachable!("counter_snapshot on a non-dict heap entry");
-    };
-    let dict = dict.get(vm.heap);
-    dict.iter()
-        .map(|(k, v)| (k.clone_with_heap(vm.heap), v.clone_with_heap(vm.heap)))
-        .collect()
-}
-
-/// Returns the `HeapId` of a mapping in-place right-hand operand, or raises
+/// Returns the dictionary handle for an in-place right-hand operand, or raises
 /// CPython's `AttributeError: 'X' object has no attribute 'items'` — the failure
 /// `c += other` / `-=` / `|=` hit when `other.items()` has no `.items()`.
-fn counter_require_mapping(rhs: &Value, vm: &mut VM<'_>) -> RunResult<HeapId> {
-    match rhs {
-        Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::Dict(_)) => Ok(*id),
-        other => Err(ExcType::attribute_error(other.py_type_name(vm), "items")),
+fn counter_require_mapping<'h>(rhs: &Value, vm: &VM<'h>) -> RunResult<HeapObjectRead<'h, Dict>> {
+    match rhs.read_heap(vm) {
+        Some(HeapReadOutput::Dict(dict)) => Ok(dict),
+        _ => Err(ExcType::attribute_error(rhs.py_type_name(vm), "items")),
     }
 }
 
-/// Returns the count for `key` in the Counter `id`, or `None` if absent.
-fn counter_lookup(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
-    let HeapReadOutput::Dict(dict) = vm.heap.read(id) else {
-        unreachable!("counter_lookup on a non-dict heap entry");
-    };
-    dict.dict_get(key, vm)
-}
-
-/// Sets `key -> count` in the Counter `id`. Takes ownership of `key` and `count`.
-fn counter_set(id: HeapId, key: Value, count: Value, vm: &mut VM<'_>) -> RunResult<()> {
-    let HeapReadOutput::Dict(mut dict) = vm.heap.read(id) else {
-        unreachable!("counter_set on a non-dict heap entry");
-    };
-    if let Some(old) = dict.set(key, count, vm)? {
-        old.drop_with(vm);
-    }
-    Ok(())
-}
-
-/// Removes every entry whose count is not strictly positive from the Counter `id`.
-fn counter_retain_positive(id: HeapId, vm: &mut VM<'_>) -> RunResult<()> {
+/// Removes every entry whose count is not strictly positive from `counter`.
+fn counter_retain_positive<'h>(counter: &mut HeapObjectRead<'h, Dict>, vm: &mut VM<'h>) -> RunResult<()> {
     // The keys to remove are collected first: the scan clones them out of the
     // dict, so popping while iterating is not possible. Both guards release what
     // they still hold if a count comparison — or a `pop` hashing a key — raises.
     let mut remove = DropGuard::new(Vec::new(), vm);
     {
         let (remove, vm) = remove.as_parts_mut();
-        let entries = counter_snapshot(id, vm).into_iter();
+        let entries = counter.clone_all_pairs(vm)?.into_iter();
         defer_drop_mut!(entries, vm);
-        for entry in entries.by_ref() {
-            let mut entry = DropGuard::new(entry, vm);
-            let ((_, count), vm) = entry.as_parts_mut();
-            let positive = count_is_positive(count, vm)?;
-            if !positive {
-                let ((key, count), vm) = entry.into_parts();
-                count.drop_with(vm);
+        for (key, count) in entries {
+            defer_drop_mut!(count, vm);
+            let mut key_guard = DropGuard::new(key, vm);
+            if !count_is_positive(count, key_guard.ctx())? {
+                let (key, vm) = key_guard.into_parts();
                 remove.push(key);
             }
         }
@@ -903,10 +918,7 @@ fn counter_retain_positive(id: HeapId, vm: &mut VM<'_>) -> RunResult<()> {
     defer_drop_mut!(remove, vm);
     for key in remove.by_ref() {
         defer_drop!(key, vm);
-        let HeapReadOutput::Dict(mut dict) = vm.heap.read(id) else {
-            unreachable!("counter_retain_positive on a non-dict heap entry");
-        };
-        if let Some(old) = dict.pop(key, vm)? {
+        if let Some(old) = counter.pop(key, vm)? {
             old.drop_with(vm);
         }
     }

--- a/crates/monty/src/modules/collections/defaultdict.rs
+++ b/crates/monty/src/modules/collections/defaultdict.rs
@@ -8,7 +8,8 @@ use crate::{
     args::ArgValues,
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{HeapData, HeapId, HeapReadOutput},
+    heap::HeapObjectRead,
+    types::Dict,
     value::Value,
 };
 
@@ -19,11 +20,12 @@ use crate::{
 /// Shared by the getitem miss path (`Value::py_getitem`) and the explicit
 /// `__missing__` method. The factory runs via `VM::evaluate_function`, so a
 /// factory that performs external/OS calls is unsupported (documented).
-pub(crate) fn defaultdict_missing(dict_id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
-    let factory = match vm.heap.get(dict_id) {
-        HeapData::Dict(d) => d.default_factory().map(|f| f.clone_with_heap(vm.heap)),
-        _ => unreachable!("defaultdict_missing on a non-dict heap entry"),
-    };
+pub(crate) fn defaultdict_missing<'h>(
+    dict: &mut HeapObjectRead<'h, Dict>,
+    key: &Value,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
+    let factory = dict.get(vm.heap).default_factory().map(|f| f.clone_with_heap(vm.heap));
     let Some(factory) = factory else {
         return Err(ExcType::key_error(key, vm));
     };
@@ -40,9 +42,6 @@ pub(crate) fn defaultdict_missing(dict_id: HeapId, key: &Value, vm: &mut VM<'_>)
     // returns the one object the factory produced).
     let key_clone = key.clone_with_heap(vm.heap);
     let value_ret = value.clone_with_heap(vm.heap);
-    let HeapReadOutput::Dict(mut dict) = vm.heap.read(dict_id) else {
-        unreachable!("defaultdict_missing on a non-dict heap entry");
-    };
     // A `set` failure (e.g. a key `__eq__` raising during collision) must
     // release the cloned `value_ret`, which the `?` early-return would leak.
     match dict.set(key_clone, value, vm) {

--- a/crates/monty/src/modules/collections/mod.rs
+++ b/crates/monty/src/modules/collections/mod.rs
@@ -116,7 +116,13 @@ pub(crate) fn counter_init(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value>
     let Value::Ref(dict_id) = value else {
         unreachable!("just allocated a ref");
     };
-    if let Err(e) = counter_update(dict_id, source, kwargs, false, vm) {
+    let result = {
+        let HeapReadOutput::Dict(mut counter) = vm.heap.read(dict_id) else {
+            unreachable!("just allocated a Counter dict");
+        };
+        counter_update(&mut counter, source, kwargs, false, vm)
+    };
+    if let Err(e) = result {
         value.drop_with(vm);
         return Err(e);
     }

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -514,7 +514,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Deque> {
     fn py_iadd_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         // `deque_extend` consumes the iterable, so hand it an owned clone.
         let iterable = other.clone_with_heap(vm.heap);
-        deque_extend(self.id(), iterable, ExtendEnd::Right, vm)?;
+        deque_extend(self, iterable, ExtendEnd::Right, vm)?;
         Ok(true)
     }
 
@@ -559,8 +559,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Deque> {
             args.drop_with(vm);
             return Err(ExcType::attribute_error(Type::Deque, attr.as_str(vm.interns)));
         };
-        let self_id = self.id();
-        call_deque_method(self, self_id, method, args, vm).map(CallResult::Value)
+        call_deque_method(self, method, args, vm).map(CallResult::Value)
     }
 }
 
@@ -691,8 +690,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DequeIterator> {
 /// name the type), while `index`/`insert`/`rotate` use `PyArg_UnpackTuple` (which
 /// does not). The messages are reproduced verbatim.
 fn call_deque_method<'h>(
-    deque: &mut HeapRead<'h, Deque>,
-    self_id: HeapId,
+    deque: &mut HeapObjectRead<'h, Deque>,
     method: StaticStrings,
     args: ArgValues,
     vm: &mut VM<'h>,
@@ -757,13 +755,13 @@ fn call_deque_method<'h>(
         }
         StaticStrings::Extend => {
             let iterable = args.get_one_arg("deque.extend", vm.heap)?;
-            deque_extend(self_id, iterable, ExtendEnd::Right, vm)?;
+            deque_extend(deque, iterable, ExtendEnd::Right, vm)?;
             Ok(Value::None)
         }
         StaticStrings::Extendleft => {
             let iterable = args.get_one_arg("deque.extendleft", vm.heap)?;
             // extendleft REVERSES the input: each item is pushed to the front in turn.
-            deque_extend(self_id, iterable, ExtendEnd::Left, vm)?;
+            deque_extend(deque, iterable, ExtendEnd::Left, vm)?;
             Ok(Value::None)
         }
         StaticStrings::Rotate => rotate(deque, args, vm),
@@ -959,7 +957,7 @@ pub(crate) enum ExtendEnd {
     Left,
 }
 
-/// Extends `deque_id` in place by every item of `iterable` — `deque.extend`
+/// Extends `deque` in place by every item of `iterable` — `deque.extend`
 /// and `extendleft`, and CPython's `deque.__iadd__` (`+=` *is* `extend`).
 ///
 /// Each item is appended as the source yields it, so an iterator that raises
@@ -969,17 +967,23 @@ pub(crate) enum ExtendEnd {
 /// Extending a deque *by itself* is the one case that cannot append while it
 /// iterates, or it would chase its own tail; it snapshots the original items
 /// first, as CPython does.
-///
-/// The deque is re-read for each append rather than held across the loop: the
-/// source's `__next__` can run sandbox code, and a live read handle would block
-/// the heap from freeing the entry.
-pub(crate) fn deque_extend(deque_id: HeapId, iterable: Value, end: ExtendEnd, vm: &mut VM<'_>) -> RunResult<()> {
-    if iterable.ref_id() == Some(deque_id) {
-        let items = deque_snapshot(deque_id, vm).into_iter();
+pub(crate) fn deque_extend<'h>(
+    deque: &mut HeapObjectRead<'h, Deque>,
+    iterable: Value,
+    end: ExtendEnd,
+    vm: &mut VM<'h>,
+) -> RunResult<()> {
+    if iterable.ref_id() == Some(deque.id()) {
+        let items = deque
+            .get(vm.heap)
+            .iter()
+            .map(|item| item.clone_with_heap(vm.heap))
+            .collect::<Vec<_>>()
+            .into_iter();
         iterable.drop_with(vm);
         defer_drop_mut!(items, vm);
         for item in items.by_ref() {
-            deque_push(deque_id, item, end, vm);
+            deque_push(deque, item, end, vm);
         }
         Ok(())
     } else {
@@ -993,40 +997,17 @@ pub(crate) fn deque_extend(deque_id: HeapId, iterable: Value, end: ExtendEnd, vm
         // retains at most `maxlen` items however long the iterator, so cap
         // the estimate at what it can actually keep.
         let hint = iter.iter_size_hint(vm);
-        let retained = deque_maxlen(deque_id, vm).map_or(hint, |maxlen| hint.min(maxlen));
+        let retained = deque.get(vm.heap).maxlen().map_or(hint, |maxlen| hint.min(maxlen));
         check_estimated_size(retained.saturating_mul(VALUE_SIZE), &vm.heap.tracker)?;
         while let Some(item) = iter.py_next(vm)? {
-            deque_push(deque_id, item, end, vm);
+            deque_push(deque, item, end, vm);
         }
         Ok(())
     }
 }
 
-/// The `maxlen` bound of the deque `deque_id`, or `None` if unbounded.
-fn deque_maxlen(deque_id: HeapId, vm: &VM<'_>) -> Option<usize> {
-    let HeapReadOutput::Deque(deque) = vm.heap.read(deque_id) else {
-        unreachable!("deque id must reference a deque");
-    };
-    deque.get(vm.heap).maxlen()
-}
-
-/// Clones every item of the deque `deque_id`, for the self-extension case.
-fn deque_snapshot(deque_id: HeapId, vm: &mut VM<'_>) -> Vec<Value> {
-    let HeapReadOutput::Deque(deque) = vm.heap.read(deque_id) else {
-        unreachable!("deque id must reference a deque");
-    };
-    deque
-        .get(vm.heap)
-        .iter()
-        .map(|item| item.clone_with_heap(vm.heap))
-        .collect()
-}
-
-/// Appends one item to whichever end of `deque_id` the extension targets.
-fn deque_push(deque_id: HeapId, item: Value, end: ExtendEnd, vm: &mut VM<'_>) {
-    let HeapReadOutput::Deque(mut deque) = vm.heap.read(deque_id) else {
-        unreachable!("deque id must reference a deque");
-    };
+/// Appends one item to whichever end the extension targets.
+fn deque_push<'h>(deque: &mut HeapRead<'h, Deque>, item: Value, end: ExtendEnd, vm: &mut VM<'h>) {
     match end {
         ExtendEnd::Right => deque.append(vm, item),
         ExtendEnd::Left => deque.appendleft(vm, item),

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1090,7 +1090,7 @@ impl<'h> HeapRead<'h, Dict> {
     ///
     /// Preflights the slot bytes so an over-budget clone raises a graceful
     /// `MemoryError` instead of bursting past the allocator's hard limit.
-    fn clone_all_pairs(&self, vm: &mut VM<'h>) -> RunResult<Vec<(Value, Value)>> {
+    pub(crate) fn clone_all_pairs(&self, vm: &mut VM<'h>) -> RunResult<Vec<(Value, Value)>> {
         let len = self.get(vm.heap).len();
         vm.heap.tracker.check_allocation(len.saturating_mul(2 * VALUE_SIZE))?;
         let mut pairs = Vec::with_capacity(len);
@@ -1172,8 +1172,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
             Some(HeapReadOutput::Dict(other)) => {
                 // Two Counters compare as multisets (zero counts ignored); any
                 // other pairing is plain dict equality.
-                let both_counters = self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter();
-                if both_counters {
+                if self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter() {
                     Ok(Some(self.eq_counter(&other, vm)?))
                 } else {
                     Ok(Some(self.eq_dict(&other, vm)?))
@@ -1200,56 +1199,54 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
             // Only the four ordering operators reach `py_cmp_op`.
             _ => return Ok(None),
         };
-        match other.ref_id() {
-            Some(other_id) if self.both_counters(other_id, vm) => {
-                Ok(Some(counter_compare(self.id(), other_id, cmp, vm)?))
-            }
-            _ => Ok(None),
+        let Some(HeapReadOutput::Dict(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        if self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter() {
+            Ok(Some(counter_compare(self, &other, cmp, vm)?))
+        } else {
+            Ok(None)
         }
     }
 
     fn py_neg_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_unary(true, vm, self.id())
+        self.counter_unary(true, vm)
     }
 
     fn py_pos_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_unary(false, vm, self.id())
+        self.counter_unary(false, vm)
     }
 
     fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_binary(other, CounterOp::Add, vm, self.id())
+        self.counter_binary(other, CounterOp::Add, vm)
     }
 
     fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_binary(other, CounterOp::Sub, vm, self.id())
+        self.counter_binary(other, CounterOp::Sub, vm)
     }
 
     fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_binary(other, CounterOp::And, vm, self.id())
+        self.counter_binary(other, CounterOp::And, vm)
     }
 
     fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_binary(other, CounterOp::Or, vm, self.id())
+        self.counter_binary(other, CounterOp::Or, vm)
     }
 
     fn py_iadd_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        let self_id = self.id();
-        self.counter_inplace(other, CounterOp::Add, vm, self_id)
+        self.counter_inplace(other, CounterOp::Add, vm)
     }
 
     fn py_isub_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        let self_id = self.id();
-        self.counter_inplace(other, CounterOp::Sub, vm, self_id)
+        self.counter_inplace(other, CounterOp::Sub, vm)
     }
 
     fn py_iand_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        let self_id = self.id();
-        self.counter_inplace(other, CounterOp::And, vm, self_id)
+        self.counter_inplace(other, CounterOp::And, vm)
     }
 
     fn py_ior_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        let self_id = self.id();
-        self.counter_inplace(other, CounterOp::Or, vm, self_id)
+        self.counter_inplace(other, CounterOp::Or, vm)
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
@@ -1323,19 +1320,15 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
 
         let value = match method {
             // Counter-only methods (a plain dict falls through to AttributeError).
-            StaticStrings::MostCommon if self.get(vm.heap).is_counter() => counter_most_common(self.id(), args, vm),
-            StaticStrings::Elements if self.get(vm.heap).is_counter() => counter_elements(self.id(), args, vm),
+            StaticStrings::MostCommon if self.get(vm.heap).is_counter() => counter_most_common(self, args, vm),
+            StaticStrings::Elements if self.get(vm.heap).is_counter() => counter_elements(self, args, vm),
             StaticStrings::Total if self.get(vm.heap).is_counter() => {
                 args.check_zero_args("total", vm.heap)?;
-                counter_total(self.id(), vm)
+                counter_total(self, vm)
             }
-            StaticStrings::Subtract if self.get(vm.heap).is_counter() => {
-                counter_update_method(self.id(), args, true, vm)
-            }
+            StaticStrings::Subtract if self.get(vm.heap).is_counter() => counter_update_method(self, args, true, vm),
             // Counter overrides `update` to add counts, and disables `fromkeys`.
-            StaticStrings::Update if self.get(vm.heap).is_counter() => {
-                counter_update_method(self.id(), args, false, vm)
-            }
+            StaticStrings::Update if self.get(vm.heap).is_counter() => counter_update_method(self, args, false, vm),
             StaticStrings::Fromkeys if self.get(vm.heap).is_counter() => {
                 args.drop_with(vm);
                 return Err(ExcType::not_implemented(
@@ -1426,7 +1419,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
             StaticStrings::DunderMissing if self.get(vm.heap).is_defaultdict() => {
                 let key = args.get_one_arg("__missing__", vm.heap)?;
                 defer_drop!(key, vm);
-                defaultdict_missing(self.id(), key, vm)
+                defaultdict_missing(self, key, vm)
             }
             _ => {
                 let type_name = self.py_type(vm).name(vm.heap, vm.interns);
@@ -1438,25 +1431,21 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
     }
 }
 
-impl<'h> HeapRead<'h, Dict> {
+impl<'h> HeapObjectRead<'h, Dict> {
     /// Runs a binary `Counter` operator (`+ - & |`), which needs *both* operands
     /// to be Counters.
     ///
     /// Any other pairing reports `None` so the caller raises its ordinary
     /// `TypeError`, matching CPython: `Counter.__add__` returns `NotImplemented`
     /// for a non-Counter, and a plain dict has no `+` of its own.
-    fn counter_binary(
-        &self,
-        other: &Value,
-        op: CounterOp,
-        vm: &mut VM<'h>,
-        self_id: HeapId,
-    ) -> RunResult<Option<Value>> {
-        match other.ref_id() {
-            Some(other_id) if self.both_counters(other_id, vm) => {
-                Ok(Some(counter_binary_op(self_id, other_id, op, vm)?))
-            }
-            _ => Ok(None),
+    fn counter_binary(&self, other: &Value, op: CounterOp, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        let Some(HeapReadOutput::Dict(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        if self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter() {
+            Ok(Some(counter_binary_op(self, &other, op, vm)?))
+        } else {
+            Ok(None)
         }
     }
 
@@ -1468,9 +1457,9 @@ impl<'h> HeapRead<'h, Dict> {
     /// `other[elem]` raises — so once the left is a Counter this owns the
     /// operation, error paths included. A plain dict reports `false`, falling
     /// back to the binary operator.
-    fn counter_inplace(&mut self, other: &Value, op: CounterOp, vm: &mut VM<'h>, self_id: HeapId) -> RunResult<bool> {
+    fn counter_inplace(&mut self, other: &Value, op: CounterOp, vm: &mut VM<'h>) -> RunResult<bool> {
         if self.get(vm.heap).is_counter() {
-            counter_inplace_op(self_id, other, op, vm)?;
+            counter_inplace_op(self, other, op, vm)?;
             Ok(true)
         } else {
             Ok(false)
@@ -1482,17 +1471,12 @@ impl<'h> HeapRead<'h, Dict> {
     ///
     /// A plain dict has no unary form and reports `None` for the caller's
     /// `TypeError`.
-    fn counter_unary(&self, negate: bool, vm: &mut VM<'h>, self_id: HeapId) -> RunResult<Option<Value>> {
+    fn counter_unary(&self, negate: bool, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         if self.get(vm.heap).is_counter() {
-            Ok(Some(counter_unary_op(self_id, negate, vm)?))
+            Ok(Some(counter_unary_op(self, negate, vm)?))
         } else {
             Ok(None)
         }
-    }
-
-    /// Whether this dict and the heap value `other_id` are both Counters.
-    fn both_counters(&self, other_id: HeapId, vm: &VM<'h>) -> bool {
-        self.get(vm.heap).is_counter() && matches!(vm.heap.get(other_id), HeapData::Dict(d) if d.is_counter())
     }
 }
 

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -338,14 +338,13 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, OpenFile> {
             ));
         };
 
-        let self_id = self.id();
         match method {
-            StaticStrings::Read => self.read(self_id, vm, args),
-            StaticStrings::Readline => self.readline(self_id, vm, args),
-            StaticStrings::Readlines => self.readlines(self_id, vm, args),
+            StaticStrings::Read => self.read(vm, args),
+            StaticStrings::Readline => self.readline(vm, args),
+            StaticStrings::Readlines => self.readlines(vm, args),
             StaticStrings::Tell => self.tell(vm, args),
-            StaticStrings::Seek => self.seek(self_id, vm, args),
-            StaticStrings::Write => self.write(self_id, vm, args),
+            StaticStrings::Seek => self.seek(vm, args),
+            StaticStrings::Write => self.write(vm, args),
             StaticStrings::Close => self.close(vm, args),
             StaticStrings::Flush => self.flush(vm, args),
             StaticStrings::Readable => self.readable(vm, args),
@@ -413,7 +412,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, OpenFile> {
     }
 }
 
-impl<'h> HeapRead<'h, OpenFile> {
+impl<'h> HeapObjectRead<'h, OpenFile> {
     /// Implements `file.read()` and `file.read(size)`.
     ///
     /// All variants flow through the same buffer-store hook so the file's
@@ -421,7 +420,7 @@ impl<'h> HeapRead<'h, OpenFile> {
     /// caller mixes bare `read()`, sized `read(N)`, or line-oriented
     /// operations. The buffer holds the full file content; further reads
     /// slice it in pure Monty.
-    fn read(&mut self, self_id: HeapId, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
+    fn read(&mut self, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
         let spec = parse_read_size_arg(args.get_zero_one_arg("read", vm.heap)?, vm)?;
         if matches!(spec, ReadSpec::Size(0)) {
             // `read(0)`: empty result without any OS call, position unchanged.
@@ -436,23 +435,23 @@ impl<'h> HeapRead<'h, OpenFile> {
             };
             Ok(CallResult::Value(empty_result(binary, vm.heap)))
         } else {
-            self.read_with_spec(self_id, vm, spec)
+            self.read_with_spec(vm, spec)
         }
     }
 
     /// Implements `file.readline()` — yields up to and including the next
     /// `\n`, or the rest of the buffer if the final line has no newline. At
     /// EOF returns `''`/`b''`.
-    fn readline(&mut self, self_id: HeapId, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
+    fn readline(&mut self, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
         args.check_zero_args("readline", vm.heap)?;
-        self.read_with_spec(self_id, vm, ReadSpec::Line)
+        self.read_with_spec(vm, ReadSpec::Line)
     }
 
     /// Implements `file.readlines()` — returns a `list[str]` (or `list[bytes]`
     /// for binary mode) of every remaining line.
-    fn readlines(&mut self, self_id: HeapId, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
+    fn readlines(&mut self, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
         args.check_zero_args("readlines", vm.heap)?;
-        self.read_with_spec(self_id, vm, ReadSpec::Lines)
+        self.read_with_spec(vm, ReadSpec::Lines)
     }
 
     /// Implements `file.tell()` — returns the current position as an int.
@@ -476,10 +475,10 @@ impl<'h> HeapRead<'h, OpenFile> {
     /// Implements `file.seek(offset, whence=0)` — repositions within the
     /// buffer, loading it on demand if not yet present, then returns the new
     /// absolute position.
-    fn seek(&mut self, self_id: HeapId, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
+    fn seek(&mut self, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
         let (offset, whence) = parse_seek_args(args, vm)?;
         if self.get(vm.heap).mode.readable() {
-            self.read_with_spec(self_id, vm, ReadSpec::Seek { offset, whence })
+            self.read_with_spec(vm, ReadSpec::Seek { offset, whence })
         } else {
             let (target, file_length) = {
                 let file = self.get(vm.heap);
@@ -506,7 +505,7 @@ impl<'h> HeapRead<'h, OpenFile> {
     /// Otherwise records the spec on the file and yields a
     /// [`CallResult::OsCallWithEffect`] so the host loads the full content
     /// and the resume hook completes the operation.
-    fn read_with_spec(&mut self, self_id: HeapId, vm: &mut VM<'h>, spec: ReadSpec) -> RunResult<CallResult> {
+    fn read_with_spec(&mut self, vm: &mut VM<'h>, spec: ReadSpec) -> RunResult<CallResult> {
         let (binary, buffer_loaded) = {
             let file = self.get(vm.heap);
             file.ensure_open()?;
@@ -538,10 +537,11 @@ impl<'h> HeapRead<'h, OpenFile> {
         } else {
             OsFunctionCall::ReadText(path)
         };
-        inc_ref_for_pending_oscall(vm, self_id);
+        let file_id = self.id();
+        inc_ref_for_pending_oscall(vm, file_id);
         Ok(CallResult::OsCallWithEffect {
             call,
-            effect: PendingOsEffect::BufferStore { file_id: self_id },
+            effect: PendingOsEffect::BufferStore { file_id },
         })
     }
 
@@ -549,7 +549,7 @@ impl<'h> HeapRead<'h, OpenFile> {
     ///
     /// As with [`Self::read`], the first OS-call argument is the file object
     /// itself, delivered to the host as a `MontyObject::FileHandle`.
-    fn write(&mut self, self_id: HeapId, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
+    fn write(&mut self, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
         let data = args.get_one_arg("write", vm.heap)?;
         defer_drop!(data, vm);
         let binary = self.get(vm.heap).mode.is_binary();
@@ -593,11 +593,12 @@ impl<'h> HeapRead<'h, OpenFile> {
             }
         };
 
-        inc_ref_for_pending_oscall(vm, self_id);
+        let file_id = self.id();
+        inc_ref_for_pending_oscall(vm, file_id);
         // The effect travels with the call and is armed at dispatch, so a
         // call rejected before dispatch cannot leave stale write state.
         let effect = PendingOsEffect::WritePosition {
-            file_id: self_id,
+            file_id,
             previous_position: self.get(vm.heap).position,
             previous_length: self.get(vm.heap).file_length,
         };

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -280,9 +280,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
     /// Dispatches the class's `__next__`, turning `StopIteration` into exhaustion.
     ///
     /// Every other exception propagates, including an `UncatchableExc` from a
-    /// resource limit — see [`RunError::is_stop_iteration`]. No heap borrow is
-    /// held across the call: `__next__` runs Python, which may re-enter this
-    /// same instance through a nested `next()`.
+    /// resource limit — see [`RunError::is_stop_iteration`].
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         // The absent case doubles as the not-an-iterator check, halving the
         // lookups — this runs for every item of every user iterator.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1251,9 +1251,9 @@ impl<'h> PyTrait<'h> for Value {
     fn py_getitem(&self, key: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
         let interns = vm.interns;
         match self {
-            // `heap_subscript` owns the one case a heap read cannot: a
-            // defaultdict miss, which calls its factory and re-enters the VM.
-            Self::Ref(id) => heap_subscript(*id, key, vm),
+            // `heap_subscript` owns the mutating defaultdict-miss path outside
+            // the read-only `PyTrait::py_getitem` interface.
+            Self::Ref(id) => heap_subscript(vm.heap.read(*id), key, vm),
             Self::InternString(string_id) => {
                 // Check for slice first
                 if let Self::Ref(key_id) = key


### PR DESCRIPTION
Cleaning up code now that `HeapObjectRead` can express typed value with an id.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace explicit `HeapId`/`self_id` plumbing with typed heap handles via `HeapObjectRead` across dict, Counter, deque, and file paths to reduce boilerplate while preserving identity-aware access. Behavior is unchanged; defaultdict misses still route through `__missing__` outside `PyTrait`.

- heap_subscript now takes `HeapReadOutput` and routes defaultdict misses to `defaultdict_missing(&mut HeapObjectRead<Dict>)`; `Value::py_getitem` passes `vm.heap.read(*id)`.
- Counter: all ops (`update`/`subtract`, algebra/comparisons, `most_common`/`elements`/`total`) operate on `HeapObjectRead<Dict>`; `counter_require_mapping` returns a dict handle; positive-retain and batch helpers use handles; `Dict::clone_all_pairs` is `pub(crate)`.
- Dict `PyTrait`: Counter equality/ordering and unary/binary/in-place operators use handle-based helpers; defaultdict `__missing__` uses the dict handle.
- Deque: `extend`/`extendleft` and pushes take a deque handle; direct iteration replaces ad-hoc snapshot/maxlen helpers.
- File: `read`/`readline`/`readlines`/`seek`/`write` drop explicit ids; OS call effects capture `file_id` via `self.id()`.

Migration: internal callers must pass `&mut HeapObjectRead<T>`/`&HeapObjectRead<T>` instead of `HeapId`. No public API changes.

<sup>Written for commit 1ccf2894d3baa0aaed82454537e4fc3e01b3f82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

