### PR TITLE
Compile Rust quickstart examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,9 @@ jobs:
           if-no-files-found: error
 
   # The crates layered on top of the interpreter: the type checker (which does
-  # not depend on `monty` at all) and the subprocess stack. Both build `monty`
-  # only with default features, so this job pays no feature-flag rebuilds and
-  # runs in parallel with `test-rust`.
+  # not depend on `monty` at all), the subprocess stack and the docs harness.
+  # They build `monty` only with default features, so this job pays no
+  # feature-flag rebuilds and runs in parallel with `test-rust`.
   test-rust-crates:
     runs-on: ubuntu-latest
 
@@ -192,6 +192,8 @@ jobs:
       - run: cargo llvm-cov --no-report -p monty-proto -p monty-runtime -p monty-pool
         env:
           MONTY_TEST_BIN: ${{ github.workspace }}/target/debug/monty
+      - name: Compile Rust documentation examples
+        run: cargo test --doc -p monty-doctest
       # Generating text report:
       - run: cargo llvm-cov report --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
       # Generate codecov report (use `report` subcommand to avoid recompilation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -966,9 +966,9 @@ where they are. Change one and you must change all of them:
 
 ### Rules for `docs/`
 
-- Every Python snippet is executed by `make test-docs` (pytest-examples over `docs/`,
-  `README.md` and `crates/monty-python/README.md`). Snippets that cannot run are marked
-  ```` ```python test="skip" ````; they are still ruff-linted.
+- `make test-docs` checks every Python snippet in `docs/`, `README.md`,
+  `packages/pydantic-monty/README.md`, and `crates/monty-python/README.md`.
+  It executes each snippet unless marked ```` ```python test="skip" ````; skipped snippets are still ruff-linted.
 - Sandbox-side Python (code fed to Monty, not host code) belongs inside a host snippet as
   a string, or in a `test="skip"` block. It must never be a runnable top-level block —
   CPython would execute it.
@@ -979,7 +979,8 @@ where they are. Change one and you must change all of them:
 
 ### Enforcement
 
-- `make test-docs` runs every snippet in `docs/` and both Python READMEs.
+- `make test-docs` applies the Python checks above and compiles Rust snippets in `docs/quickstart/rust.md`.
+  TypeScript snippets are not checked.
 - `make docs` builds the site with `--strict`, which fails on a broken internal link or a
   page missing from the nav. `make docs-serve` previews it.
 - The `docs-parity-reviewer` subagent (`.agents/agents/docs-parity-reviewer.md`) is the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "monty-doctest"
+version = "0.0.21"
+dependencies = [
+ "monty",
+ "monty-pool",
+ "monty-types",
+ "tokio",
+]
+
+[[package]]
 name = "monty-fs"
 version = "0.0.21"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/monty-python",
     "crates/monty-js",
     "crates/monty-datatest",
+    "crates/monty-doctest",
     "crates/monty-bench",
     "crates/monty-type-checking",
     "crates/monty-typeshed",

--- a/crates/monty-doctest/Cargo.toml
+++ b/crates/monty-doctest/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "monty-doctest"
+version = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+description = "Doctest harness for Monty's Rust documentation examples"
+publish = false
+
+[dev-dependencies]
+monty = { workspace = true }
+monty-pool = { workspace = true }
+monty-types = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/monty-doctest/src/lib.rs
+++ b/crates/monty-doctest/src/lib.rs
@@ -1,0 +1,1 @@
+#![doc = include_str!("../../../docs/quickstart/rust.md")]


### PR DESCRIPTION
The five Rust examples in `docs/quickstart/rust.md` were outside the workspace doctest graph, so API changes could leave the docs stale without failing CI.

This adds a non-published workspace crate that includes the quickstart as crate documentation. `make test-docs` now discovers the examples through `cargo test --doc --workspace`, and the existing Rust crates CI job runs the focused doctest explicitly.

Tests:
- `make test-docs`
- `cargo +nightly fmt --all -- --check`
- repository YAML, TOML, yamlfmt, zizmor, and codespell hooks

This addresses the Rust documentation part of #663. TypeScript examples remain unchecked and are outside this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles the Rust quickstart examples in CI so API drift fails the build instead of letting docs go stale. Previously CI ignored `docs/quickstart/rust.md`; now a non-published workspace crate runs its doctests in the Rust crates job.

- Add `crates/monty-doctest` that includes `docs/quickstart/rust.md` as crate docs; run with `cargo test --doc -p monty-doctest`.
- Run this step in `test-rust-crates` in `.github/workflows/ci.yml`; builds with default features and runs in parallel with `test-rust`.
- Update `CLAUDE.md` to note `make test-docs` compiles Rust quickstart snippets; TypeScript remains unchecked. No runtime code changes; `monty-doctest` is `publish = false`.

<sup>Written for commit 492c784d5a205b0b81f260d18f58c1f4cea83b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

