### PR TITLE
Let a failing `gather` leave its siblings running

### DIFF
--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -180,6 +180,10 @@ impl ExternalFuture {
 ///   [`DropWithContext`] (and clone via [`Self::clone_with_heap`]) so the
 ///   `gather` ref count stays balanced.
 ///
+/// An awaitable whose downstream has already settled keeps its `Awaiter`
+/// pointing at it; the value is discarded where it is delivered rather than
+/// the link being severed here. See [`GatherState`].
+///
 /// Not `Copy` / `Clone` on purpose — the inc_ref discipline requires every
 /// duplication to go through `clone_with_heap` and every discard to go
 /// through `drop_with`.

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -18,7 +18,7 @@ use crate::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
         GatherState, TaskId,
     },
-    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
+    bytecode::vm::scheduler::{SerializedTaskFrame, TaskState},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapObjectRead, HeapRead, HeapReadOutput, HeapReader},
@@ -140,12 +140,11 @@ impl<'h> VM<'h> {
         let mut results_guard = DropGuard::new(results, this);
         let (results, this) = results_guard.as_parts_mut();
 
-        // Roll back already-committed siblings if a later child fails during
-        // this commit pass; otherwise spawned tasks or awaiters can outlive a
-        // gather that never reached `Awaited`.
+        // A later item failing during this commit pass leaves the ones already
+        // committed running, as CPython does. They keep pointing at this
+        // gather; `resolve_child` drops what they deliver to a `Failed` one.
         if let Err(err) = this.commit_gather_items(&gather, &mut pending_children, results) {
             gather.get_mut(this.heap).state = GatherState::Failed(err.clone());
-            drop_committed_children(pending_children, &mut this.scheduler, this.heap, &err);
             return Err(err);
         }
 
@@ -176,8 +175,8 @@ impl<'h> VM<'h> {
     ///
     /// Spawns coroutine children, installs awaiters on external futures, and
     /// recursively awaits nested gathers. Any error leaves already-committed
-    /// entries in `pending_children`; the caller must pass them to
-    /// [`drop_committed_children`] before propagating the error.
+    /// entries in `pending_children` and their awaiters pointing at `gather`;
+    /// the caller settles it so their results are dropped on arrival.
     fn commit_gather_items(
         &mut self,
         gather: &HeapObjectRead<'h, GatherFuture>,
@@ -342,21 +341,19 @@ impl<'h> VM<'h> {
     ///
     /// Called when a spawned task's coroutine returns. This:
     /// 1. Marks the task as completed in the scheduler
-    /// 2. If the task belongs to a gather, stores the result and checks if gather is complete
-    /// 3. If gather is complete, unblocks the waiter and provides the collected results
+    /// 2. Hands the result to whatever awaits the task, if anything still does
+    /// 3. If that completes a gather, unblocks its waiter with the result list
     /// 4. Otherwise, switches to the next ready task
     pub(super) fn handle_task_completion(&mut self, result: Value) -> Result<AwaitResult, RunError> {
-        // Get task info. Every spawned task belongs to a gather (the only
-        // call site of `Scheduler::spawn` is `await_gather_future`), so
-        // `gather_id` is unconditionally `Some`.
         let task_id = self
             .scheduler
             .current_task_id()
             .expect("handle_task_completion called without current task");
-        let task = self.scheduler.get_task(task_id);
-        let gid = task
-            .gather_id
-            .expect("handle_task_completion: spawned task without a gather");
+        // Take the awaiter before cancelling the task: it owns the inc_ref on
+        // the gather it points at, so holding it here keeps that gather alive
+        // across the teardown below.
+        let task = self.scheduler.get_task_mut(task_id);
+        let awaiter = task.awaiter.take();
         let coroutine_id = task
             .coroutine_id
             .expect("handle_task_completion: spawned task without a coroutine");
@@ -370,28 +367,18 @@ impl<'h> VM<'h> {
         coro.get_mut(self.heap).state = CoroutineState::Completed;
         drop(coro);
 
-        // Record the result on the gather and check whether it's now complete.
-        // `resolve_child` does the fan-out for duplicate slots (`gather(c, c)`)
-        // and the final state transition; it must run BEFORE we release any
-        // inc_refs the gather is holding (cancelling children, dropping the
-        // waiter's `Blocked` ref) — otherwise the gather can be freed while
-        // we're still about to write its cached state. The gather keys by
-        // item HeapId, so we pass the coroutine's id rather than the
-        // (kind-specific) task id.
-        let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
-            panic!("task gather_id doesn't point to a GatherFuture")
-        };
-        let resolution = gather.resolve_child(self, coroutine_id, result);
-        drop(gather);
-
-        // The just-completed task is no longer in the gather's
-        // `pending_tasks` map. Cancel it now to release its inc_refs on the
-        // coroutine and gather; otherwise it would linger in the scheduler.
+        // Cancel the task now to release its inc_ref on the coroutine;
+        // otherwise it would linger in the scheduler. Its awaiter is already
+        // out, so this releases nothing the delivery below needs.
         self.scheduler.cancel_task(task_id, self.heap);
 
-        let delivery = match resolution {
-            Some(success) => self.deliver_awaiter_success(success.awaiter, Value::Ref(success.list_id)),
-            None => None,
+        // Hand the result down the chain. `None` means the gather that spawned
+        // this task settled first, so it ran on only for its side effects.
+        let delivery = if let Some(awaiter) = awaiter {
+            self.deliver_awaiter_success(awaiter, result)
+        } else {
+            result.drop_with(self);
+            None
         };
 
         let next_task_id = if let Some(waiter_id) = delivery {
@@ -427,10 +414,13 @@ impl<'h> VM<'h> {
 
     /// Handles failure of a spawned task due to an unhandled exception.
     ///
-    /// Called when an exception escapes all frames in a spawned task. This:
-    /// 1. Marks the task as failed in the scheduler
-    /// 2. If the task belongs to a gather, cleans up and propagates to waiter
-    /// 3. Otherwise, switches to the next ready task
+    /// Called when an exception escapes all frames in a spawned task. The
+    /// task's awaiter chain is walked — settling each gather on the way — to
+    /// the task that should raise it.
+    ///
+    /// A task nothing awaits has no such chain, nor has one whose chain ends
+    /// at an already-settled gather. Nothing can receive the exception, so it
+    /// is reported rather than raised.
     ///
     /// # Returns
     /// - `Ok(())` - Switched to next task, continue execution
@@ -446,44 +436,55 @@ impl<'h> VM<'h> {
             .expect("handle_task_failure called without current task");
         debug_assert!(!task_id.is_main(), "handle_task_failure called for main task");
 
-        // Get task's gather_id before marking failed
-        let gather_id = self.scheduler.get_task(task_id).gather_id;
+        // Take the task's awaiter — it owns the inc_ref on whatever it points
+        // at, so the chain walk below cannot free its first link underneath
+        // itself.
+        let awaiter = self.scheduler.get_task_mut(task_id).awaiter.take();
 
-        // If part of a gather, tear the gather down (caches the error,
-        // cancels siblings, clears pending external routing) and walk the
-        // awaiter chain (which may go through outer nested gathers) to reach
-        // the task that should resume with the exception.
-        if let Some(gid) = gather_id {
-            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
-                panic!("task gather_id doesn't point to a GatherFuture")
-            };
-            let awaiter = gather.fail(&mut self.scheduler, self.heap, &error);
-            drop(gather);
-            if let Some(waiter_id) = self.deliver_awaiter_failure(awaiter, error.clone()) {
-                // `deliver_awaiter_failure` set the waiter to `Failed`, but
-                // we propagate the exception via `Err` (the run loop's
-                // `handle_exception` raises in the waiter's frame), so the
-                // task should be running. Override to `Ready` before
-                // switching in.
-                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                self.cleanup_current_task();
-                self.scheduler.set_current_task(Some(waiter_id));
-                self.load_or_init_task(waiter_id)?;
-            }
+        // Walk the awaiter chain, settling each gather on the way, to reach
+        // the task that should resume with the exception. Delivering nothing
+        // means the chain ended nowhere: no awaiter, a gather on the way that
+        // had already settled, or a waiter that is gone.
+        if let Some(awaiter) = awaiter
+            && let Some(waiter_id) = self.deliver_awaiter_failure(awaiter, error.clone())
+        {
+            // `deliver_awaiter_failure` set the waiter to `Failed`, but we
+            // propagate the exception via `Err` (the run loop's
+            // `handle_exception` raises in the waiter's frame), so the task
+            // should be running. Override to `Ready` before switching in.
+            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+            self.discard_failed_task(task_id);
+            self.scheduler.set_current_task(Some(waiter_id));
+            self.load_or_init_task(waiter_id)?;
             return Err(error);
         }
 
-        // No gather - just mark task as failed, switch to next task
-        self.scheduler.fail_task(task_id, error, self.heap);
-        self.cleanup_current_task();
+        // Nothing can receive this exception, so it is dropped: CPython's
+        // `gather` retrieves each child's exception through a done-callback
+        // even after it has settled, so it prints nothing here either. Then
+        // drop the task and switch to the next ready one; if there is none,
+        // frames are left empty and the run loop yields.
+        drop(error);
+        self.discard_failed_task(task_id);
         self.scheduler.set_current_task(None);
         if let Some(next_task_id) = self.scheduler.next_ready_task() {
             self.scheduler.set_current_task(Some(next_task_id));
             self.load_or_init_task(next_task_id)?;
         }
-        // If no task is ready, the placeholder frame remains parked until resume.
 
         Ok(())
+    }
+
+    /// Drops the current task after an exception escaped its last frame,
+    /// discarding the VM context it was running in.
+    ///
+    /// The task has no way back — its root frame is gone — so it must leave
+    /// the scheduler rather than linger with a half-torn-down context. Its
+    /// awaiter has already been taken by this point, so this only releases
+    /// what the task itself owns.
+    fn discard_failed_task(&mut self, task_id: TaskId) {
+        self.cleanup_current_task();
+        self.scheduler.cancel_task(task_id, self.heap);
     }
 
     /// Saves the current VM context into the given task in the scheduler.
@@ -592,7 +593,12 @@ impl<'h> VM<'h> {
             let HeapReadOutput::Coroutine(coro) = self.heap.read(coro_id) else {
                 panic!("task coroutine_id doesn't point to a Coroutine")
             };
-            if coro.get(self.heap).state == CoroutineState::New {
+            let is_new = coro.get(self.heap).state == CoroutineState::New;
+            // Release the handle before either branch: both go on to drop
+            // references to this coroutine, and freeing it under a live
+            // reader panics.
+            drop(coro);
+            if is_new {
                 self.init_task_from_coroutine(coro_id)?;
             } else {
                 return self.handle_task_failure(ExcType::cannot_reuse_already_awaited_coroutine());
@@ -768,7 +774,9 @@ impl<'h> VM<'h> {
     ///   the task in `Ready` instead — `handle_task_failure` — should
     ///   `set_state(t, Ready)` before switching, since the exception is
     ///   propagated by the `Err` return rather than the state check.)
-    /// - `None` if the terminal task is gone.
+    /// - `None` if the chain ends nowhere — the terminal task is gone, or a
+    ///   gather on the way had already settled, in which case the error has no
+    ///   reader and dies here.
     fn deliver_awaiter_failure(&mut self, awaiter: Awaiter, error: RunError) -> Option<TaskId> {
         let this = self;
         defer_drop_mut!(awaiter, this);
@@ -779,7 +787,9 @@ impl<'h> VM<'h> {
                     let HeapReadOutput::GatherFuture(mut gather) = this.heap.read(*gather) else {
                         panic!("Awaiter::GatherSlot gather id is not a GatherFuture")
                     };
-                    gather.fail(&mut this.scheduler, this.heap, &error)
+                    // A gather that already settled has handed its waiter on;
+                    // this failure arrives after the fact and stops here.
+                    gather.fail(this.heap, &error)?
                 }
             };
             mem::replace(awaiter, next).drop_with(this);
@@ -806,11 +816,24 @@ impl<'h> VM<'h> {
             && let Some(waiter_id) = self.deliver_awaiter_failure(awaiter, error)
             && self.scheduler.current_task_id() != Some(waiter_id)
         {
-            self.cleanup_current_task();
+            // The task being switched away from is parked on a call of its
+            // own, and a gather failing no longer cancels it, so its context
+            // has to be saved rather than dropped — it still has to resume
+            // when its own call comes back.
+            self.park_current_context();
             self.scheduler.set_current_task(Some(waiter_id));
             self.load_or_init_task(waiter_id)?;
         }
         Ok(())
+    }
+
+    /// Puts the current task's VM context away before switching to another
+    /// task: saved if the task will run again, discarded if it is gone.
+    fn park_current_context(&mut self) {
+        match self.scheduler.current_task_id() {
+            Some(task_id) if self.scheduler.has_task(task_id) => self.save_task_context(task_id),
+            _ => self.cleanup_current_task(),
+        }
     }
 
     /// Allocates an `ExternalFuture` for `call_id` and pushes a `Value::Ref`
@@ -948,12 +971,27 @@ impl<'h> HeapRead<'h, GatherFuture> {
     /// Failure cases never reach this method — sibling failures are routed
     /// through [`HeapRead::fail`] at the failure site
     /// (`Scheduler::fail_for_call` for external rejections,
-    /// `VM::handle_task_failure` for in-frame exceptions). Both eagerly tear
-    /// the gather down before any other sibling has a chance to resolve.
+    /// `VM::handle_task_failure` for in-frame exceptions). Both settle the
+    /// gather before any other sibling has a chance to resolve, and the
+    /// siblings then keep running: their results arrive here afterwards and
+    /// are dropped.
     ///
-    /// Returns `None` while children are still in flight; otherwise
-    /// `Some(GatherResolution::Success)` with the cached result list.
+    /// Returns `None` while children are still in flight, or if the gather has
+    /// already settled; otherwise `Some(GatherSuccess)` with the cached result
+    /// list.
     fn resolve_child(&mut self, vm: &mut VM<'h>, child_id: HeapId, value: Value) -> Option<GatherSuccess> {
+        // A sibling failed (or the commit pass rolled back) while this child
+        // was still running: it has a result, and nowhere for it to go.
+        // `Pending` is not reachable — a child only exists once awaited.
+        match &self.get(vm.heap).state {
+            GatherState::Awaited(_) => {}
+            GatherState::Completed(_) | GatherState::Failed(_) => {
+                value.drop_with(vm.heap);
+                return None;
+            }
+            GatherState::Pending => panic!("resolve_child called on a gather that was never awaited"),
+        }
+
         // Remove this child's slot-index mapping.
         let indices: SmallVec<[usize; 1]> = self
             .get_mut(vm.heap)
@@ -1011,25 +1049,31 @@ impl<'h> HeapRead<'h, GatherFuture> {
         Some(GatherSuccess { list_id, awaiter })
     }
 
-    /// Tear the gather down with `error` and return its waiter.
+    /// Settles the gather on `error` and returns its waiter, or `None` if it
+    /// had already settled.
     ///
-    /// Takes `&mut Scheduler` + `&mut HeapReader` rather than `&mut VM` so
-    /// this works from both `VM::handle_task_failure` (has a VM, splits
-    /// borrows on its fields) and `Scheduler::fail_for_call` (only has a
-    /// scheduler + heap reader).
-    pub(crate) fn fail(&mut self, scheduler: &mut Scheduler, heap: &mut HeapReader<'h>, error: &RunError) -> Awaiter {
+    /// Touches nothing but this gather. The children still in flight keep
+    /// running and keep pointing here, as CPython leaves them on the loop;
+    /// what each produces is discarded when it arrives (see
+    /// [`Self::resolve_child`] and [`VM::deliver_awaiter_success`]). Releasing
+    /// nothing is what makes this safe to call with a live `HeapRead` on the
+    /// gather — severing the children here would run their `dec_ref`s under
+    /// that reader, and the last one can free the entry.
+    ///
+    /// Takes `&mut HeapReader` rather than `&mut VM` so this works from both
+    /// `VM::deliver_awaiter_failure` (has a VM, splits borrows on its fields)
+    /// and `Scheduler::fail_for_call` (only has a heap reader).
+    pub(crate) fn fail(&mut self, heap: &mut HeapReader<'h>, error: &RunError) -> Option<Awaiter> {
         // Take the Awaited bookkeeping. The state stays `Awaited` (with
         // placeholder fields) until the state replace below commits the
         // transition. The extracted `awaiter` is transferred to the caller
-        // — it owns any `GatherSlot` inc_ref it carried.
-        let (waiter, pending_children, results) = {
-            let awaited = self
-                .get_mut(heap)
-                .as_awaited_mut()
-                .expect("fail called on non-Awaited gather");
+        // — it owns any `GatherSlot` inc_ref it carried. Already settled means
+        // a chain that ends here: an earlier failure cached its error and
+        // handed the waiter on.
+        let (waiter, results) = {
+            let awaited = self.get_mut(heap).as_awaited_mut()?;
             (
                 mem::replace(&mut awaited.awaiter, Awaiter::Task(TaskId::default())),
-                mem::take(&mut awaited.pending_children),
                 mem::take(&mut awaited.results),
             )
         };
@@ -1037,55 +1081,11 @@ impl<'h> HeapRead<'h, GatherFuture> {
         // Cache a clone so re-awaits replay the same exception.
         self.get_mut(heap).state = GatherState::Failed(error.clone());
 
-        // Drop fanned-out result Values that won't reach the waiter.
+        // Drop fanned-out result Values that won't reach the waiter. The
+        // `pending_children` map goes with the `Awaited` payload; its keys are
+        // borrowed ids, owned by `items`.
         results.drop_with(heap);
 
-        // Skip nested gathers that already failed while propagating this same
-        // error up the awaiter chain.
-        drop_committed_children(pending_children, scheduler, heap, error);
-
-        waiter
-    }
-}
-
-/// Tears down children of a failed gather commit.
-///
-/// Coroutine children are cancelled through the scheduler, external futures
-/// have their gather awaiter removed, and nested gathers are failed
-/// recursively while they are still `Awaited`. Nested gathers already in a
-/// terminal state were cleaned up by the error path that reached them first.
-fn drop_committed_children(
-    pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>>,
-    scheduler: &mut Scheduler,
-    heap: &mut HeapReader<'_>,
-    error: &RunError,
-) {
-    for child_id in pending_children.into_keys() {
-        match heap.read(child_id) {
-            HeapReadOutput::Coroutine(_) => {
-                if let Some(tid) = scheduler.task_for_coroutine(child_id) {
-                    scheduler.cancel_task(tid, heap);
-                }
-            }
-            HeapReadOutput::ExternalFuture(mut fut) => {
-                if let ExternalFutureState::Pending { awaiter } = &mut fut.get_mut(heap).state
-                    && let Some(old) = awaiter.take()
-                {
-                    old.drop_with(heap);
-                }
-            }
-            HeapReadOutput::GatherFuture(mut nested) => {
-                if matches!(nested.get(heap).state, GatherState::Awaited(_)) {
-                    let nested_awaiter = nested.fail(scheduler, heap, error);
-                    nested_awaiter.drop_with(heap);
-                }
-                // Terminal or never-committed nested gathers have no active
-                // children left for this parent to tear down.
-            }
-            // `gather()` rejects anything other than these three types at
-            // construction (see `modules/asyncio.rs`), and heap entries don't
-            // change type — so keys here are always one of the above.
-            _ => unreachable!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
-        }
+        Some(waiter)
     }
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -420,7 +420,8 @@ impl<'h> VM<'h> {
     ///
     /// A task nothing awaits has no such chain, nor has one whose chain ends
     /// at an already-settled gather. Nothing can receive the exception, so it
-    /// is reported rather than raised.
+    /// is dropped — as CPython does, whose `gather` retrieves a late child's
+    /// exception through a done-callback and prints nothing either.
     ///
     /// # Returns
     /// - `Ok(())` - Switched to next task, continue execution

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -61,13 +61,28 @@ enum AwaitResult {
     Yield(Vec<CallId>),
 }
 
+/// Yields to the host when an exception left no task to run.
+///
+/// A spawned task whose exception nobody could receive is discarded with no
+/// successor loaded, leaving the parked frame `cleanup_current_task` installs,
+/// which dispatch must not execute. The surviving tasks are parked on external
+/// calls, so the correct move is to hand those back to the host.
+macro_rules! yield_if_parked {
+    ($self:expr) => {
+        if $self.current_frame.is_parked {
+            return Ok(FrameExit::ResolveFutures($self.scheduler.pending_call_ids()));
+        }
+    };
+}
+
 /// Tries an operation and routes a Python exception through the active frames.
 macro_rules! try_catch {
     ($self:expr, $expr:expr) => {
-        if let Err(e) = $expr
-            && let Some(result) = $self.handle_exception(e)
-        {
-            return Err(result);
+        if let Err(e) = $expr {
+            if let Some(result) = $self.handle_exception(e) {
+                return Err(result);
+            }
+            yield_if_parked!($self);
         }
     };
 }
@@ -80,6 +95,7 @@ macro_rules! catch {
         if let Some(result) = $self.handle_exception($err) {
             return Err(result);
         }
+        yield_if_parked!($self);
     }};
 }
 
@@ -1614,6 +1630,7 @@ impl<'h> VM<'h> {
                     if let Some(result) = self.handle_exception_with_value(error, raised) {
                         return Err(result);
                     }
+                    yield_if_parked!(self);
                 }
                 Opcode::Assert => {
                     match decode_assert_flags(self.current_frame.fetch_u8()).expect("invalid assert flags in bytecode")
@@ -1642,6 +1659,7 @@ impl<'h> VM<'h> {
                     if let Some(result) = self.handle_exception_with_value(error, raised) {
                         return Err(result);
                     }
+                    yield_if_parked!(self);
                 }
                 Opcode::ClearException => {
                     // Pop the current exception from the stack
@@ -1904,6 +1922,7 @@ impl<'h> VM<'h> {
         if let Some(uncaught_error) = self.handle_exception(error) {
             return Err(uncaught_error);
         }
+        yield_if_parked!(self);
         // Exception was caught, continue execution
         self.run_external()
     }
@@ -2028,6 +2047,20 @@ impl<'h> VM<'h> {
     #[cfg(feature = "test-hooks")]
     pub(crate) fn __force_gc_for_tests(&mut self) -> usize {
         self.run_gc()
+    }
+
+    /// Releases everything the scheduler still holds, as dropping the VM
+    /// would.
+    ///
+    /// A run can end with tasks still live — a task detached from a failed
+    /// gather outlives it, and the module can return before that task next
+    /// gets a turn. Their references are real, so the leak check in
+    /// `run_ref_counts_with_tracker` has to run *after* this rather than
+    /// count them as unreachable.
+    #[cfg(feature = "ref-count-return")]
+    pub(crate) fn __finalize_tasks_for_tests(&mut self) {
+        self.cleanup_current_task();
+        self.scheduler.cleanup(self.heap);
     }
 
     /// Returns the source position for the instruction currently executing.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -65,12 +65,12 @@ enum AwaitResult {
 ///
 /// A spawned task whose exception nobody could receive is discarded with no
 /// successor loaded, leaving the parked frame `cleanup_current_task` installs,
-/// which dispatch must not execute. The surviving tasks are parked on external
-/// calls, so the correct move is to hand those back to the host.
+/// which dispatch must not execute. See [`VM::yield_parked`] for what is
+/// handed back.
 macro_rules! yield_if_parked {
     ($self:expr) => {
         if $self.current_frame.is_parked {
-            return Ok(FrameExit::ResolveFutures($self.scheduler.pending_call_ids()));
+            return $self.yield_parked();
         }
     };
 }
@@ -2072,6 +2072,24 @@ impl<'h> VM<'h> {
     pub(crate) fn __finalize_tasks_for_tests(&mut self) {
         self.cleanup_current_task();
         self.scheduler.cleanup(self.heap);
+    }
+
+    /// Hands the surviving tasks' pending calls back to the host, for
+    /// [`yield_if_parked`] when dispatch has no frame left to run.
+    ///
+    /// Those tasks are parked on external calls, so there is normally
+    /// something to hand over. With nothing pending there is no way forward
+    /// either: resuming would fail the same way one round-trip later, blaming
+    /// the scheduler rather than the discarded task that emptied it.
+    fn yield_parked(&self) -> Result<FrameExit, RunError> {
+        let pending_call_ids = self.scheduler.pending_call_ids();
+        if pending_call_ids.is_empty() {
+            Err(RunError::internal(
+                "asyncio scheduler stalled: exception discarded with no task to run and no pending external calls",
+            ))
+        } else {
+            Ok(FrameExit::ResolveFutures(pending_call_ids))
+        }
     }
 
     /// Returns the source position for the instruction currently executing.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -601,6 +601,17 @@ pub struct VMSnapshot {
     pending_os_effect: Option<PendingOsEffect>,
 }
 
+impl VMSnapshot {
+    /// Number of tasks the scheduler held when this snapshot was taken.
+    ///
+    /// Test-only bridge for [`crate::ResolveFutures::__live_task_count_for_tests`];
+    /// `scheduler` is private to this module.
+    #[cfg(feature = "test-hooks")]
+    pub(crate) fn live_task_count(&self) -> usize {
+        self.scheduler.task_count()
+    }
+}
+
 // ============================================================================
 // Virtual Machine
 // ============================================================================

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -79,10 +79,13 @@ pub(crate) struct Task {
     /// Coroutine being executed by this task (if any).
     /// Used to mark the coroutine as Completed when the task finishes.
     pub coroutine_id: Option<HeapId>,
-    /// GatherFuture this task belongs to (if spawned by gather).
-    /// Used to cancel sibling tasks when this task fails. The gather itself
-    /// stores the slot-index mapping under `AwaitedGather::pending_children`.
-    pub gather_id: Option<HeapId>,
+    /// Where this task's result goes, owning whatever the `Awaiter` owns —
+    /// for the `GatherSlot` a spawned child gets, an inc_ref on its gather.
+    ///
+    /// `None` means nothing wants the result: the main task, or a child whose
+    /// gather settled before it finished. Such a task still runs to
+    /// completion; its result is dropped on arrival.
+    pub awaiter: Option<Awaiter>,
     /// Current execution state.
     pub state: TaskState,
 }
@@ -95,8 +98,8 @@ impl<C: ContainsHeap> DropWithContext<C> for Task {
         if let Some(coro_id) = self.coroutine_id.take() {
             heap.heap_mut().dec_ref(coro_id);
         }
-        if let Some(gid) = self.gather_id.take() {
-            heap.heap_mut().dec_ref(gid);
+        if let Some(awaiter) = self.awaiter.take() {
+            awaiter.drop_with(heap);
         }
     }
 }
@@ -132,8 +135,8 @@ impl Task {
     /// # Arguments
     /// * `id` - Unique task identifier
     /// * `coroutine_id` - Optional HeapId of the coroutine being executed
-    /// * `gather_id` - Optional HeapId of the GatherFuture this task belongs to
-    pub fn new(id: TaskId, coroutine_id: Option<HeapId>, gather_id: Option<HeapId>) -> Self {
+    /// * `awaiter` - Where the task's result goes; owned (see [`Task::awaiter`])
+    pub fn new(id: TaskId, coroutine_id: Option<HeapId>, awaiter: Option<Awaiter>) -> Self {
         Self {
             id,
             frames: Vec::new(),
@@ -141,7 +144,7 @@ impl Task {
             exception_stack: Vec::new(),
             instruction_ip: 0,
             coroutine_id,
-            gather_id,
+            awaiter,
             state: TaskState::Ready,
         }
     }
@@ -223,15 +226,6 @@ impl Scheduler {
         self.current_task
     }
 
-    /// Returns a reference to a task by ID.
-    ///
-    /// # Panics
-    /// Panics if the task ID doesn't exist.
-    #[inline]
-    pub fn get_task(&self, task_id: TaskId) -> &Task {
-        self.tasks.get(&task_id).expect("Scheduler::get_task: task not found")
-    }
-
     /// Returns a mutable reference to a task by ID.
     ///
     /// # Panics
@@ -304,9 +298,10 @@ impl Scheduler {
     /// both coroutine states are still `New`, so the state check in
     /// `await_coroutine` doesn't catch it. Callers translate `None`
     /// into a `RuntimeError: cannot reuse already awaited coroutine`.
-    /// Both `coroutine_id` and `gather_id` (when present) become **owning**
-    /// references held by the new task; the matching `dec_ref` happens in
-    /// [`Scheduler::cancel_task`].
+    /// Both `coroutine_id` and the `GatherSlot` built from `gather_id` become
+    /// **owning** references held by the new task; the matching `dec_ref`
+    /// happens in [`Scheduler::cancel_task`]. It takes `gather_id` rather than
+    /// a ready-made `Awaiter` so the `None` return above has nothing to unwind.
     pub fn spawn(&mut self, heap: &Heap, coroutine_id: HeapId, gather_id: Option<HeapId>) -> Option<TaskId> {
         if self.coroutine_to_task.contains_key(&coroutine_id) {
             return None;
@@ -317,26 +312,23 @@ impl Scheduler {
 
         // Take ownership of the heap references — the task now holds an inc_ref'd
         // pointer to its coroutine and (if applicable) its enclosing gather.
+        // The slot is keyed by the coroutine's own id, which is what
+        // `resolve_child` looks up.
         heap.inc_ref(coroutine_id);
-        if let Some(gid) = gather_id {
-            heap.inc_ref(gid);
-        }
+        let awaiter = gather_id.map(|gather| {
+            heap.inc_ref(gather);
+            Awaiter::GatherSlot {
+                gather,
+                source: coroutine_id,
+            }
+        });
 
-        let task = Task::new(task_id, Some(coroutine_id), gather_id);
+        let task = Task::new(task_id, Some(coroutine_id), awaiter);
         self.tasks.insert(task_id, task);
         self.coroutine_to_task.insert(coroutine_id, task_id);
         self.ready_queue.push_back(task_id);
 
         Some(task_id)
-    }
-
-    /// Returns the task driving `coroutine_id`, if any.
-    ///
-    /// Each spawned task owns exactly one coroutine for its lifetime; this
-    /// looks up the inverse mapping populated in [`Scheduler::spawn`].
-    #[inline]
-    pub fn task_for_coroutine(&self, coroutine_id: HeapId) -> Option<TaskId> {
-        self.coroutine_to_task.get(&coroutine_id).copied()
     }
 
     /// Gets the next ready task from the queue.
@@ -367,15 +359,10 @@ impl Scheduler {
 
     /// Marks a task as failed with an error.
     ///
-    /// If the task is part of a gather, returns the gather_id so the caller
-    /// can collect siblings from the gather on the heap.
-    ///
-    /// # Returns
-    /// The gather_id if this task belongs to a gather (for sibling lookup).
-    pub fn fail_task(&mut self, task_id: TaskId, error: RunError, heap: &mut Heap) -> Option<HeapId> {
-        let gather_id = self.get_task(task_id).gather_id;
+    /// Only the state changes: the task keeps its `Awaiter`, so whoever wanted
+    /// its result is still reachable when the failure is delivered.
+    pub fn fail_task(&mut self, task_id: TaskId, error: RunError, heap: &mut Heap) {
         self.set_state(task_id, TaskState::Failed(error), heap);
-        gather_id
     }
 
     /// Cancels a task, fully releasing its resources and removing it from the
@@ -475,10 +462,10 @@ impl Scheduler {
     /// Looks up the `ExternalFuture` heap entry, transitions it to `Failed`
     /// with a clone of the error, and yields the awaiter that owned the
     /// future's `Pending` slot — except for `Awaiter::Task(t)` where `t` is a
-    /// child of a gather: in that case we tear the gather down here (rather
-    /// than leaving the parked task `Failed` for a sibling's resolution to
-    /// discover later) and return the gather's awaiter instead, so the
-    /// caller's chain walk picks up at the right level.
+    /// child of a still-running gather: in that case we settle the gather here
+    /// (rather than leaving the parked task `Failed` for a sibling's
+    /// resolution to discover later) and return the gather's awaiter instead,
+    /// so the caller's chain walk picks up at the right level.
     ///
     /// The returned `Awaiter` is owned (callers must walk it via
     /// `deliver_awaiter_failure`, which drops every link).
@@ -503,34 +490,45 @@ impl Scheduler {
         heap.dec_ref(future_id);
 
         match awaiter {
+            // Nothing is waiting on this call — it was never awaited. The
+            // failure stays cached on the future for a later await to replay.
             None => None,
             Some(Awaiter::Task(task_id)) => {
-                let gather_id = self.tasks.get(&task_id).and_then(|t| t.gather_id);
-                if let Some(gather_id) = gather_id {
+                // A task's own awaiter is the `GatherSlot` its gather gave it;
+                // borrow that gather's id without taking the task's ref, which
+                // stays until the task is cancelled.
+                let gather_id = match self.tasks.get(&task_id).and_then(|t| t.awaiter.as_ref()) {
+                    Some(Awaiter::GatherSlot { gather, .. }) => Some(*gather),
+                    Some(Awaiter::Task(_)) | None => None,
+                };
+                match gather_id {
                     // The task that was awaiting the future is itself in a
-                    // gather. Tear that gather down here so the failure
-                    // anchors at the same site as the resolution; return
-                    // the gather's awaiter for the caller to chain.
-                    let HeapReadOutput::GatherFuture(mut gather_rd) = heap.read(gather_id) else {
-                        panic!("gather_id doesn't point to a GatherFuture")
-                    };
-                    let outer_awaiter = gather_rd.fail(self, heap, error);
-                    drop(gather_rd);
-                    Some(outer_awaiter)
-                } else {
-                    Some(Awaiter::Task(task_id))
+                    // gather. Settle that gather here so the failure anchors
+                    // at the same site as the resolution; return the gather's
+                    // awaiter for the caller to chain. A gather that has
+                    // already settled takes nothing more, and the failure is
+                    // the parked task's own to raise.
+                    Some(gather_id) => {
+                        let HeapReadOutput::GatherFuture(mut gather_rd) = heap.read(gather_id) else {
+                            panic!("gather_id doesn't point to a GatherFuture")
+                        };
+                        let outer_awaiter = gather_rd.fail(heap, error);
+                        drop(gather_rd);
+                        outer_awaiter.or(Some(Awaiter::Task(task_id)))
+                    }
+                    None => Some(Awaiter::Task(task_id)),
                 }
             }
             Some(Awaiter::GatherSlot { gather, .. }) => {
                 let HeapReadOutput::GatherFuture(mut gather_rd) = heap.read(gather) else {
                     panic!("gather_id doesn't point to a GatherFuture")
                 };
-                let outer_awaiter = gather_rd.fail(self, heap, error);
+                let outer_awaiter = gather_rd.fail(heap, error);
                 drop(gather_rd);
                 // Release the inc_ref the destructured `GatherSlot` owned
-                // on `gather` (we tore that gather down above).
+                // on `gather` (we settled that gather above).
                 heap.dec_ref(gather);
-                Some(outer_awaiter)
+                outer_awaiter
             }
         }
     }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -513,8 +513,26 @@ impl Scheduler {
                             panic!("gather_id doesn't point to a GatherFuture")
                         };
                         let outer_awaiter = gather_rd.fail(heap, error);
+                        // Dropped before the cancel below: that releases the
+                        // task's `GatherSlot` inc_ref on this gather, which
+                        // must not run under a live reader on it.
                         drop(gather_rd);
-                        outer_awaiter.or(Some(Awaiter::Task(task_id)))
+                        match outer_awaiter {
+                            // The gather handed the failure outwards, so
+                            // nothing will ever deliver it to `task_id`. Its
+                            // `await` raised, so it is finished — drop it, or
+                            // it stays `Blocked` forever on a future that was
+                            // just failed and unregistered, holding its
+                            // coroutine and this gather alive for the rest of
+                            // the session. Siblings are untouched: the task is
+                            // blocked on an external future, so the cancel
+                            // walk finds no gather to cascade into.
+                            Some(outer) => {
+                                self.cancel_task(task_id, heap);
+                                Some(outer)
+                            }
+                            None => Some(Awaiter::Task(task_id)),
+                        }
                     }
                     None => Some(Awaiter::Task(task_id)),
                 }
@@ -547,6 +565,16 @@ impl Scheduler {
     #[inline]
     pub fn has_task(&self, task_id: TaskId) -> bool {
         self.tasks.contains_key(&task_id)
+    }
+
+    /// Number of tasks the scheduler still holds.
+    ///
+    /// Test-only: a task whose await has already failed must not stay parked,
+    /// and a finished run tears the scheduler down, so this count while
+    /// suspended is the only way a test can see one.
+    #[cfg(feature = "test-hooks")]
+    pub fn task_count(&self) -> usize {
+        self.tasks.len()
     }
 
     /// Cleans up all scheduler resources: the pending-future inc_refs and

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -526,6 +526,11 @@ impl Executor {
             executor.populate_inputs(inputs, &mut vm)?;
             let frame_exit_result = vm.run_module();
 
+            // Tasks the module left running (a sibling detached from a failed
+            // gather, say) hold real references, and are not reachable from
+            // any name — so tear the scheduler down first and hold the
+            // leak check to what survives that.
+            vm.__finalize_tasks_for_tests();
             vm.__force_gc_for_tests();
 
             // Take globals out of the VM so we can inspect them, but keep VM alive

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -450,6 +450,18 @@ impl ResolveFutures {
         Self::new(executor, vm_state, heap, pending_call_ids)
     }
 
+    /// Number of tasks still live while this snapshot is suspended.
+    ///
+    /// Test-only: lets a test assert that a gather child whose external call
+    /// failed was dropped rather than left parked forever on a future that
+    /// can no longer be resolved.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __live_task_count_for_tests(&self) -> usize {
+        self.vm_state.live_task_count()
+    }
+
     /// Resumes execution with results for some or all pending futures.
     ///
     /// **Incremental resolution**: You don't need to provide all results at once.

--- a/crates/monty/test_cases/async__gather_all.py
+++ b/crates/monty/test_cases/async__gather_all.py
@@ -204,8 +204,9 @@ assert await nested_2 == [[1, 1], [1, 1]]  # pyright: ignore
 
 
 # === Sibling failure while blocked on a gather of gathers ===
-# The failing sibling cancels the task blocked on `gather(gather(...))`, whose
-# inner gather owns a task of its own; the scheduler must keep running after.
+# The failing sibling settles the gather that a task blocked on
+# `gather(gather(...))` was a child of, whose inner gather owns a task of its
+# own; the scheduler must keep running after.
 async def leaf():
     return 1
 
@@ -225,3 +226,152 @@ except ValueError as e:
     assert str(e) == 'boom'
 
 assert await asyncio.gather(leaf(), leaf()) == [1, 1]  # pyright: ignore
+
+
+# === A failing gather leaves its siblings running ===
+# CPython does not cancel the other children when one raises; they stay on the
+# loop and finish as it turns. `ticks` gives the loop those turns, and the
+# order the orphans interleave in is not part of the contract, hence `sorted`.
+sibling_log = []
+
+
+async def tick():
+    pass
+
+
+async def ticks(n):
+    for _ in range(n):
+        await asyncio.gather(tick())
+
+
+async def step(tag):
+    sibling_log.append(tag)
+
+
+async def stepping_worker():
+    for i in range(3):
+        await asyncio.gather(step('step' + str(i)))
+    sibling_log.append('finished')
+
+
+async def raise_boom():
+    raise ValueError('boom')
+
+
+try:
+    await asyncio.gather(stepping_worker(), raise_boom())  # pyright: ignore
+    assert False, 'expected the failing child to propagate'
+except ValueError as e:
+    assert str(e) == 'boom'
+
+await ticks(8)  # pyright: ignore
+assert sorted(sibling_log) == ['finished', 'step0', 'step1', 'step2']
+
+
+# === ... including the children of a gather a sibling was awaiting ===
+nested_log = []
+
+
+async def nested_leaf():
+    nested_log.append('leaf')
+
+
+async def awaits_nested_gather():
+    await asyncio.gather(asyncio.gather(nested_leaf()))
+    nested_log.append('holder finished')
+
+
+try:
+    await asyncio.gather(awaits_nested_gather(), raise_boom())  # pyright: ignore
+    assert False, 'expected the failing child to propagate'
+except ValueError as e:
+    assert str(e) == 'boom'
+
+await ticks(4)  # pyright: ignore
+assert sorted(nested_log) == ['holder finished', 'leaf']
+
+
+# === A gather that fails while starting up leaves them running too ===
+# The second item is already awaited, so `gather` itself raises — after the
+# first item has been spawned. That one keeps running.
+startup_log = []
+
+
+async def startup_step():
+    startup_log.append('ran')
+
+
+reused_coroutine = startup_step()
+await reused_coroutine  # pyright: ignore
+startup_log.clear()
+
+try:
+    await asyncio.gather(startup_step(), reused_coroutine)  # pyright: ignore
+    assert False, 'expected the reused coroutine to be rejected'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine'
+
+await ticks(4)  # pyright: ignore
+assert startup_log == ['ran']
+
+
+# === An exception in a task nobody awaits any more is discarded ===
+# CPython stores it on the task and reports it unretrieved at collection;
+# either way it does not reach the code that stopped waiting.
+orphan_log = []
+
+
+async def raises_after_yielding():
+    await asyncio.gather(tick())
+    orphan_log.append('reached the raise')
+    raise KeyError('nobody is listening')
+
+
+try:
+    await asyncio.gather(raises_after_yielding(), raise_boom())  # pyright: ignore
+    assert False, 'expected the failing child to propagate'
+except ValueError as e:
+    assert str(e) == 'boom'
+
+await ticks(4)  # pyright: ignore
+orphan_log.append('run continues')
+assert orphan_log == ['reached the raise', 'run continues']
+
+
+# === A nested gather outlives the parent that settled ===
+# The inner gather is an item of the failing one, so it keeps driving its own
+# children. When one of them raises it settles on that error with nobody left
+# to raise into, and when it is the last one in flight the settling releases
+# the inner gather's final reference.
+nested_late_log = []
+
+
+async def nested_raiser():
+    await asyncio.gather(tick())
+    raise KeyError('inner raised late')
+
+
+async def nested_survivor():
+    await asyncio.gather(tick())
+    nested_late_log.append('survivor finished')
+
+
+try:
+    await asyncio.gather(asyncio.gather(nested_raiser(), nested_survivor()), raise_boom())  # pyright: ignore
+    assert False, 'expected the failing child to propagate'
+except ValueError as e:
+    assert str(e) == 'boom'
+
+await ticks(6)  # pyright: ignore
+assert nested_late_log == ['survivor finished']
+
+# The same with the raiser as the inner gather's only child.
+try:
+    await asyncio.gather(asyncio.gather(nested_raiser()), raise_boom())  # pyright: ignore
+    assert False, 'expected the failing child to propagate'
+except ValueError as e:
+    assert str(e) == 'boom'
+
+await ticks(6)  # pyright: ignore
+nested_late_log.append('run continues')
+assert nested_late_log == ['survivor finished', 'run continues']

--- a/crates/monty/test_cases/refcount__gather_detached_sibling.py
+++ b/crates/monty/test_cases/refcount__gather_detached_sibling.py
@@ -3,14 +3,18 @@
 # but its own completion path is left to release its coroutine and results.
 import asyncio
 
+completed = 0
+
 
 async def leaf():
     return [1, 2, 3]
 
 
 async def survivor():
+    global completed
     for _ in range(2):
         await asyncio.gather(leaf(), leaf())
+    completed += 1
 
 
 async def task_fail():
@@ -22,7 +26,14 @@ try:
 except ValueError:
     pass
 
-# Give the detached sibling the turns it needs to run to completion.
-for _ in range(6):
+# The detached sibling only advances while something else suspends, so drive it
+# with top-level awaits until it reports completion instead of a fixed turn count.
+for _ in range(20):
+    if completed:
+        break
     await asyncio.gather(leaf())  # pyright: ignore
+
+# The loop above is bounded, so assert the sibling really ran: a scheduler change
+# that stops driving it should fail here, not as an unexplained ref-count leak.
+assert completed == 1
 # ref-counts={'asyncio': 1}

--- a/crates/monty/test_cases/refcount__gather_detached_sibling.py
+++ b/crates/monty/test_cases/refcount__gather_detached_sibling.py
@@ -1,0 +1,28 @@
+# Test that a sibling left running by a failing gather balances its references
+# once it finishes. The sibling outlives the gather that spawned it, so nothing
+# but its own completion path is left to release its coroutine and results.
+import asyncio
+
+
+async def leaf():
+    return [1, 2, 3]
+
+
+async def survivor():
+    for _ in range(2):
+        await asyncio.gather(leaf(), leaf())
+
+
+async def task_fail():
+    raise ValueError('outer task failed')
+
+
+try:
+    await asyncio.gather(survivor(), task_fail())  # pyright: ignore
+except ValueError:
+    pass
+
+# Give the detached sibling the turns it needs to run to completion.
+for _ in range(6):
+    await asyncio.gather(leaf())  # pyright: ignore
+# ref-counts={'asyncio': 1}

--- a/crates/monty/test_cases/refcount__gather_nested_cancel.py
+++ b/crates/monty/test_cases/refcount__gather_nested_cancel.py
@@ -1,6 +1,6 @@
-# Test that nested GatherFuture is properly cleaned up when outer task is cancelled.
-# When one task in an outer gather fails, sibling tasks (including those with inner gathers)
-# should be cancelled and all GatherFutures properly cleaned up.
+# Test that a nested GatherFuture is properly cleaned up when the outer gather fails.
+# The sibling task and its inner gather are detached rather than cancelled, and are
+# released when the run ends without the main task ever waiting on them again.
 import asyncio
 
 

--- a/crates/monty/test_cases/refcount__gather_nested_cancel.py
+++ b/crates/monty/test_cases/refcount__gather_nested_cancel.py
@@ -1,6 +1,7 @@
-# Test that a nested GatherFuture is properly cleaned up when the outer gather fails.
-# The sibling task and its inner gather are detached rather than cancelled, and are
-# released when the run ends without the main task ever waiting on them again.
+# Test that a nested GatherFuture is released when the outer gather fails and the
+# detached sibling never runs again. Nothing balances these refs mid-run — the
+# end-of-run scheduler teardown does — so this covers the sibling that never
+# finishes; refcount__gather_detached_sibling.py covers the one that does.
 import asyncio
 
 

--- a/crates/monty/test_cases/refcount__gather_nested_gather_cancel.py
+++ b/crates/monty/test_cases/refcount__gather_nested_gather_cancel.py
@@ -1,7 +1,7 @@
-# Test that a nested GatherFuture *item* is released once the run ends, having
-# been detached when its parent gather failed. Unlike
-# refcount__gather_nested_cancel, the inner gather is a direct item of the
-# gather the detached task is blocked on, not reached via a coroutine.
+# Test that a nested GatherFuture *item* is released by the end-of-run scheduler
+# teardown, having been detached when its parent gather failed and never run
+# again. Unlike refcount__gather_nested_cancel, the inner gather is a direct
+# item of the gather the detached task is blocked on, not reached via a coroutine.
 import asyncio
 
 

--- a/crates/monty/test_cases/refcount__gather_nested_gather_cancel.py
+++ b/crates/monty/test_cases/refcount__gather_nested_gather_cancel.py
@@ -1,6 +1,7 @@
-# Test that a nested GatherFuture *item* is cleaned up when the task awaiting it
-# is cancelled. Unlike refcount__gather_nested_cancel, the inner gather is a direct
-# item of the gather the cancelled task is blocked on, not reached via a coroutine.
+# Test that a nested GatherFuture *item* is released once the run ends, having
+# been detached when its parent gather failed. Unlike
+# refcount__gather_nested_cancel, the inner gather is a direct item of the
+# gather the detached task is blocked on, not reached via a coroutine.
 import asyncio
 
 

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -501,6 +501,77 @@ fn gather_first_external_fails_immediately() {
     assert_eq!(exc.message(), Some("foo failed"));
 }
 
+// === Test: Gather - a coroutine child whose external call fails is dropped ===
+
+/// A gather child that is a coroutine gets its own task, and its failing
+/// external call is settled against the gather rather than raised inside the
+/// child. Nothing would then deliver the failure to that child, so it must be
+/// dropped here — otherwise it stays `Blocked` on a future that has just been
+/// failed and unregistered, holding its coroutine and the gather for the rest
+/// of the session. Its siblings are unaffected and keep running.
+#[test]
+#[cfg(feature = "test-hooks")]
+fn gather_coroutine_child_dropped_when_its_external_fails() {
+    let code = r"
+import asyncio
+
+async def child():
+    return await foo()
+
+async def sibling():
+    return await bar()
+
+async def main():
+    try:
+        await asyncio.gather(child(), sibling())
+    except ValueError as exc:
+        assert str(exc) == 'foo failed'
+    return await baz()
+
+await main()
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let (state, call_ids) = drive_to_resolve_futures(progress);
+    assert_eq!(call_ids.len(), 2, "child and sibling each yield one external call");
+    // main, child, sibling.
+    assert_eq!(state.__live_task_count_for_tests(), 3);
+
+    // Fail the child's call, leaving the sibling's outstanding.
+    let progress = state
+        .resume(
+            vec![(
+                call_ids[0],
+                ExtFunctionResult::Error(MontyException::new(ExcType::ValueError, Some("foo failed".to_string()))),
+            )],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+
+    let RunProgress::FunctionCall(call) = progress else {
+        panic!("expected main to reach `baz` after catching the error");
+    };
+    let baz_id = call.call_id;
+    let RunProgress::ResolveFutures(state) = call.resume_pending(PrintWriter::Stdout).unwrap() else {
+        panic!("expected to suspend on `baz`");
+    };
+
+    // The child is gone; the sibling is still parked on `bar`, as CPython
+    // leaves it on the loop.
+    assert_eq!(state.__live_task_count_for_tests(), 2);
+
+    let progress = state
+        .resume(
+            vec![(baz_id, ExtFunctionResult::Return(MontyObject::Int(11)))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    assert_eq!(progress.into_complete().expect("should complete"), MontyObject::Int(11));
+}
+
 // === Test: Gather - second external fails ===
 
 #[test]

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -1064,11 +1064,11 @@ caught
     assert_eq!(result, MontyObject::Bool(true));
 }
 
-// === Test: orphaned external whose awaiting task was already cancelled ===
+// === Test: external call whose result nothing is waiting for ===
 
-/// Leaves a pending external with no live awaiter: `boom()` raises
-/// synchronously, failing the gather and cancelling `slow()` while its external
-/// call is outstanding, so the host's answer has nobody to deliver to.
+/// Leaves a pending external whose result nobody wants: `boom()` raises
+/// synchronously, failing the gather while `slow()`'s call is outstanding.
+/// `slow()` keeps running, but the gather it would return to has settled.
 fn create_orphaned_external_runner() -> MontyRun {
     let code = r"
 import asyncio
@@ -1116,8 +1116,9 @@ fn orphaned_external_resolved_alongside_live_one() {
 
     let (state, orphan, live) = orphan_and_live_ids(progress);
 
-    // Resolving `bar()` readies `main`, `foo()`'s result is discarded; the
-    // scheduler must still find `main` to run.
+    // Resolving `bar()` readies `main`. `foo()`'s result reaches `slow()`,
+    // whose own result the failed gather discards; the scheduler must still
+    // find `main` to run.
     let results = vec![
         (orphan, ExtFunctionResult::Return(MontyObject::Int(1))),
         (live, ExtFunctionResult::Return(MontyObject::Int(7))),
@@ -1137,8 +1138,8 @@ fn orphaned_external_failed_alongside_live_one() {
 
     let (state, orphan, live) = orphan_and_live_ids(progress);
 
-    // The orphan's awaiter chain terminates at a cancelled task, so it fails
-    // nothing; only `bar()`'s failure reaches a task.
+    // The orphan's failure raises inside `slow()`, where nothing awaits it,
+    // and dies there; only `bar()`'s failure reaches a task.
     let results = vec![
         (
             orphan,
@@ -1154,4 +1155,257 @@ fn orphaned_external_failed_alongside_live_one() {
         .resume(results, PrintWriter::Stdout)
         .expect_err("the live failure should surface");
     assert_eq!(err.message(), Some("live"));
+}
+
+// === Test: a gather failure leaves siblings running, externals and all ===
+
+/// The sibling of a failed gather child is parked on an external call of its
+/// own. That call must still be served, and the sibling must still be holding
+/// the frames to resume into — it is no longer torn down with the gather, so
+/// switching away from it has to save its context rather than drop it.
+#[test]
+fn detached_sibling_still_receives_its_external_result() {
+    let code = r"
+import asyncio
+
+log = []
+
+async def parked():
+    log.append(await parked_call(1))
+
+async def doomed():
+    return await doomed_call(2)
+
+async def main():
+    try:
+        await asyncio.gather(parked(), doomed())
+    except ValueError as e:
+        log.append(str(e))
+    # Suspending again is what gives the detached sibling a turn; a run whose
+    # main task never waits again ends with it still parked.
+    log.append(await tail_call(3))
+    return log
+
+await main()
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let (state, calls) = drive_collecting_calls(progress);
+    let call_id = |name: &str| {
+        calls
+            .iter()
+            .find_map(|(id, call_name)| (call_name == name).then_some(*id))
+            .unwrap_or_else(|| panic!("{name} should have parked"))
+    };
+
+    // Fail the gather through one child while the other is still parked.
+    let error = MontyException::new(ExcType::ValueError, Some("doomed failed".to_string()));
+    let progress = state
+        .resume(
+            vec![(call_id("doomed_call"), ExtFunctionResult::Error(error))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+
+    // The main task carries on to its own call, and the sibling's is still
+    // outstanding alongside it.
+    let (state, tail_calls) = drive_collecting_calls(progress);
+    let tail_id = tail_calls
+        .iter()
+        .find_map(|(id, name)| (name == "tail_call").then_some(*id))
+        .expect("the main task should have parked on its own call");
+
+    // Answer the sibling's call alone: with the main task still parked, the
+    // sibling is the one ready task, so it resumes and finishes its work.
+    let progress = state
+        .resume(
+            vec![(call_id("parked_call"), ExtFunctionResult::Return(MontyObject::Int(7)))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    let state = progress
+        .into_resolve_futures()
+        .expect("the main task's own call should still be pending");
+    let progress = state
+        .resume(
+            vec![(tail_id, ExtFunctionResult::Return(MontyObject::Int(3)))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+
+    let result = progress.into_complete().expect("should complete");
+    assert_eq!(
+        result,
+        MontyObject::List(vec![
+            MontyObject::String("doomed failed".to_string()),
+            MontyObject::Int(7),
+            MontyObject::Int(3)
+        ]),
+        "the main task caught the failure and the sibling still logged its result"
+    );
+}
+
+/// A task raising with nothing left awaiting it is discarded silently.
+///
+/// The exception has nowhere to go: the gather that was waiting on the task
+/// settled on its sibling's error. CPython's `gather` retrieves each child's
+/// exception through a done-callback even after settling, so it prints nothing
+/// either. The run must carry on, and its output must stay clean.
+#[test]
+fn discarded_task_exception_is_silent() {
+    let code = r"
+import asyncio
+
+async def parked():
+    await parked_call(1)
+    raise ValueError('nobody is waiting')
+
+async def doomed():
+    return await doomed_call(2)
+
+async def main():
+    try:
+        await asyncio.gather(parked(), doomed())
+    except ValueError:
+        pass
+    return await tail_call(3)
+
+await main()
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let (state, calls) = drive_collecting_calls(progress);
+    let call_id = |name: &str| {
+        calls
+            .iter()
+            .find_map(|(id, call_name)| (call_name == name).then_some(*id))
+            .unwrap_or_else(|| panic!("{name} should have parked"))
+    };
+
+    // Fail the gather, detaching `parked()`.
+    let error = MontyException::new(ExcType::ValueError, Some("doomed failed".to_string()));
+    let progress = state
+        .resume(
+            vec![(call_id("doomed_call"), ExtFunctionResult::Error(error))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    let (state, tail_calls) = drive_collecting_calls(progress);
+    let tail_id = tail_calls
+        .iter()
+        .find_map(|(id, name)| (name == "tail_call").then_some(*id))
+        .expect("the main task should have parked on its own call");
+
+    // Resume only the sibling's call, so it runs into its `raise` while the
+    // main task is still parked — the run would otherwise finish first and
+    // never give the detached task a turn.
+    let mut output = String::new();
+    let progress = state
+        .resume(
+            vec![(call_id("parked_call"), ExtFunctionResult::Return(MontyObject::Int(1)))],
+            PrintWriter::collect_string(&mut output),
+        )
+        .unwrap();
+    assert_eq!(output, "");
+
+    let RunProgress::ResolveFutures(state) = progress else {
+        panic!("the main task should still be parked on its own call")
+    };
+    let result = state
+        .resume(
+            vec![(tail_id, ExtFunctionResult::Return(MontyObject::Int(3)))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    let RunProgress::Complete(complete) = result else {
+        panic!("the discarded exception must not fail the run")
+    };
+    assert_eq!(complete, MontyObject::Int(3));
+}
+
+/// A detached sibling's own call failing raises inside that sibling, where it
+/// can be caught. Uncaught, it has nowhere left to go — the gather that was
+/// waiting on the sibling has already settled — so it must not surface as the
+/// run's error.
+#[test]
+fn detached_sibling_failure_does_not_surface() {
+    let code = r"
+import asyncio
+
+log = []
+
+async def parked():
+    await parked_call(1)
+    log.append('not reached')
+
+async def doomed():
+    return await doomed_call(2)
+
+async def main():
+    try:
+        await asyncio.gather(parked(), doomed())
+    except ValueError as e:
+        log.append(str(e))
+    log.append(await tail_call(3))
+    return log
+
+await main()
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let (state, calls) = drive_collecting_calls(progress);
+    let call_id = |name: &str| {
+        calls
+            .iter()
+            .find_map(|(id, call_name)| (call_name == name).then_some(*id))
+            .unwrap_or_else(|| panic!("{name} should have parked"))
+    };
+
+    let error = MontyException::new(ExcType::ValueError, Some("doomed failed".to_string()));
+    let progress = state
+        .resume(
+            vec![(call_id("doomed_call"), ExtFunctionResult::Error(error))],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+
+    let (state, tail_calls) = drive_collecting_calls(progress);
+    let tail_id = tail_calls
+        .iter()
+        .find_map(|(id, name)| (name == "tail_call").then_some(*id))
+        .expect("the main task should have parked on its own call");
+
+    // Reject the detached sibling's call: it raises in a task nobody is
+    // waiting on, and dies there.
+    let error = MontyException::new(ExcType::KeyError, Some("nobody is listening".to_string()));
+    let progress = state
+        .resume(
+            vec![
+                (call_id("parked_call"), ExtFunctionResult::Error(error)),
+                (tail_id, ExtFunctionResult::Return(MontyObject::Int(3))),
+            ],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+
+    let result = progress
+        .into_complete()
+        .expect("the detached failure must not end the run");
+    assert_eq!(
+        result,
+        MontyObject::List(vec![
+            MontyObject::String("doomed failed".to_string()),
+            MontyObject::Int(3)
+        ]),
+        "only the awaited failure reached the main task"
+    );
 }

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -80,12 +80,31 @@ Its result reaches the sibling; a result arriving for a `gather` that has alread
 Which task runs next also differs.
 A task resumed by a host result runs to its next suspension before any other ready task gets a turn, where CPython's
 loop takes them in the order they were woken.
-Only the interleaving differs: every task still gets its turns, and no result is lost.
+Among the tasks that do resume, only the ordering differs.
+A task parked with nothing left to wake it never resumes at all, and a result routed to an already-failed
+`gather` is discarded.
 This applies to all async code, not only to siblings of a failed `gather`.
 
-### A failed `gather` nobody awaits is never reported
+### `gather` does not start its children until it is awaited
 
+CPython's `gather` schedules each awaitable as a task straight away, so the children run whether or not the result is
+ever awaited.
+Monty holds the awaitables and spawns nothing until the `await`, so a `gather(...)` whose result is discarded runs no
+code at all:
+
+```python
+async def boom():
+    print('boom ran')
+    raise ValueError('x')
+
+asyncio.gather(boom())  # CPython prints `boom ran`, Monty runs nothing
+```
+
+Awaiting the gather later still runs the children, and a gather that has already failed re-raises its cached
+exception on every later await.
+
+Neither does Monty report the exception CPython loses track of here.
 CPython prints `_GatheringFuture exception was never retrieved`, a `future:` line and the traceback to stderr when a
-failed `gather` is garbage collected without having been awaited.
-Monty prints nothing, and has no stderr to print it to: `print()` only ever writes stdout.
-Awaiting the `gather` later still raises the cached exception.
+gather holding an unretrieved exception is collected.
+In Monty that gather never ran, and no sandboxed code can write to stderr in any case — `print()` rejects its `file`
+argument.

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -81,8 +81,6 @@ Which task runs next also differs.
 A task resumed by a host result runs to its next suspension before any other ready task gets a turn, where CPython's
 loop takes them in the order they were woken.
 Among the tasks that do resume, only the ordering differs.
-A task parked with nothing left to wake it never resumes at all, and a result routed to an already-failed
-`gather` is discarded.
 This applies to all async code, not only to siblings of a failed `gather`.
 
 ### `gather` does not start its children until it is awaited

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -54,20 +54,38 @@ every branch is blocked on an external call, hands the pending calls to the
 host, and resumes when the host returns results. There is no preemption, no
 threads, and no in-sandbox scheduler.
 
-### A failing `gather` cancels its siblings
+### Siblings left running by a failed `gather` only advance while something else suspends
 
-When one child of a `gather` raises, every sibling still running is cancelled where it is blocked and never resumes.
-That includes the tasks of any gather a sibling was itself awaiting.
-CPython leaves those siblings running as tasks on the loop, so:
+When one child of a `gather` raises, the siblings keep running as they do in CPython.
+They resume only when a host result arrives or when another task awaits, because Monty has no event loop of its own
+to turn.
+Code that catches the error and then returns without awaiting again leaves them parked where they were:
 
 ```python
-async def worker():
-    for _ in range(3):
-        await asyncio.gather(step())
-    done.append('finished')
+async def sibling():
+    await asyncio.gather(tick())
+    print('sibling finished')
+
+try:
+    await asyncio.gather(sibling(), raises())
+except ValueError:
+    pass
 ```
 
-appends `'finished'` under CPython after a sibling of `worker()` raises, but not under Monty.
+CPython prints `sibling finished` here, Monty prints nothing.
 
-External calls already passed to the host are not cancelled.
-The host still resolves them and the results are discarded.
+An external call a sibling already passed to the host is still resolved by the host.
+Its result reaches the sibling; a result arriving for a `gather` that has already failed is discarded.
+
+Which task runs next also differs.
+A task resumed by a host result runs to its next suspension before any other ready task gets a turn, where CPython's
+loop takes them in the order they were woken.
+Only the interleaving differs: every task still gets its turns, and no result is lost.
+This applies to all async code, not only to siblings of a failed `gather`.
+
+### A failed `gather` nobody awaits is never reported
+
+CPython prints `_GatheringFuture exception was never retrieved`, a `future:` line and the traceback to stderr when a
+failed `gather` is garbage collected without having been awaited.
+Monty prints nothing, and has no stderr to print it to: `print()` only ever writes stdout.
+Awaiting the `gather` later still raises the cached exception.


### PR DESCRIPTION
When one child of a `gather` raises, the other children keep running instead of being cancelled, as they do in CPython.

-------

The reference chain is task→gather→task which remains unchanged (child points up at the gather)
- tasks in a hash map on the scheduler
- gathers live on the heap

**Change**: `Task::gather_id` becomes `Task::awaiter: Opt>` - `gather_id` was a special-case field needing bespoke handling; as an `Awaiter`, coroutine children join the generic chain walk, so "already settled?" is decided in one place. 

**Enables**: cancelling siblings was the old way to stop late results reaching a dead gather; now a single settled-check discards them instead, so siblings keep running.

Fixes three panics reachable from sandboxed Python: dispatch against an empty frame stack, `fail_future` discarding a live sibling's frames, and freeing a coroutine under a live reader.

Divergences: `limitations/asyncio.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a failing `asyncio.gather` leave its siblings running instead of cancelling them, matching CPython. Results or exceptions arriving after the gather settles are discarded, and exceptions in detached tasks stay silent.

- Replaces `Task::gather_id` with `Task::awaiter: Option<Awaiter>` so each spawned child owns the edge to its gather; the failed gather is retained until its last child finishes and releases it.
- Settles a gather in place without touching its children: delivery walks the awaiter chain, and a value or error landing on an already-settled gather, or on no waiter, is dropped.
- Switches safely for detached siblings: `park_current_context` saves a parked sibling's live frames, `discard_failed_task` removes failed tasks, and `yield_if_parked!` yields to the host when only parked frames remain.
- Has `Scheduler::fail_for_call` settle an enclosing still-running gather and return its awaiter, and drops a gather child whose own external call failed so it doesn't stay parked forever on a future that can never resolve, releasing its references.
- Errors with the real cause when a discarded task leaves nothing to run — no pending calls yields "asyncio scheduler stalled" rather than blaming the scheduler one round-trip later.
- Fixes three panics reachable from sandboxed Python: dispatch against an empty frame stack, `fail_future` discarding a live sibling's frames, and freeing a coroutine under a live reader.
- Adds tests for detached siblings, nested gathers, externals, and refcounts — the latter verified through a `test-hooks` live-task-count bridge — finalizing the scheduler before ref-count checks, and updates `limitations/asyncio.md` for the lazy start, siblings advancing only when something else suspends, and unreported unretrieved exceptions.

<sup>Written for commit bda89fbf245fb2c54d663e8ce8f82f4ae6cf2be0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



