### PR TITLE
fix(type): clean up arguments for non-callable types

### DIFF
--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -542,7 +542,11 @@ impl Type {
             }
 
             // Non-callable types - raise TypeError
-            _ => Err(ExcType::type_error_not_callable(&self.name(vm.heap, vm.interns))),
+            _ => {
+                let type_name = self.name(vm.heap, vm.interns);
+                args.drop_with(vm.heap);
+                Err(ExcType::type_error_not_callable(&type_name))
+            }
         }
     }
 }

--- a/crates/monty/test_cases/type__ops.py
+++ b/crates/monty/test_cases/type__ops.py
@@ -203,3 +203,12 @@ try:
     raise ValueError('test')
 except ValueError as e:
     assert type(e).__name__ == 'ValueError'
+
+# regression for #719: heap-backed arg must be released on non-callable type
+import json
+
+try:
+    type(json)([1, 2])
+    assert False, 'type(json)([1, 2]) should raise'
+except TypeError as e:
+    assert str(e) == "cannot create 'module' instances"

--- a/crates/monty/test_cases/type__ops.py
+++ b/crates/monty/test_cases/type__ops.py
@@ -211,4 +211,9 @@ try:
     type(json)([1, 2])
     assert False, 'type(json)([1, 2]) should raise'
 except TypeError as e:
-    assert str(e) == "cannot create 'module' instances"
+    # monty raises its own message; CPython reaches module.__init__
+    # with a non-str name instead. Both prove the call raises TypeError.
+    assert str(e) in (
+        "cannot create 'module' instances",  # monty
+        "module() argument 'name' must be str, not list",  # CPython
+    )


### PR DESCRIPTION
## Summary

Fixes #719.

Type::call owns its ArgValues, but the fallback for non-callable types returned TypeError without releasing heap-backed arguments through DropWithContext.

Capture the type name first, release the arguments with rgs.drop_with(vm.heap), then construct the same error.

## Regression

A heap-backed argument such as:

`python
import json
type(json)([1, 2])
`

previously leaked the heap-backed list (observable as Value::Ref(...) dropped without calling drop_with() under --features memory-model-checks). It now correctly raises TypeError: cannot create 'module' instances and releases the argument via DropWithContext.

Added a case to crates/monty/test_cases/type__ops.py covering this path.

## Testing

- cargo check -p monty / cargo check -p monty --features memory-model-checks
- focused regression via MontyRun with and without memory-model-checks
- cargo test -p monty --lib (45 tests)
- cargo fmt --check / git diff --check clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a heap leak when calling non-callable types by dropping owned arguments before raising TypeError. Previously `Type::call` returned the error without releasing heap-backed `ArgValues`; now it captures the type name, calls `args.drop_with(vm.heap)`, and returns the same error (fixes #719).

- Adds a regression test for `type(json)([1, 2])` covering both monty and CPython error messages.
- Changes are limited to the non-callable fallback in `Type::call`; no public API or behavior change beyond proper cleanup.

<sup>Written for commit b9902c1b7e5d5f7a1dab200315a8bea1d4c7816a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

