### PR TITLE
Implement str.format

### DIFF
--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -682,6 +682,28 @@ fn async_accumulation_reaches_the_soft_limit() {
     child.shutdown();
 }
 
+/// A value that already meets its width emits no fill, so a multibyte fill
+/// must not be charged as though it were repeated to the full width.
+#[test]
+fn formatting_without_padding_does_not_charge_fill() {
+    let mut child = ChildProc::spawn();
+    child.create_repl_with(configure_with_max_memory(1024 * 1024));
+    let code = "s = 'x' * 400_000\nlen(f'{s:é<400000}')";
+    assert_eq!(child.feed_complete(code), MontyObject::Int(400_000));
+    child.shutdown();
+}
+
+/// Generic string fallback must use the same exact output bound as direct strings.
+#[test]
+fn formatting_generic_value_without_padding_does_not_charge_fill() {
+    let mut child = ChildProc::spawn();
+    child.create_repl_with(configure_with_max_memory(1024 * 1024));
+    let code = "s = 'x' * 400_000\nclass Value:\n    def __str__(self):\n        return s\nvalue = Value()\nlen(f'{value:é<400000}')";
+    assert_eq!(child.feed_complete(code), MontyObject::Int(400_000));
+    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+    child.shutdown();
+}
+
 /// Gathers nested as *items* of one another (`g = asyncio.gather(g)`) cost no
 /// Python frames, so nothing but `max_memory` bounds how deep a nest gets built.
 /// Building one too large for the limit must end the run with a `MemoryError`,

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -704,6 +704,22 @@ fn formatting_generic_value_without_padding_does_not_charge_fill() {
     child.shutdown();
 }
 
+#[test]
+fn impossible_format_capacity_preserves_the_worker() {
+    let width = isize::MAX.unsigned_abs() / 'é'.len_utf8() + 2;
+    let mut child = ChildProc::spawn();
+    child.create_repl();
+    for code in [
+        format!("'{{0:é<{width}}}'.format('x')"),
+        format!("'{{0:é<{width}}}'.format(1)"),
+    ] {
+        let (_, event) = child.feed(&code);
+        assert_eq!(expect_error(event).exc_type, "MemoryError", "{code}");
+    }
+    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+    child.shutdown();
+}
+
 /// Gathers nested as *items* of one another (`g = asyncio.gather(g)`) cost no
 /// Python frames, so nothing but `max_memory` bounds how deep a nest gets built.
 /// Building one too large for the limit must end the run with a `MemoryError`,

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -5,6 +5,7 @@
 
 use std::{
     io::{Read, Write},
+    iter::repeat_n,
     process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio},
     thread,
     time::{Duration, Instant},
@@ -721,6 +722,31 @@ fn impossible_format_capacity_preserves_the_worker() {
 }
 
 #[test]
+fn large_unnested_format_spec_preserves_the_worker() {
+    const SPEC_LEN: usize = 5_500_000;
+    let mut template = String::with_capacity(SPEC_LEN + 4);
+    template.push_str("{0:");
+    template.extend(repeat_n('x', SPEC_LEN));
+    template.push('}');
+
+    for junk_len in [5_000_000, 10_000_000] {
+        let mut child = ChildProc::spawn();
+        child.create_repl_with(configure_with_max_memory(16 * 1024 * 1024));
+        let inputs = vec![pb::NamedValue {
+            name: "template".to_owned(),
+            value: Some(str_value(&template)),
+        }];
+        // The smaller filler reaches tracked error rendering without room for
+        // another spec copy. The larger one requires a preflighted receiver copy.
+        let code = format!("junk = 'j' * {junk_len}\ntemplate.format(0)");
+        let (_, event) = child.feed_with(&code, inputs);
+        assert_eq!(expect_error(event).exc_type, "MemoryError", "junk_len {junk_len}");
+        assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+        child.shutdown();
+    }
+}
+
+#[test]
 fn numeric_formatting_peak_memory_preserves_the_worker() {
     for code in ["'{:08000000d}'.format(1)", "'{:.8000000f}'.format(1.0)"] {
         let mut child = ChildProc::spawn();
@@ -792,7 +818,7 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
         ("'x' * 10_000_000", 10_031_137),
         // Each formatter builder must fail softly before the worker reaches its hard ceiling.
         ("s = 'x' * 400_000\n'{0}{0}'.format(s)", 1_231_000),
-        ("s = 'x' * 400_000\n'{0:>1000000}'.format(s)", 1_430_760),
+        ("s = 'x' * 400_000\n'{0:>1000000}'.format(s)", 1_431_791),
         ("s = 'é' * 200_000\n'{0!a}'.format(s)", 1_230_835),
         ("b'x' * 10_000_000", 10_031_269),
         ("[None] * 1_000_000", 16_031_391),

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -740,6 +740,8 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
     // each case with the allocator usage it should be refused at
     let cases = [
         ("'x' * 10_000_000", 10_031_137),
+        // Formatting must account for the retained input and the growing output.
+        ("s = 'x' * 400_000\n'{0}{0}'.format(s)", 1_231_000),
         ("b'x' * 10_000_000", 10_031_269),
         ("[None] * 1_000_000", 16_031_391),
         ("2 ** 10_000_000", 10_031_230),

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -720,6 +720,18 @@ fn impossible_format_capacity_preserves_the_worker() {
     child.shutdown();
 }
 
+#[test]
+fn numeric_formatting_peak_memory_preserves_the_worker() {
+    for code in ["'{:08000000d}'.format(1)", "'{:.8000000f}'.format(1.0)"] {
+        let mut child = ChildProc::spawn();
+        child.create_repl_with(configure_with_max_memory(10_000_000));
+        let (_, event) = child.feed(code);
+        assert_eq!(expect_error(event).exc_type, "MemoryError", "{code}");
+        assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2), "{code}");
+        child.shutdown();
+    }
+}
+
 /// Gathers nested as *items* of one another (`g = asyncio.gather(g)`) cost no
 /// Python frames, so nothing but `max_memory` bounds how deep a nest gets built.
 /// Building one too large for the limit must end the run with a `MemoryError`,

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -866,6 +866,20 @@ fn host_call_arguments_over_the_limit_still_fail_gracefully() {
     child.shutdown();
 }
 
+/// A format receiver can already consume most of the soft budget, so its
+/// native copy must be refused before the hard allocator exits the worker.
+#[test]
+fn large_str_format_template_preserves_the_worker() {
+    let mut child = ChildProc::spawn();
+    child.create_repl_with(configure_with_max_memory(10 * 1024 * 1024));
+    assert_eq!(child.feed_complete("template = 'x' * 8_000_000"), MontyObject::None);
+
+    let (_, event) = child.feed("template.format()");
+    assert_eq!(expect_error(event).exc_type, "MemoryError");
+    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+    child.shutdown();
+}
+
 /// Reading `p.args` off a widely bound partial must raise `MemoryError` and
 /// leave the session usable, not kill the worker.
 ///

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -740,8 +740,10 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
     // each case with the allocator usage it should be refused at
     let cases = [
         ("'x' * 10_000_000", 10_031_137),
-        // Formatting must account for the retained input and the growing output.
+        // Each formatter builder must fail softly before the worker reaches its hard ceiling.
         ("s = 'x' * 400_000\n'{0}{0}'.format(s)", 1_231_000),
+        ("s = 'x' * 400_000\n'{0:>1000000}'.format(s)", 1_430_760),
+        ("s = 'é' * 200_000\n'{0!a}'.format(s)", 1_230_835),
         ("b'x' * 10_000_000", 10_031_269),
         ("[None] * 1_000_000", 16_031_391),
         ("2 ** 10_000_000", 10_031_230),
@@ -861,20 +863,6 @@ fn host_call_arguments_over_the_limit_still_fail_gracefully() {
     let mut child = ChildProc::spawn();
     child.create_repl_with(configure_with_max_memory(8 * 1024 * 1024));
     let (_, event) = child.feed("foobar('A' * (16 * 1024 * 1024))");
-    assert_eq!(expect_error(event).exc_type, "MemoryError");
-    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
-    child.shutdown();
-}
-
-/// A format receiver can already consume most of the soft budget, so its
-/// native copy must be refused before the hard allocator exits the worker.
-#[test]
-fn large_str_format_template_preserves_the_worker() {
-    let mut child = ChildProc::spawn();
-    child.create_repl_with(configure_with_max_memory(10 * 1024 * 1024));
-    assert_eq!(child.feed_complete("template = 'x' * 8_000_000"), MontyObject::None);
-
-    let (_, event) = child.feed("template.format()");
     assert_eq!(expect_error(event).exc_type, "MemoryError");
     assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
     child.shutdown();

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -1,17 +1,17 @@
 //! F-string and value formatting helpers for the VM.
 
+use std::fmt::Write as _;
+
 use super::VM;
 use crate::{
     bytecode::op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC},
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
-    fstring::{
-        ParsedFormatSpec, ascii_escape, decode_format_spec, format_string, format_with_spec, validate_string_spec,
-    },
+    fstring::{ParsedFormatSpec, decode_format_spec, format_string, format_with_spec, validate_string_spec},
     heap::HeapReadOutput,
-    resource_checks::check_repeat_size,
+    string_builder::StringBuilder,
     types::{
-        PyTrait, date::format_date_strftime, datetime::format_datetime_strftime, str::allocate_string,
+        PyTrait, Type, date::format_date_strftime, datetime::format_datetime_strftime, str::allocate_string,
         time::format_time_strftime,
     },
     value::Value,
@@ -39,17 +39,6 @@ impl VM<'_> {
     /// Formats a value for f-string interpolation.
     ///
     /// See `Opcode::FormatValue` for the flag layout.
-    ///
-    /// Python f-string formatting order:
-    /// 1. Apply format spec to original value (type-specific formatting)
-    /// 2. Apply conversion flag to the result
-    ///
-    /// However, conversion flags like !s, !r, !a are applied BEFORE formatting
-    /// if the value would be repr'd. The key insight is:
-    /// - No conversion: format the original value type
-    /// - !s conversion: convert to str first, then format as string
-    /// - !r conversion: convert to repr first, then format as string
-    /// - !a conversion: convert to ascii repr first, then format as string
     pub(super) fn format_value(&mut self, flags: u8) -> Result<(), RunError> {
         let this = self;
         let conversion = flags & 0x03;
@@ -91,19 +80,31 @@ impl VM<'_> {
         conversion: u8,
         format_spec: Option<&str>,
     ) -> Result<String, RunError> {
-        if let Some(format_spec) = format_spec {
-            // Temporal specs are strftime strings, not mini-language specs.
-            if conversion == 0
-                && let Some(formatted) = self.try_format_temporal(value, format_spec)?
-            {
-                return Ok(formatted);
+        if conversion != 0 {
+            let converted = self.convert_value(value, conversion)?;
+            if let Some(format_spec) = format_spec {
+                self.format_runtime_string(&converted, format_spec)
+            } else {
+                Ok(converted)
             }
-
-            let spec = self.parse_runtime_format_spec(format_spec, value)?;
-            self.format_parsed_value(value, conversion, &spec)
+        } else if let Some(format_spec) = format_spec {
+            if let Some(formatted) = self.try_format_temporal(value, format_spec)? {
+                Ok(formatted)
+            } else {
+                let spec = {
+                    let value_type = value.py_type_name(self);
+                    Self::parse_runtime_format_spec(format_spec, &value_type)?
+                };
+                self.format_parsed_value(value, 0, &spec)
+            }
         } else {
-            self.convert_value(value, conversion)
+            self.convert_value(value, 0)
         }
+    }
+
+    pub(crate) fn format_runtime_string(&mut self, value: &str, format_spec: &str) -> Result<String, RunError> {
+        let spec = Self::parse_runtime_format_spec(format_spec, "str")?;
+        self.format_parsed_string(value, &spec)
     }
 
     fn format_parsed_value(
@@ -112,23 +113,46 @@ impl VM<'_> {
         conversion: u8,
         spec: &ParsedFormatSpec,
     ) -> Result<String, RunError> {
-        // Keep pad_string from allocating before the tracker sees the width.
-        check_repeat_size(spec.width, spec.fill.len_utf8(), &self.heap.tracker)?;
-
         if conversion == 0 {
             format_with_spec(value, spec, self)
         } else {
-            // Conversions happen first, so the spec must be valid for strings.
             let s = self.convert_value(value, conversion)?;
-            validate_string_spec(spec)?;
-            Ok(format_string(&s, spec)?)
+            self.format_parsed_string(&s, spec)
         }
     }
 
-    fn convert_value(&mut self, value: &Value, conversion: u8) -> Result<String, RunError> {
+    fn format_parsed_string(&self, value: &str, spec: &ParsedFormatSpec) -> Result<String, RunError> {
+        validate_string_spec(spec)?;
+        format_string(value, spec, &self.heap.tracker)
+    }
+
+    pub(crate) fn convert_value(&mut self, value: &Value, conversion: u8) -> Result<String, RunError> {
         match conversion {
+            0 | 1 if value.py_type(self) == Type::Str => Ok(value.to_str(self)?.to_owned()),
             2 => str_value_into_string(value.py_repr(self)?, self),
-            3 => Ok(ascii_escape(&str_value_into_string(value.py_repr(self)?, self)?)),
+            3 => {
+                let value = str_value_into_string(value.py_repr(self)?, self)?;
+                let mut escaped = StringBuilder::with_capacity(value.len(), &self.heap.tracker)?;
+                for (index, character) in value.chars().enumerate() {
+                    self.heap.tracker.check_time_every(index)?;
+                    if character.is_ascii() {
+                        escaped.push(character)?;
+                    } else {
+                        let code = u32::from(character);
+                        let result = if code <= 0xff {
+                            write!(escaped, "\\x{code:02x}")
+                        } else if code <= 0xffff {
+                            write!(escaped, "\\u{code:04x}")
+                        } else {
+                            write!(escaped, "\\U{code:08x}")
+                        };
+                        if result.is_err() {
+                            return escaped.finish_raw();
+                        }
+                    }
+                }
+                escaped.finish_raw()
+            }
             // No conversion and `!s` both use `str()`.
             _ => str_value_into_string(value.py_str(self)?, self),
         }
@@ -163,14 +187,9 @@ impl VM<'_> {
     }
 
     /// Adds the value type only to errors where CPython does.
-    fn parse_runtime_format_spec(
-        &mut self,
-        format_spec: &str,
-        value_for_error: &Value,
-    ) -> Result<ParsedFormatSpec, RunError> {
+    fn parse_runtime_format_spec(format_spec: &str, value_type: &str) -> Result<ParsedFormatSpec, RunError> {
         format_spec.parse::<ParsedFormatSpec>().map_err(|err| {
             let message = if err.needs_type_suffix() {
-                let value_type = value_for_error.py_type_name(self);
                 format!("{err} for object of type '{value_type}'")
             } else {
                 err.to_string()

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -74,6 +74,7 @@ impl VM<'_> {
         Ok(())
     }
 
+    /// Formats a value from a runtime format spec.
     pub(crate) fn format_runtime_value(
         &mut self,
         value: &Value,
@@ -102,11 +103,13 @@ impl VM<'_> {
         }
     }
 
+    /// Formats an already-converted string from a runtime format spec.
     pub(crate) fn format_runtime_string(&mut self, value: &str, format_spec: &str) -> Result<String, RunError> {
         let spec = Self::parse_runtime_format_spec(format_spec, "str")?;
         self.format_parsed_string(value, &spec)
     }
 
+    /// Formats a value from a parsed format spec.
     fn format_parsed_value(
         &mut self,
         value: &Value,
@@ -121,11 +124,13 @@ impl VM<'_> {
         }
     }
 
+    /// Formats a string from a parsed format spec.
     fn format_parsed_string(&self, value: &str, spec: &ParsedFormatSpec) -> Result<String, RunError> {
         validate_string_spec(spec)?;
         format_string(value, spec, &self.heap.tracker)
     }
 
+    /// Applies the f-string and `str.format()` conversion flags to a value.
     pub(crate) fn convert_value(&mut self, value: &Value, conversion: u8) -> Result<String, RunError> {
         match conversion {
             0 | 1 if value.py_type(self) == Type::Str => Ok(value.to_str(self)?.to_owned()),

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -62,59 +62,22 @@ impl VM<'_> {
         let value = this.pop();
         defer_drop!(value, this);
 
-        // Format with spec applied to original value type, or convert and format as string
-        let formatted = if let Some(spec_value) = format_spec {
-            defer_drop!(spec_value, this);
-
-            // date/datetime/time: with no conversion flag, CPython hands the
-            // whole spec to the value's `__format__`, which treats it as a
-            // strftime string (`f"{dt:%Y-%m-%d}"`). Only the runtime (dynamic) spec path
-            // carries the raw string; a valid mini-language spec on a temporal
-            // value (rare/nonsensical) still takes the generic route below.
-            let temporal = if conversion == 0 && !static_spec {
-                this.try_format_temporal(value, spec_value)?
-            } else {
-                None
-            };
-
-            if let Some(formatted) = temporal {
-                formatted
-            } else {
-                let spec = this.get_format_spec(spec_value, value, static_spec)?;
-
-                // Pre-check: reject format specs with huge width before pad_string
-                // allocates an untracked Rust String.
-                check_repeat_size(spec.width, spec.fill.len_utf8(), &this.heap.tracker)?;
-
-                if conversion == 0 {
-                    // No conversion: format the original value through its own
-                    // type (`format_with_spec` does the type-specific validation).
-                    format_with_spec(value, &spec, this)?
-                } else {
-                    // `!s`/`!r`/`!a` convert to a string first, so the spec is now
-                    // a *string* spec: CPython applies it to the converted text and
-                    // rejects flags that are illegal there (`#`, `,`, `+`, a non-`s`
-                    // type, …). Validate via the same `validate_string_spec` the
-                    // `str` branch of `format_with_spec` uses, then format.
-                    let s = match conversion {
-                        2 => str_value_into_string(value.py_repr(this)?, this)?,
-                        3 => ascii_escape(&str_value_into_string(value.py_repr(this)?, this)?),
-                        // `!s` (1) and any unused bit pattern fall back to `str()`.
-                        _ => str_value_into_string(value.py_str(this)?, this)?,
+        let formatted = match format_spec {
+            Some(spec_value) => {
+                defer_drop!(spec_value, this);
+                if static_spec {
+                    // The compiler only sets this flag for encoded integer specs.
+                    let Value::Int(encoded) = spec_value else {
+                        unreachable!("FORMAT_VALUE_STATIC_SPEC flag without Value::Int on stack");
                     };
-                    validate_string_spec(&spec)?;
-                    format_string(&s, &spec)?
+                    let spec = decode_format_spec(*encoded);
+                    this.format_parsed_value(value, conversion, &spec)?
+                } else {
+                    let spec = str_value_into_string(spec_value.py_str(this)?, this)?;
+                    this.format_runtime_value(value, conversion, Some(&spec))?
                 }
             }
-        } else {
-            // No format spec - just convert based on conversion flag
-            match conversion {
-                0 => str_value_into_string(value.py_str(this)?, this)?,
-                1 => str_value_into_string(value.py_str(this)?, this)?,
-                2 => str_value_into_string(value.py_repr(this)?, this)?,
-                3 => ascii_escape(&str_value_into_string(value.py_repr(this)?, this)?),
-                _ => str_value_into_string(value.py_str(this)?, this)?,
-            }
+            None => this.format_runtime_value(value, conversion, None)?,
         };
 
         let result = allocate_string(formatted, this.heap);
@@ -122,87 +85,98 @@ impl VM<'_> {
         Ok(())
     }
 
-    /// Formats a `date`, `datetime` or `time` value by treating the spec as a
-    /// `strftime` string, mirroring CPython's `__format__` for temporal types
-    /// (`f"{dt:%Y-%m-%d}"`).
-    ///
-    /// Returns `Ok(None)` for any non-temporal value so the caller falls back
-    /// to the generic mini-language formatter. `spec_value` is the runtime
-    /// (dynamic) spec string; an empty spec maps to `str()`, matching
-    /// `datetime.__format__('')`.
-    fn try_format_temporal(&mut self, value: &Value, spec_value: &Value) -> Result<Option<String>, RunError> {
-        let this = self;
+    pub(crate) fn format_runtime_value(
+        &mut self,
+        value: &Value,
+        conversion: u8,
+        format_spec: Option<&str>,
+    ) -> Result<String, RunError> {
+        if let Some(format_spec) = format_spec {
+            // Temporal specs are strftime strings, not mini-language specs.
+            if conversion == 0
+                && let Some(formatted) = self.try_format_temporal(value, format_spec)?
+            {
+                return Ok(formatted);
+            }
+
+            let spec = self.parse_runtime_format_spec(format_spec, value)?;
+            self.format_parsed_value(value, conversion, &spec)
+        } else {
+            self.convert_value(value, conversion)
+        }
+    }
+
+    fn format_parsed_value(
+        &mut self,
+        value: &Value,
+        conversion: u8,
+        spec: &ParsedFormatSpec,
+    ) -> Result<String, RunError> {
+        // Keep pad_string from allocating before the tracker sees the width.
+        check_repeat_size(spec.width, spec.fill.len_utf8(), &self.heap.tracker)?;
+
+        if conversion == 0 {
+            format_with_spec(value, spec, self)
+        } else {
+            // Conversions happen first, so the spec must be valid for strings.
+            let s = self.convert_value(value, conversion)?;
+            validate_string_spec(spec)?;
+            Ok(format_string(&s, spec)?)
+        }
+    }
+
+    fn convert_value(&mut self, value: &Value, conversion: u8) -> Result<String, RunError> {
+        match conversion {
+            2 => str_value_into_string(value.py_repr(self)?, self),
+            3 => Ok(ascii_escape(&str_value_into_string(value.py_repr(self)?, self)?)),
+            // No conversion and `!s` both use `str()`.
+            _ => str_value_into_string(value.py_str(self)?, self),
+        }
+    }
+
+    /// Keeps temporal strftime specs out of generic mini-language parsing.
+    fn try_format_temporal(&mut self, value: &Value, spec_str: &str) -> Result<Option<String>, RunError> {
         let Value::Ref(id) = value else {
             return Ok(None);
         };
         let id = *id;
         let temporal = matches!(
-            this.heap.read(id),
+            self.heap.read(id),
             HeapReadOutput::Date(_) | HeapReadOutput::DateTime(_) | HeapReadOutput::Time(_)
         );
         if !temporal {
             return Ok(None);
         }
 
-        let spec_str_value = spec_value.py_str(this)?;
-        defer_drop!(spec_str_value, this);
-        let spec_str = spec_str_value.to_str(this)?;
-        // An empty (dynamic) spec behaves like `str()`; strftime("") is also
-        // "" but routing explicitly keeps the intent clear.
+        // `datetime.__format__("")` falls back to `str()`.
         if spec_str.is_empty() {
-            return str_value_into_string(value.py_str(this)?, this).map(Some);
+            return self.convert_value(value, 0).map(Some);
         }
 
-        let formatted = match this.heap.read(id) {
-            HeapReadOutput::Date(d) => format_date_strftime(*d.get(this.heap), spec_str),
-            HeapReadOutput::DateTime(d) => format_datetime_strftime(d.get(this.heap), spec_str),
-            HeapReadOutput::Time(t) => format_time_strftime(t.get(this.heap), spec_str),
+        let formatted = match self.heap.read(id) {
+            HeapReadOutput::Date(d) => format_date_strftime(*d.get(self.heap), spec_str),
+            HeapReadOutput::DateTime(d) => format_datetime_strftime(d.get(self.heap), spec_str),
+            HeapReadOutput::Time(t) => format_time_strftime(t.get(self.heap), spec_str),
             _ => unreachable!("temporal-ness checked above"),
         };
         formatted.map(Some)
     }
 
-    /// Resolves a format spec value pushed by `compile_format_value` into a
-    /// [`ParsedFormatSpec`].
-    ///
-    /// `static_spec` is the discriminator from the `FormatValue` flags
-    /// ([`FORMAT_VALUE_STATIC_SPEC`]): when set, the compiler emitted the
-    /// spec as `Value::Int(encoded)` and we just decode the bit-packed form;
-    /// otherwise the spec was constructed at runtime and we parse its string
-    /// representation. `value_for_error` is used to include the formatted
-    /// value's type in the parse-error message; we only fetch `py_type()`
-    /// on the error path.
-    fn get_format_spec(
+    /// Adds the value type only to errors where CPython does.
+    fn parse_runtime_format_spec(
         &mut self,
-        spec_value: &Value,
+        format_spec: &str,
         value_for_error: &Value,
-        static_spec: bool,
     ) -> Result<ParsedFormatSpec, RunError> {
-        if static_spec {
-            // Compiler invariant: the static-spec flag is only emitted
-            // alongside a LoadConst of Value::Int(encoded).
-            let Value::Int(encoded) = spec_value else {
-                unreachable!("FORMAT_VALUE_STATIC_SPEC flag without Value::Int on stack");
+        format_spec.parse::<ParsedFormatSpec>().map_err(|err| {
+            let message = if err.needs_type_suffix() {
+                let value_type = value_for_error.py_type_name(self);
+                format!("{err} for object of type '{value_type}'")
+            } else {
+                err.to_string()
             };
-            Ok(decode_format_spec(*encoded))
-        } else {
-            let this = self;
-            let spec_str_value = spec_value.py_str(this)?;
-            defer_drop!(spec_str_value, this);
-            spec_str_value.to_str(this)?.parse::<ParsedFormatSpec>().map_err(|err| {
-                // CPython suffixes the value's type onto some spec errors
-                // (`Invalid format specifier`, `Unknown format code`) but not
-                // others (`Format specifier missing precision`, the `Cannot
-                // specify …` grouping conflicts), which are self-contained.
-                let message = if err.needs_type_suffix() {
-                    let value_type = value_for_error.py_type_name(this);
-                    format!("{err} for object of type '{value_type}'")
-                } else {
-                    err.to_string()
-                };
-                RunError::Exc(SimpleException::new_msg(ExcType::ValueError, message).into())
-            })
-        }
+            RunError::Exc(SimpleException::new_msg(ExcType::ValueError, message).into())
+        })
     }
 }
 

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -7,7 +7,10 @@ use crate::{
     bytecode::op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC},
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
-    fstring::{ParsedFormatSpec, decode_format_spec, format_string, format_with_spec, validate_string_spec},
+    fstring::{
+        ParseFormatSpecError, ParsedFormatSpec, decode_format_spec, format_string, format_with_spec,
+        validate_string_spec,
+    },
     heap::HeapReadOutput,
     string_builder::StringBuilder,
     types::{
@@ -92,10 +95,9 @@ impl VM<'_> {
             if let Some(formatted) = self.try_format_temporal(value, format_spec)? {
                 Ok(formatted)
             } else {
-                let spec = {
-                    let value_type = value.py_type_name(self);
-                    Self::parse_runtime_format_spec(format_spec, &value_type)?
-                };
+                let spec = format_spec
+                    .parse::<ParsedFormatSpec>()
+                    .map_err(|err| Self::spec_error(&err, &value.py_type_name(self)))?;
                 self.format_parsed_value(value, 0, &spec)
             }
         } else {
@@ -105,7 +107,9 @@ impl VM<'_> {
 
     /// Formats an already-converted string from a runtime format spec.
     pub(crate) fn format_runtime_string(&mut self, value: &str, format_spec: &str) -> Result<String, RunError> {
-        let spec = Self::parse_runtime_format_spec(format_spec, "str")?;
+        let spec = format_spec
+            .parse::<ParsedFormatSpec>()
+            .map_err(|err| Self::spec_error(&err, "str"))?;
         self.format_parsed_string(value, &spec)
     }
 
@@ -191,16 +195,15 @@ impl VM<'_> {
         formatted.map(Some)
     }
 
-    /// Adds the value type only to errors where CPython does.
-    fn parse_runtime_format_spec(format_spec: &str, value_type: &str) -> Result<ParsedFormatSpec, RunError> {
-        format_spec.parse::<ParsedFormatSpec>().map_err(|err| {
-            let message = if err.needs_type_suffix() {
-                format!("{err} for object of type '{value_type}'")
-            } else {
-                err.to_string()
-            };
-            RunError::Exc(SimpleException::new_msg(ExcType::ValueError, message).into())
-        })
+    /// Builds CPython's `ValueError` for a bad runtime spec, adding the value
+    /// type only where CPython does; callers look the type up only on this path.
+    fn spec_error(err: &ParseFormatSpecError, value_type: &str) -> RunError {
+        let message = if err.needs_type_suffix() {
+            format!("{err} for object of type '{value_type}'")
+        } else {
+            err.to_string()
+        };
+        RunError::Exc(SimpleException::new_msg(ExcType::ValueError, message).into())
     }
 }
 

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -8,7 +8,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
     fstring::{
-        ParseFormatSpecError, ParsedFormatSpec, decode_format_spec, format_string, format_with_spec,
+        ParseFormatSpecReason, ParsedFormatSpec, decode_format_spec, format_string, format_with_spec,
         validate_string_spec,
     },
     heap::HeapReadOutput,
@@ -95,9 +95,8 @@ impl VM<'_> {
             if let Some(formatted) = self.try_format_temporal(value, format_spec)? {
                 Ok(formatted)
             } else {
-                let spec = format_spec
-                    .parse::<ParsedFormatSpec>()
-                    .map_err(|err| Self::spec_error(&err, &value.py_type_name(self)))?;
+                let value_type = value.py_type_name(self);
+                let spec = self.parse_runtime_spec(format_spec, &value_type)?;
                 self.format_parsed_value(value, 0, &spec)
             }
         } else {
@@ -107,9 +106,7 @@ impl VM<'_> {
 
     /// Formats an already-converted string from a runtime format spec.
     pub(crate) fn format_runtime_string(&mut self, value: &str, format_spec: &str) -> Result<String, RunError> {
-        let spec = format_spec
-            .parse::<ParsedFormatSpec>()
-            .map_err(|err| Self::spec_error(&err, "str"))?;
+        let spec = self.parse_runtime_spec(format_spec, "str")?;
         self.format_parsed_string(value, &spec)
     }
 
@@ -195,15 +192,41 @@ impl VM<'_> {
         formatted.map(Some)
     }
 
-    /// Builds CPython's `ValueError` for a bad runtime spec, adding the value
-    /// type only where CPython does; callers look the type up only on this path.
-    fn spec_error(err: &ParseFormatSpecError, value_type: &str) -> RunError {
-        let message = if err.needs_type_suffix() {
-            format!("{err} for object of type '{value_type}'")
-        } else {
-            err.to_string()
+    /// Parses a runtime spec without copying it onto an error path.
+    fn parse_runtime_spec(&self, spec: &str, value_type: &str) -> Result<ParsedFormatSpec, RunError> {
+        let reason = match ParsedFormatSpec::parse_runtime(spec) {
+            Ok(parsed) => return Ok(parsed),
+            Err(reason) => reason,
         };
-        RunError::Exc(SimpleException::new_msg(ExcType::ValueError, message).into())
+        let mut message = StringBuilder::new(&self.heap.tracker);
+        match &reason {
+            ParseFormatSpecReason::Malformed => {
+                message.push_str("Invalid format specifier '")?;
+                message.push_str(spec)?;
+                message.push('\'')?;
+            }
+            ParseFormatSpecReason::NumberOverflow => {
+                message.push_str("Invalid format specifier '")?;
+                message.push_str(spec)?;
+                message.push_str("': width or precision overflows usize")?;
+            }
+            ParseFormatSpecReason::MissingPrecision => {
+                message.push_str("Format specifier missing precision")?;
+            }
+            ParseFormatSpecReason::UnknownFormatCode(code) => {
+                message.push_str("Unknown format code '")?;
+                message.push(*code)?;
+                message.push('\'')?;
+            }
+            ParseFormatSpecReason::GroupingConflict(detail) => message.push_str(detail)?,
+        }
+        if reason.needs_type_suffix() {
+            message.push_str(" for object of type '")?;
+            message.push_str(value_type)?;
+            message.push('\'')?;
+        }
+        let message = message.finish_raw()?;
+        Err(SimpleException::new_msg(ExcType::ValueError, message).into())
     }
 }
 

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -14,11 +14,12 @@ use monty_types::ResourceTracker;
 use crate::{
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunError, SimpleException},
+    exception_private::{ExcType, RunError, RunResult, SimpleException},
     expressions::ExprLoc,
     heap::HeapData,
     intern::StringId,
     resource_checks::check_repeat_size,
+    string_builder::StringBuilder,
     types::{LongInt, PyTrait, Type, long_int::check_bits_str_digits_limit},
     value::Value,
 };
@@ -687,7 +688,7 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
         validate_string_spec(spec)?;
         // `value` is already a `str`, so borrow it directly — no `py_str`
         // round-trip (which would allocate a fresh heap copy just to drop it).
-        return Ok(format_string(value.to_str(vm)?, spec)?);
+        return format_string(value.to_str(vm)?, spec, &vm.heap.tracker);
     }
 
     // A grouping option (`,`/`_`) is only legal for certain presentation
@@ -811,7 +812,7 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
         (_, None) => {
             let s = value.py_str(vm)?;
             defer_drop!(s, vm);
-            Ok(format_string(s.to_str(vm)?, spec)?)
+            format_string(s.to_str(vm)?, spec, &vm.heap.tracker)
         }
 
         // Type mismatch errors
@@ -1231,24 +1232,47 @@ pub fn decode_format_spec(encoded: i64) -> ParsedFormatSpec {
 /// 2. Alignment: Pads to `width` using `fill` character (default left-aligned for strings)
 ///
 /// Returns an error if `=` alignment is used (sign-aware padding only valid for numbers).
-pub fn format_string(value: &str, spec: &ParsedFormatSpec) -> Result<String, FormatError> {
-    // Handle precision (string truncation)
-    let value = if let Some(prec) = spec.precision {
-        value.chars().take(prec).collect::<String>()
-    } else {
-        value.to_owned()
-    };
-
-    // Validate alignment for strings (= is only for numbers)
+pub fn format_string(value: &str, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     if spec.align == Some(Align::SignAware) {
-        return Err(FormatError::InvalidAlignment(
-            "'=' alignment not allowed in string format specifier".to_owned(),
-        ));
+        return Err(
+            FormatError::InvalidAlignment("'=' alignment not allowed in string format specifier".to_owned()).into(),
+        );
     }
 
-    // Default alignment for strings is left
+    check_repeat_size(spec.width, spec.fill.len_utf8(), tracker)?;
+    let precision = spec.precision.unwrap_or(usize::MAX);
+    let mut end = value.len();
+    let mut value_len = 0;
+    for (index, (byte_offset, _)) in value.char_indices().enumerate() {
+        tracker.check_time_every(index)?;
+        if value_len == precision {
+            end = byte_offset;
+            break;
+        }
+        value_len += 1;
+    }
+    let value = &value[..end];
+
+    let padding = spec.width.saturating_sub(value_len);
     let align = spec.align.unwrap_or(Align::Left);
-    Ok(pad_string(&value, spec.width, align, spec.fill))
+    let left_padding = match align {
+        Align::Right => padding,
+        Align::Center => padding / 2,
+        Align::Left | Align::SignAware => 0,
+    };
+    let right_padding = padding - left_padding;
+    let capacity = value.len().saturating_add(padding.saturating_mul(spec.fill.len_utf8()));
+    let mut output = StringBuilder::with_capacity(capacity, tracker)?;
+    for index in 0..left_padding {
+        tracker.check_time_every(index)?;
+        output.push(spec.fill)?;
+    }
+    output.push_str(value)?;
+    for index in 0..right_padding {
+        tracker.check_time_every(left_padding + index)?;
+        output.push(spec.fill)?;
+    }
+    output.finish_raw()
 }
 
 /// Formats an integer in decimal with a format specification.

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -2270,12 +2270,7 @@ fn fix_exp_format(s: &str, tracker: &ResourceTracker) -> RunResult<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use monty_types::{LARGE_RESULT_THRESHOLD, ResourceLimits, ResourceTracker};
-
-    use super::{grouped_digit_count, insert_grouping, push_format_str};
-    use crate::{exception_private::RunError, string_builder::StringBuilder};
+    use super::grouped_digit_count;
 
     #[test]
     fn grouped_digit_count_inverts_the_grouped_width() {
@@ -2294,31 +2289,5 @@ mod tests {
         assert_eq!(total, 3 * (1usize << 61));
         assert!(total + (total - 1) / 3 >= width);
         assert!(total - 1 + (total - 2) / 3 < width);
-    }
-
-    #[test]
-    fn grouped_padding_checks_time_before_allocating() {
-        let tracker = ResourceTracker::new(ResourceLimits::default().max_duration(Duration::ZERO));
-        tracker.on_execution_start();
-        let error = insert_grouping("1", 3, ',', isize::MAX as usize, &tracker).unwrap_err();
-        tracker.on_execution_stop();
-        let RunError::UncatchableExc(error) = error else {
-            panic!("expected uncatchable timeout, got {error:?}");
-        };
-        assert!(error.exc.to_string().contains("time limit exceeded"));
-    }
-
-    #[test]
-    fn large_format_fragment_checks_time_during_copy() {
-        let value = "x".repeat(LARGE_RESULT_THRESHOLD + 1);
-        let tracker = ResourceTracker::new(ResourceLimits::default().max_duration(Duration::ZERO));
-        let mut output = StringBuilder::new(&tracker);
-        tracker.on_execution_start();
-        let error = push_format_str(&mut output, &value, &tracker).unwrap_err();
-        tracker.on_execution_stop();
-        let RunError::UncatchableExc(error) = error else {
-            panic!("expected uncatchable timeout, got {error:?}");
-        };
-        assert!(error.exc.to_string().contains("time limit exceeded"));
     }
 }

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -1520,8 +1520,7 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
             .unwrap_or(0)
     };
 
-    // precision is typically small (default 6), safe to convert to i32
-    let prec_i32 = i32::try_from(precision).unwrap_or(i32::MAX);
+    let exp_magnitude = usize::try_from(exp.unsigned_abs()).unwrap_or(usize::MAX);
     // A type-less spec that reaches here carries a precision (the no-precision
     // case goes through `format_float_default`). CPython's type-less-with-
     // precision form is `g`-like but diverges in two ways: it switches to
@@ -1530,12 +1529,16 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
     // (the `Py_DTSF_ADD_DOT_0` flag) — e.g. `f"{100.0:.3}"` is `'1e+02'` (not
     // `g`'s `'100'`) and `f"{1.0:.2}"` is `'1.0'` (not `'1'`).
     let is_default = spec.type_char.is_none();
-    let sci_threshold = if is_default { prec_i32 - 1 } else { prec_i32 };
+    let sci_threshold = if is_default {
+        precision.saturating_sub(1)
+    } else {
+        precision
+    };
     // The alternate form (`#`) keeps the trailing zeros that `g` normally strips
     // and forces a decimal point. This applies whenever the `g` algorithm runs
     // — an explicit `g`/`G` *or* a type-less spec that carries a precision.
     let alternate_g = spec.alternate;
-    let abs_str = if exp < -4 || exp >= sci_threshold {
+    let abs_str = if exp < -4 || (exp >= 0 && exp_magnitude >= sci_threshold) {
         // Use exponential notation
         let exp_prec = precision.saturating_sub(1);
         if alternate_g {
@@ -1550,9 +1553,11 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
             strip_trailing_zeros_exp(&fmt_float_exp(abs_val, exp_prec.min(MAX_FMT_PRECISION_EXP), uppercase))
         }
     } else {
-        // Use fixed notation - result is non-negative due to .max(0)
-        let sig_digits_i32 = (prec_i32 - exp - 1).max(0);
-        let sig_digits = usize::try_from(sig_digits_i32).expect("sig_digits guaranteed non-negative");
+        let sig_digits = if exp < 0 {
+            precision.saturating_add(exp_magnitude).saturating_sub(1)
+        } else {
+            precision.saturating_sub(exp_magnitude.saturating_add(1))
+        };
         if alternate_g {
             // `#` keeps the trailing zeros, so the digit count scales with
             // precision; `fmt_float_fixed` synthesises any beyond the formatter

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -2266,27 +2266,3 @@ fn fix_exp_format(s: &str, tracker: &ResourceTracker) -> RunResult<String> {
     output.push_str(digits)?;
     output.finish_raw()
 }
-
-#[cfg(test)]
-mod tests {
-    use super::grouped_digit_count;
-
-    #[test]
-    fn grouped_digit_count_inverts_the_grouped_width() {
-        for group_size in [3, 4] {
-            for width in 0..=512 {
-                let total = grouped_digit_count(1, group_size, width);
-                assert!(total + (total - 1) / group_size >= width);
-                if total > 1 {
-                    assert!(total - 1 + (total - 2) / group_size < width);
-                }
-            }
-        }
-
-        let width = isize::MAX as usize;
-        let total = grouped_digit_count(1, 3, width);
-        assert_eq!(total, 3 * (1usize << 61));
-        assert!(total + (total - 1) / 3 >= width);
-        assert!(total - 1 + (total - 2) / 3 < width);
-    }
-}

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -1866,11 +1866,11 @@ fn pad_signed_ungrouped(
 /// first split into its leading digit run and any trailing part (fraction,
 /// exponent, `%`). Binary/octal/hex presentations group in fours and never
 /// carry a suffix; decimal/float presentations group in threes. `prefix` (the
-/// `#` base marker or `""`) sits after the sign and is never grouped. The `0`
-/// flag is special: its leading zeros become part of the number and are
-/// themselves grouped to fill the field width (`format(1234, '08,')` →
-/// `'0,001,234'`), whereas `=` fill and outside padding wrap an already-grouped
-/// value.
+/// `#` base marker or `""`) sits after the sign and is never grouped. Zero fill
+/// (the `0` flag or an explicit `0=`) is special: its leading zeros become part
+/// of the number and are themselves grouped to fill the field width
+/// (`format(1234, '08,')` → `'0,001,234'`), whereas any other `=` fill and
+/// outside padding wrap an already-grouped value.
 fn pad_signed_grouped(
     sign: &str,
     prefix: &str,

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -1904,8 +1904,7 @@ fn pad_signed_grouped(
         return pad_signed_ungrouped(sign, prefix, abs_str, align, spec, tracker);
     }
 
-    // An explicit `0=` fill groups like the `0` flag: CPython grows the digits,
-    // not the fill, so the zeros carry separators either way.
+    // CPython grows the digits, not the fill, for the `0` flag and an explicit `0=` alike.
     let grouped_zero_fill = spec.zero_pad || (spec.fill == '0' && spec.align == Some(Align::SignAware));
     let min_int_width = if grouped_zero_fill {
         // Grow the integer part with grouped leading zeros until the whole
@@ -1999,7 +1998,7 @@ fn push_format_str(output: &mut StringBuilder<'_>, value: &str, tracker: &Resour
 /// the right, optionally left-padding with `'0'` first so the grouped result
 /// is at least `min_width` characters wide.
 ///
-/// `min_width` drives the `0`-flag interaction: CPython grows the zero-padded
+/// `min_width` drives the zero-fill interaction: CPython grows the zero-padded
 /// integer one digit at a time until digits-plus-separators reach the field
 /// width, so the result can overshoot `min_width` by one when the final digit
 /// also introduces a separator (`format(1234, '08,')` → `'0,001,234'`, 9

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -625,7 +625,7 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
         value
     };
 
-    // `spec.width` is the minimum field width; every formatter below pads the
+    // `spec.width` is the minimum field width; numeric formatters below pad the
     // value out to it with `spec.fill` via `pad_string`/`iter::repeat_n`, which
     // build a native `String` through the global allocator. A literal
     // width is clamped to 16 bits by the bytecode encoding, but a *dynamic*
@@ -633,8 +633,11 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
     // would materialize gigabytes of padding before the post-construction
     // check, OOM-ing or aborting the host. Reject an over-budget width here,
     // up front, using the same guard sequence repeats and `str.ljust`/`zfill`
-    // already use. The check is free below `LARGE_RESULT_THRESHOLD`.
-    check_repeat_size(spec.fill.len_utf8(), spec.width, &vm.heap.tracker)?;
+    // already use. String formatting reserves its actual post-precision output,
+    // so a width estimate there would reject no-padding cases.
+    if matches!(value_type, Type::Int | Type::Float | Type::Bool) {
+        check_repeat_size(spec.fill.len_utf8(), spec.width, &vm.heap.tracker)?;
+    }
 
     // `spec.precision` on the float formats is rendered as that many decimal
     // digits. `fmt_float_fixed` / `fmt_float_exp` synthesise the digits beyond
@@ -1239,7 +1242,6 @@ pub fn format_string(value: &str, spec: &ParsedFormatSpec, tracker: &ResourceTra
         );
     }
 
-    check_repeat_size(spec.width, spec.fill.len_utf8(), tracker)?;
     let precision = spec.precision.unwrap_or(usize::MAX);
     let mut end = value.len();
     let mut value_len = 0;

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -1904,7 +1904,10 @@ fn pad_signed_grouped(
         return pad_signed_ungrouped(sign, prefix, abs_str, align, spec, tracker);
     }
 
-    let min_int_width = if spec.zero_pad {
+    // An explicit `0=` fill groups like the `0` flag: CPython grows the digits,
+    // not the fill, so the zeros carry separators either way.
+    let grouped_zero_fill = spec.zero_pad || (spec.fill == '0' && spec.align == Some(Align::SignAware));
+    let min_int_width = if grouped_zero_fill {
         // Grow the integer part with grouped leading zeros until the whole
         // field (sign + prefix + grouped digits + suffix) reaches the width.
         let reserved = sign.len() + prefix.len() + suffix.len();

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -6,10 +6,11 @@
 //! F-strings can contain literal text and interpolated expressions with optional
 //! conversion flags (`!s`, `!r`, `!a`) and format specifications.
 
-use std::{fmt, fmt::Write, iter, iter::Peekable, str, str::FromStr};
+use std::{fmt, fmt::Write, iter::Peekable, str, str::FromStr};
 
 pub use monty_types::FormatFloat;
-use monty_types::ResourceTracker;
+use monty_types::{LARGE_RESULT_THRESHOLD, ResourceTracker};
+use unicode_general_category::{GeneralCategory, get_general_category};
 
 use crate::{
     bytecode::VM,
@@ -625,28 +626,9 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
         value
     };
 
-    // `spec.width` is the minimum field width; numeric formatters below pad the
-    // value out to it with `spec.fill` via `pad_string`/`iter::repeat_n`, which
-    // build a native `String` through the global allocator. A literal
-    // width is clamped to 16 bits by the bytecode encoding, but a *dynamic*
-    // width (`f"{v:>{w}}"`, `w` a runtime value) is not, so an over-large `w`
-    // would materialize gigabytes of padding before the post-construction
-    // check, OOM-ing or aborting the host. Reject an over-budget width here,
-    // up front, using the same guard sequence repeats and `str.ljust`/`zfill`
-    // already use. String formatting reserves its actual post-precision output,
-    // so a width estimate there would reject no-padding cases.
-    if matches!(value_type, Type::Int | Type::Float | Type::Bool) {
-        check_repeat_size(spec.fill.len_utf8(), spec.width, &vm.heap.tracker)?;
-    }
-
     // `spec.precision` on the float formats is rendered as that many decimal
-    // digits. `fmt_float_fixed` / `fmt_float_exp` synthesise the digits beyond
-    // `MAX_FMT_PRECISION` by appending raw `'0'` chars to a Rust `String`, so an
-    // attacker-chosen precision (`f"{v:.{p}f}"`, `p` a runtime value) could cross
-    // the allocator's hard ceiling before returning a graceful error. Precision
-    // is parsed as an unrestricted `usize`; bound it by the
-    // active resource tracker the same way the width check above does. Skip for
-    // non-finite floats since the helpers ignore precision in that case.
+    // digits. Reject an attacker-chosen oversized result before formatting;
+    // tracker-backed builders guard the later copies at their actual size.
     //
     // This applies to `f`/`e`/`%` always, and to the `g`-family
     // (`g`/`G`/`n`/type-less-with-precision) *only* under alternate form (`#`):
@@ -675,7 +657,11 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
             // Fractional grouping (`f"{v:.{p}_f}"`) weaves in one separator per
             // three emitted digits, so the native string reaches ~4/3 × precision
             // before `allocate_string` accounts for it; budget the separators too.
-            let separators = if spec.frac_grouping.is_some() { precision / 3 } else { 0 };
+            let separators = if spec.frac_grouping.is_some() {
+                precision.saturating_sub(1) / 3
+            } else {
+                0
+            };
             check_repeat_size(precision.saturating_add(separators), 1, &vm.heap.tracker)?;
         }
     }
@@ -699,6 +685,15 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
     // dispatching to a formatter that would otherwise ignore the flag.
     if let Some(grouping) = spec.grouping {
         validate_grouping(grouping, spec.type_char, value_type)?;
+    }
+    if let Some(grouping) = spec.frac_grouping
+        && spec.type_char == Some(TypeChar::N)
+    {
+        return Err(SimpleException::new_msg(
+            ExcType::ValueError,
+            format!("Cannot specify '{}' with 'n'.", grouping.separator()),
+        )
+        .into());
     }
 
     // Precision is meaningless for integer presentations. CPython rejects it
@@ -784,31 +779,33 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
     match (value, spec.type_char) {
         // Integer formatting. `n` (locale number) formats an integer like `d`;
         // Monty has no locale, so the C-locale form — no grouping — applies.
-        (Value::Int(n), None | Some(TypeChar::D | TypeChar::N)) => Ok(format_int(*n, spec)),
-        (Value::Int(n), Some(TypeChar::B)) => Ok(format_int_base(*n, 2, false, spec)?),
-        (Value::Int(n), Some(TypeChar::O)) => Ok(format_int_base(*n, 8, false, spec)?),
-        (Value::Int(n), Some(TypeChar::X)) => Ok(format_int_base(*n, 16, false, spec)?),
-        (Value::Int(n), Some(TypeChar::XUpper)) => Ok(format_int_base(*n, 16, true, spec)?),
-        (Value::Int(n), Some(TypeChar::C)) => Ok(format_char(*n, spec)?),
+        (Value::Int(n), None | Some(TypeChar::D | TypeChar::N)) => format_int(*n, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::B)) => format_int_base(*n, 2, false, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::O)) => format_int_base(*n, 8, false, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::X)) => format_int_base(*n, 16, false, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::XUpper)) => format_int_base(*n, 16, true, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::C)) => format_char(*n, spec, &vm.heap.tracker),
 
         // Float formatting. A type-less spec with no precision uses the repr
         // (shortest) digits, *not* `g` — only an explicit `g`/`G` or a type-less
         // spec that carries a precision selects the `g` algorithm.
-        (Value::Float(f), None) if spec.precision.is_none() => Ok(format_float_default(*f, spec)),
+        (Value::Float(f), None) if spec.precision.is_none() => format_float_default(*f, spec, &vm.heap.tracker),
         // `n` on a float behaves like `g` (locale-aware in CPython; C-locale
         // here, so plain `g`).
-        (Value::Float(f), None | Some(TypeChar::G | TypeChar::GUpper | TypeChar::N)) => Ok(format_float_g(*f, spec)),
-        (Value::Float(f), Some(TypeChar::F | TypeChar::FUpper)) => Ok(format_float_f(*f, spec)),
-        (Value::Float(f), Some(TypeChar::E)) => Ok(format_float_e(*f, spec, false)),
-        (Value::Float(f), Some(TypeChar::EUpper)) => Ok(format_float_e(*f, spec, true)),
-        (Value::Float(f), Some(TypeChar::Percent)) => Ok(format_float_percent(*f, spec)),
+        (Value::Float(f), None | Some(TypeChar::G | TypeChar::GUpper | TypeChar::N)) => {
+            format_float_g(*f, spec, &vm.heap.tracker)
+        }
+        (Value::Float(f), Some(TypeChar::F | TypeChar::FUpper)) => format_float_f(*f, spec, &vm.heap.tracker),
+        (Value::Float(f), Some(TypeChar::E)) => format_float_e(*f, spec, false, &vm.heap.tracker),
+        (Value::Float(f), Some(TypeChar::EUpper)) => format_float_e(*f, spec, true, &vm.heap.tracker),
+        (Value::Float(f), Some(TypeChar::Percent)) => format_float_percent(*f, spec, &vm.heap.tracker),
 
         // Int to float formatting (Python allows this)
-        (Value::Int(n), Some(TypeChar::F | TypeChar::FUpper)) => Ok(format_float_f(*n as f64, spec)),
-        (Value::Int(n), Some(TypeChar::E)) => Ok(format_float_e(*n as f64, spec, false)),
-        (Value::Int(n), Some(TypeChar::EUpper)) => Ok(format_float_e(*n as f64, spec, true)),
-        (Value::Int(n), Some(TypeChar::G | TypeChar::GUpper)) => Ok(format_float_g(*n as f64, spec)),
-        (Value::Int(n), Some(TypeChar::Percent)) => Ok(format_float_percent(*n as f64, spec)),
+        (Value::Int(n), Some(TypeChar::F | TypeChar::FUpper)) => format_float_f(*n as f64, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::E)) => format_float_e(*n as f64, spec, false, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::EUpper)) => format_float_e(*n as f64, spec, true, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::G | TypeChar::GUpper)) => format_float_g(*n as f64, spec, &vm.heap.tracker),
+        (Value::Int(n), Some(TypeChar::Percent)) => format_float_percent(*n as f64, spec, &vm.heap.tracker),
 
         // No type specifier on a non-string value: convert to string and
         // format. (`str` values are handled by the short-circuit above.)
@@ -1003,6 +1000,7 @@ fn spec_has_directives(spec: &ParsedFormatSpec) -> bool {
         || spec.zero_pad
         || spec.width != 0
         || spec.grouping.is_some()
+        || spec.frac_grouping.is_some()
         || spec.precision.is_some()
         || spec.type_char.is_some()
 }
@@ -1264,12 +1262,12 @@ pub fn format_string(value: &str, spec: &ParsedFormatSpec, tracker: &ResourceTra
     };
     let right_padding = padding - left_padding;
     let capacity = value.len().saturating_add(padding.saturating_mul(spec.fill.len_utf8()));
-    let mut output = StringBuilder::with_capacity(capacity, tracker)?;
+    let mut output = format_builder(capacity, tracker)?;
     for index in 0..left_padding {
         tracker.check_time_every(index)?;
         output.push(spec.fill)?;
     }
-    output.push_str(value)?;
+    push_format_str(&mut output, value, tracker)?;
     for index in 0..right_padding {
         tracker.check_time_every(left_padding + index)?;
         output.push(spec.fill)?;
@@ -1283,12 +1281,12 @@ pub fn format_string(value: &str, spec: &ParsedFormatSpec, tracker: &ResourceTra
 /// - Sign prefix based on `sign` spec: `+` (always show), `-` (negatives only), ` ` (space for positive)
 /// - Zero-padding: When `zero_pad` is true or `=` alignment, inserts zeros between sign and digits
 /// - Alignment: Right-aligned by default for numbers, pads to `width` with `fill` character
-pub fn format_int(n: i64, spec: &ParsedFormatSpec) -> String {
+pub fn format_int(n: i64, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     let is_negative = n < 0;
     // Use unsigned_abs() to avoid overflow panic on i64::MIN
     let abs_str = n.unsigned_abs().to_string();
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    pad_signed_numeric(sign, "", &abs_str, spec)
+    pad_signed_numeric(sign, "", &abs_str, spec, tracker)
 }
 
 /// Formats an integer in binary (base 2), octal (base 8), or hexadecimal (base 16).
@@ -1302,7 +1300,13 @@ pub fn format_int(n: i64, spec: &ParsedFormatSpec) -> String {
 /// here rather than via `to_uppercase()` on the padded result (which would also
 /// uppercase an alphabetic fill, e.g. `f"{180:a>8X}"` → `aaaaaaB4`).
 /// Returns an error for invalid base values.
-pub fn format_int_base(n: i64, base: u32, uppercase: bool, spec: &ParsedFormatSpec) -> Result<String, FormatError> {
+pub fn format_int_base(
+    n: i64,
+    base: u32,
+    uppercase: bool,
+    spec: &ParsedFormatSpec,
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
     let is_negative = n < 0;
     let abs_val = n.unsigned_abs();
 
@@ -1311,12 +1315,12 @@ pub fn format_int_base(n: i64, base: u32, uppercase: bool, spec: &ParsedFormatSp
         (8, _) => (format!("{abs_val:o}"), "0o"),
         (16, false) => (format!("{abs_val:x}"), "0x"),
         (16, true) => (format!("{abs_val:X}"), "0X"),
-        _ => return Err(FormatError::ValueError("Invalid base".to_owned())),
+        _ => return Err(FormatError::ValueError("Invalid base".to_owned()).into()),
     };
     let prefix = if spec.alternate { base_prefix } else { "" };
 
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    Ok(pad_signed_numeric(sign, prefix, &abs_str, spec))
+    pad_signed_numeric(sign, prefix, &abs_str, spec, tracker)
 }
 
 /// Formats a big integer ([`LongInt`]) through the numeric mini-language,
@@ -1374,7 +1378,7 @@ fn format_long_int(
         if uppercase {
             digits.make_ascii_uppercase();
         }
-        Ok(pad_signed_numeric(sign, prefix, &digits, spec))
+        pad_signed_numeric(sign, prefix, &digits, spec, tracker)
     };
     let as_float = || match li.to_f64() {
         Some(f) if f.is_finite() => Ok(f),
@@ -1395,11 +1399,11 @@ fn format_long_int(
         Some(TypeChar::O) => radix(8, "0o", false),
         Some(TypeChar::X) => radix(16, "0x", false),
         Some(TypeChar::XUpper) => radix(16, "0x", true),
-        Some(TypeChar::F | TypeChar::FUpper) => Ok(format_float_f(as_float()?, spec)),
-        Some(TypeChar::E) => Ok(format_float_e(as_float()?, spec, false)),
-        Some(TypeChar::EUpper) => Ok(format_float_e(as_float()?, spec, true)),
-        Some(TypeChar::G | TypeChar::GUpper) => Ok(format_float_g(as_float()?, spec)),
-        Some(TypeChar::Percent) => Ok(format_float_percent(as_float()?, spec)),
+        Some(TypeChar::F | TypeChar::FUpper) => format_float_f(as_float()?, spec, tracker),
+        Some(TypeChar::E) => format_float_e(as_float()?, spec, false, tracker),
+        Some(TypeChar::EUpper) => format_float_e(as_float()?, spec, true, tracker),
+        Some(TypeChar::G | TypeChar::GUpper) => format_float_g(as_float()?, spec, tracker),
+        Some(TypeChar::Percent) => format_float_percent(as_float()?, spec, tracker),
         // A `LongInt` is always out of the C-long range `c` converts through.
         Some(TypeChar::C) => Err(SimpleException::new_msg(
             ExcType::OverflowError,
@@ -1423,9 +1427,9 @@ fn format_long_int(
 /// Returns `Overflow` error if out of range, `ValueError` if not a valid Unicode scalar value
 /// (e.g., surrogate code points). Right-aligned by default: `c` is an integer
 /// presentation, so it follows the numeric default (`format(65, '5c')` → `'    A'`).
-pub fn format_char(n: i64, spec: &ParsedFormatSpec) -> Result<String, FormatError> {
+pub fn format_char(n: i64, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     if !(0..=0x0010_FFFF).contains(&n) {
-        return Err(FormatError::Overflow("%c arg not in range(0x110000)".to_owned()));
+        return Err(FormatError::Overflow("%c arg not in range(0x110000)".to_owned()).into());
     }
     let n_u32 = u32::try_from(n).expect("format_char n validated in 0..=0x10FFFF range");
     let c = char::from_u32(n_u32).ok_or_else(|| FormatError::ValueError("Invalid Unicode code point".to_owned()))?;
@@ -1437,7 +1441,7 @@ pub fn format_char(n: i64, spec: &ParsedFormatSpec) -> Result<String, FormatErro
         Align::SignAware => Align::Right,
         other => other,
     };
-    Ok(pad_string(&value, spec.width, align, spec.fill))
+    pad_string(&value, spec.width, align, spec.fill, tracker)
 }
 
 /// Formats a float in fixed-point notation (format types `f` and `F`).
@@ -1445,18 +1449,18 @@ pub fn format_char(n: i64, spec: &ParsedFormatSpec) -> Result<String, FormatErro
 /// Always includes a decimal point with `precision` digits after it (default 6).
 /// Handles sign prefix, zero-padding between sign and digits when `zero_pad` or `=` alignment.
 /// Right-aligned by default. NaN and infinity are formatted as `nan`/`inf` (or `NAN`/`INF` for `F`).
-pub fn format_float_f(f: f64, spec: &ParsedFormatSpec) -> String {
+pub fn format_float_f(f: f64, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     let is_negative = f.is_sign_negative() && !f.is_nan();
     let uppercase = spec.type_char == Some(TypeChar::FUpper);
     let abs_str = if let Some(word) = non_finite_repr(f, uppercase) {
         word.to_owned()
     } else {
         let abs_val = f.abs();
-        let abs_str = fmt_float_fixed(abs_val, spec.precision.unwrap_or(6));
+        let abs_str = fmt_float_fixed(abs_val, spec.precision.unwrap_or(6), tracker)?;
         maybe_alternate_point(abs_str, abs_val, spec)
     };
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    pad_signed_numeric(sign, "", &abs_str, spec)
+    pad_signed_numeric(sign, "", &abs_str, spec, tracker)
 }
 
 /// Formats a float in exponential/scientific notation (format types `e` and `E`).
@@ -1464,19 +1468,24 @@ pub fn format_float_f(f: f64, spec: &ParsedFormatSpec) -> String {
 /// Produces output like `1.234568e+03` with `precision` digits after decimal (default 6).
 /// The `uppercase` parameter controls whether to use `E` or `e` for the exponent marker.
 /// Exponent is always formatted with a sign and at least 2 digits (Python convention).
-pub fn format_float_e(f: f64, spec: &ParsedFormatSpec, uppercase: bool) -> String {
+pub fn format_float_e(
+    f: f64,
+    spec: &ParsedFormatSpec,
+    uppercase: bool,
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
     let is_negative = f.is_sign_negative() && !f.is_nan();
     let abs_str = if let Some(word) = non_finite_repr(f, uppercase) {
         word.to_owned()
     } else {
         let abs_val = f.abs();
-        let abs_str = fmt_float_exp(abs_val, spec.precision.unwrap_or(6), uppercase);
+        let abs_str = fmt_float_exp(abs_val, spec.precision.unwrap_or(6), uppercase, tracker)?;
         // Fix exponent format to match Python (e+03 not e3)
-        let abs_str = fix_exp_format(&abs_str);
+        let abs_str = fix_exp_format(&abs_str, tracker)?;
         maybe_alternate_point(abs_str, abs_val, spec)
     };
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    pad_signed_numeric(sign, "", &abs_str, spec)
+    pad_signed_numeric(sign, "", &abs_str, spec, tracker)
 }
 
 /// Formats a float in "general" format (format types `g` and `G`).
@@ -1487,7 +1496,7 @@ pub fn format_float_e(f: f64, spec: &ParsedFormatSpec, uppercase: bool) -> Strin
 ///
 /// Unlike `f` and `e` formats, trailing zeros are stripped from the result.
 /// Default precision is 6, but minimum is 1 significant digit.
-pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
+pub fn format_float_g(f: f64, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     let is_negative = f.is_sign_negative() && !f.is_nan();
     // `G` (and only `G`) uppercases the exponent marker and `inf`/`nan`.
     let uppercase = spec.type_char == Some(TypeChar::GUpper);
@@ -1497,7 +1506,7 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
         // `z` never coerces a non-finite value (`word` has no digits), so the
         // sign is `"-"` for `-inf` as usual.
         let sign = numeric_sign(is_negative, word, spec);
-        return pad_signed_numeric(sign, "", word, spec);
+        return pad_signed_numeric(sign, "", word, spec, tracker);
     }
 
     let precision = spec.precision.unwrap_or(6).max(1);
@@ -1546,11 +1555,14 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
             // precision: let `fmt_float_exp` synthesise the digits beyond Rust's
             // formatter cap, then normalise the exponent (`e+06`). Bounded by the
             // precision pre-check in `format_with_spec`.
-            fix_exp_format(&fmt_float_exp(abs_val, exp_prec, uppercase))
+            fix_exp_format(&fmt_float_exp(abs_val, exp_prec, uppercase, tracker)?, tracker)?
         } else {
             // Plain `g` strips trailing zeros, so mantissa digits beyond the cap
             // would be dropped anyway — cap to avoid generating them.
-            strip_trailing_zeros_exp(&fmt_float_exp(abs_val, exp_prec.min(MAX_FMT_PRECISION_EXP), uppercase))
+            strip_trailing_zeros_exp(
+                &fmt_float_exp(abs_val, exp_prec.min(MAX_FMT_PRECISION_EXP), uppercase, tracker)?,
+                tracker,
+            )?
         }
     } else {
         let sig_digits = if exp < 0 {
@@ -1562,7 +1574,7 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
             // `#` keeps the trailing zeros, so the digit count scales with
             // precision; `fmt_float_fixed` synthesises any beyond the formatter
             // cap (bounded by the precision pre-check in `format_with_spec`).
-            fmt_float_fixed(abs_val, sig_digits)
+            fmt_float_fixed(abs_val, sig_digits, tracker)?
         } else {
             // Plain `g` strips trailing zeros, so digits beyond the cap would be
             // dropped anyway — cap before formatting.
@@ -1584,7 +1596,7 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
     };
 
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    pad_signed_numeric(sign, "", &abs_str, spec)
+    pad_signed_numeric(sign, "", &abs_str, spec, tracker)
 }
 
 /// Formats a float with the *default* presentation — no type char and no
@@ -1599,14 +1611,14 @@ pub fn format_float_g(f: f64, spec: &ParsedFormatSpec) -> String {
 /// Unlike the repr/str path this needs an owned `String` (the result is
 /// post-processed by `maybe_alternate_point` and then padded), so it
 /// materializes [`FormatFloat`] via `to_string` rather than streaming.
-fn format_float_default(f: f64, spec: &ParsedFormatSpec) -> String {
+fn format_float_default(f: f64, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     let is_negative = f.is_sign_negative() && !f.is_nan();
     let abs_val = f.abs();
     // The alternate form (`#`) still forces a decimal point on the repr digits,
     // even in scientific notation (`format(1e20, '#')` → `'1.e+20'`).
     let abs_str = maybe_alternate_point(FormatFloat(abs_val).to_string(), abs_val, spec);
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    pad_signed_numeric(sign, "", &abs_str, spec)
+    pad_signed_numeric(sign, "", &abs_str, spec, tracker)
 }
 
 /// Applies ASCII conversion to a string (escapes non-ASCII characters).
@@ -1637,7 +1649,7 @@ pub fn ascii_escape(s: &str) -> String {
 ///
 /// Multiplies the value by 100 and appends a `%` sign. Uses fixed-point notation
 /// with `precision` decimal places (default 6). For example, `0.1234` becomes `12.340000%`.
-pub fn format_float_percent(f: f64, spec: &ParsedFormatSpec) -> String {
+pub fn format_float_percent(f: f64, spec: &ParsedFormatSpec, tracker: &ResourceTracker) -> RunResult<String> {
     let percent_val = f * 100.0;
     let is_negative = percent_val.is_sign_negative() && !percent_val.is_nan();
     // The `%` presentation has no uppercase variant, so `inf`/`nan` stay lower.
@@ -1645,12 +1657,16 @@ pub fn format_float_percent(f: f64, spec: &ParsedFormatSpec) -> String {
         format!("{word}%")
     } else {
         let abs_val = percent_val.abs();
-        let abs_str = format!("{}%", fmt_float_fixed(abs_val, spec.precision.unwrap_or(6)));
+        let digits = fmt_float_fixed(abs_val, spec.precision.unwrap_or(6), tracker)?;
+        let mut output = format_builder(digits.len().saturating_add(1), tracker)?;
+        push_format_str(&mut output, &digits, tracker)?;
+        output.push('%')?;
+        let abs_str = output.finish_raw()?;
         // `#` forces the point before the `%` (`#.0%` → `50.%`).
         maybe_alternate_point(abs_str, abs_val, spec)
     };
     let sign = numeric_sign(is_negative, &abs_str, spec);
-    pad_signed_numeric(sign, "", &abs_str, spec)
+    pad_signed_numeric(sign, "", &abs_str, spec, tracker)
 }
 
 // ============================================================================
@@ -1772,20 +1788,26 @@ fn maybe_alternate_point(abs_str: String, abs_val: f64, spec: &ParsedFormatSpec)
 /// integer digits before padding — see [`pad_signed_grouped`]. When
 /// `spec.frac_grouping` is set, the fractional digits are grouped first (a
 /// no-op for values with no fractional part, e.g. integers).
-fn pad_signed_numeric(sign: &str, prefix: &str, abs_str: &str, spec: &ParsedFormatSpec) -> String {
+fn pad_signed_numeric(
+    sign: &str,
+    prefix: &str,
+    abs_str: &str,
+    spec: &ParsedFormatSpec,
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
     // Fractional grouping is applied up front so the integer-grouping/padding
     // below treats the grouped fraction as an opaque suffix.
     let frac_grouped;
     let abs_str = if let Some(g) = spec.frac_grouping {
-        frac_grouped = insert_frac_grouping(abs_str, g.separator());
+        frac_grouped = insert_frac_grouping(abs_str, g.separator(), tracker)?;
         frac_grouped.as_str()
     } else {
         abs_str
     };
     let align = spec.align.unwrap_or(Align::Right);
     match spec.grouping {
-        None => pad_signed_ungrouped(sign, prefix, abs_str, align, spec),
-        Some(grouping) => pad_signed_grouped(sign, prefix, abs_str, align, grouping, spec),
+        None => pad_signed_ungrouped(sign, prefix, abs_str, align, spec, tracker),
+        Some(grouping) => pad_signed_grouped(sign, prefix, abs_str, align, grouping, spec, tracker),
     }
 }
 
@@ -1798,24 +1820,28 @@ fn pad_signed_numeric(sign: &str, prefix: &str, abs_str: &str, spec: &ParsedForm
 /// when the string has no fractional part (e.g. an integer), so it is safe to
 /// call unconditionally from [`pad_signed_numeric`]. Output size is bounded by
 /// the (already tracked) input length plus one separator per three digits.
-fn insert_frac_grouping(s: &str, sep: char) -> String {
-    let Some(dot) = s.find('.') else {
-        return s.to_owned();
+fn insert_frac_grouping(s: &str, sep: char, tracker: &ResourceTracker) -> RunResult<String> {
+    let (after, frac_len) = if let Some(dot) = s.find('.') {
+        let after = dot + 1;
+        let frac_len = s[after..]
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(s.len() - after);
+        (after, frac_len)
+    } else {
+        (s.len(), 0)
     };
-    let after = dot + 1;
-    let frac_len = s[after..]
-        .find(|c: char| !c.is_ascii_digit())
-        .unwrap_or(s.len() - after);
-    let mut out = String::with_capacity(s.len() + frac_len / 3);
-    out.push_str(&s[..after]);
+    let separators = frac_len.saturating_sub(1) / 3;
+    let mut out = format_builder(s.len().saturating_add(separators), tracker)?;
+    push_format_str(&mut out, &s[..after], tracker)?;
     for (i, c) in s[after..after + frac_len].chars().enumerate() {
+        tracker.check_time_every(i)?;
         if i > 0 && i.is_multiple_of(3) {
-            out.push(sep);
+            out.push(sep)?;
         }
-        out.push(c);
+        out.push(c)?;
     }
-    out.push_str(&s[after + frac_len..]);
-    out
+    push_format_str(&mut out, &s[after + frac_len..], tracker)?;
+    out.finish_raw()
 }
 
 /// Padding for a signed numeric with no thousands grouping (the common case).
@@ -1823,21 +1849,15 @@ fn insert_frac_grouping(s: &str, sep: char) -> String {
 /// Handles the three modes documented on [`pad_signed_numeric`]: `0`-flag
 /// zero-padding, `=` sign-aware fill, and ordinary outside padding. `prefix`
 /// (the `#` base marker or `""`) is emitted right after the sign in every mode.
-fn pad_signed_ungrouped(sign: &str, prefix: &str, abs_str: &str, align: Align, spec: &ParsedFormatSpec) -> String {
-    if spec.zero_pad || align == Align::SignAware {
-        let fill = if spec.zero_pad { '0' } else { spec.fill };
-        let total_len = sign.len() + prefix.len() + abs_str.len();
-        if spec.width > total_len {
-            let padding = spec.width - total_len;
-            let pad_str: String = iter::repeat_n(fill, padding).collect();
-            format!("{sign}{prefix}{pad_str}{abs_str}")
-        } else {
-            format!("{sign}{prefix}{abs_str}")
-        }
-    } else {
-        let value = format!("{sign}{prefix}{abs_str}");
-        pad_string(&value, spec.width, align, spec.fill)
-    }
+fn pad_signed_ungrouped(
+    sign: &str,
+    prefix: &str,
+    abs_str: &str,
+    align: Align,
+    spec: &ParsedFormatSpec,
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
+    pad_signed_parts(sign, prefix, abs_str, "", align, spec, tracker)
 }
 
 /// Padding for a signed numeric with a thousands separator (`,` or `_`).
@@ -1858,7 +1878,8 @@ fn pad_signed_grouped(
     align: Align,
     grouping: Grouping,
     spec: &ParsedFormatSpec,
-) -> String {
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
     let sep = grouping.separator();
     let is_base = matches!(
         spec.type_char,
@@ -1880,32 +1901,95 @@ fn pad_signed_grouped(
     // no commas). Delegating here also avoids `insert_grouping` underflowing
     // on an empty digit string.
     if int_digits.is_empty() {
-        return pad_signed_ungrouped(sign, prefix, abs_str, align, spec);
+        return pad_signed_ungrouped(sign, prefix, abs_str, align, spec, tracker);
     }
 
-    if spec.zero_pad {
+    let min_int_width = if spec.zero_pad {
         // Grow the integer part with grouped leading zeros until the whole
         // field (sign + prefix + grouped digits + suffix) reaches the width.
         let reserved = sign.len() + prefix.len() + suffix.len();
-        let min_int_width = spec.width.saturating_sub(reserved);
-        let grouped = insert_grouping(int_digits, group_size, sep, min_int_width);
-        format!("{sign}{prefix}{grouped}{suffix}")
-    } else if align == Align::SignAware {
-        // `=` with a non-`0` fill: group normally, then insert fill (never
-        // grouped) between the prefix and the value.
-        let body = format!("{}{suffix}", insert_grouping(int_digits, group_size, sep, 0));
-        let total_len = sign.len() + prefix.len() + body.len();
-        if spec.width > total_len {
-            let pad_str: String = iter::repeat_n(spec.fill, spec.width - total_len).collect();
-            format!("{sign}{prefix}{pad_str}{body}")
-        } else {
-            format!("{sign}{prefix}{body}")
-        }
+        spec.width.saturating_sub(reserved)
     } else {
-        let grouped = insert_grouping(int_digits, group_size, sep, 0);
-        let value = format!("{sign}{prefix}{grouped}{suffix}");
-        pad_string(&value, spec.width, align, spec.fill)
+        0
+    };
+    let grouped = insert_grouping(int_digits, group_size, sep, min_int_width, tracker)?;
+    pad_signed_parts(sign, prefix, &grouped, suffix, align, spec, tracker)
+}
+
+/// Builds a signed value and its padding into one tracked buffer.
+fn pad_signed_parts(
+    sign: &str,
+    prefix: &str,
+    body: &str,
+    suffix: &str,
+    align: Align,
+    spec: &ParsedFormatSpec,
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
+    tracker.check_time()?;
+    let value_len = sign.len() + prefix.len() + body.len() + suffix.len();
+    let padding = spec.width.saturating_sub(value_len);
+    let fill = if spec.zero_pad { '0' } else { spec.fill };
+    let capacity = sign
+        .len()
+        .saturating_add(prefix.len())
+        .saturating_add(body.len())
+        .saturating_add(suffix.len())
+        .saturating_add(padding.saturating_mul(fill.len_utf8()));
+    let mut output = format_builder(capacity, tracker)?;
+
+    if spec.zero_pad || align == Align::SignAware {
+        output.push_str(sign)?;
+        output.push_str(prefix)?;
+        push_padding(&mut output, fill, padding, tracker)?;
+        push_format_str(&mut output, body, tracker)?;
+        push_format_str(&mut output, suffix, tracker)?;
+    } else {
+        let left = match align {
+            Align::Left => 0,
+            Align::Right => padding,
+            Align::Center => padding / 2,
+            Align::SignAware => unreachable!(),
+        };
+        push_padding(&mut output, fill, left, tracker)?;
+        output.push_str(sign)?;
+        output.push_str(prefix)?;
+        push_format_str(&mut output, body, tracker)?;
+        push_format_str(&mut output, suffix, tracker)?;
+        push_padding(&mut output, fill, padding - left, tracker)?;
     }
+    output.finish_raw()
+}
+
+/// Appends repeated fill while polling long writes for time limits.
+fn push_padding(output: &mut StringBuilder<'_>, fill: char, count: usize, tracker: &ResourceTracker) -> RunResult<()> {
+    for i in 0..count {
+        tracker.check_time_every(i)?;
+        output.push(fill)?;
+    }
+    Ok(())
+}
+
+/// Defers large timed allocations so emission can poll before reserving the full result.
+fn format_builder(capacity: usize, tracker: &ResourceTracker) -> RunResult<StringBuilder<'_>> {
+    if capacity > LARGE_RESULT_THRESHOLD && tracker.max_duration().is_some() {
+        Ok(StringBuilder::new(tracker))
+    } else {
+        Ok(StringBuilder::with_capacity(capacity, tracker)?)
+    }
+}
+
+/// Copies large timed fragments incrementally so the deadline is polled during the copy.
+fn push_format_str(output: &mut StringBuilder<'_>, value: &str, tracker: &ResourceTracker) -> RunResult<()> {
+    if value.len() <= LARGE_RESULT_THRESHOLD || tracker.max_duration().is_none() {
+        output.push_str(value)?;
+    } else {
+        for (i, c) in value.chars().enumerate() {
+            tracker.check_time_every(i)?;
+            output.push(c)?;
+        }
+    }
+    Ok(())
 }
 
 /// Inserts `sep` between every `group_size` digits of `digits`, counting from
@@ -1919,29 +2003,27 @@ fn pad_signed_grouped(
 /// wide for a width of 8). Callers must pass a non-empty `digits` (numeric
 /// formatters always emit at least one digit, and [`pad_signed_grouped`]
 /// routes non-finite values away before reaching here); the arithmetic is
-/// nonetheless hardened against an empty string so it can never panic. Output
-/// size is bounded by `min_width` (already capped against the resource tracker
-/// via `check_repeat_size` in [`format_with_spec`]), so a plain `String` is
-/// safe here.
-fn insert_grouping(digits: &str, group_size: usize, sep: char, min_width: usize) -> String {
+/// nonetheless hardened against an empty string so it can never panic.
+fn insert_grouping(
+    digits: &str,
+    group_size: usize,
+    sep: char,
+    min_width: usize,
+    tracker: &ResourceTracker,
+) -> RunResult<String> {
+    tracker.check_time()?;
     // `digits` are ASCII (decimal or hex), so byte length == char count.
     let ndigits = digits.len();
-    // Grow the total digit count until digits + separators reach `min_width`.
-    // `saturating_sub` guards the `total == 0` case defensively: callers must
-    // pass a non-empty `digits`, but an empty string would otherwise underflow
-    // here, and an underflow on attacker-controlled format specs is a host
-    // panic (a sandbox DoS) we must never risk.
-    let mut total = ndigits;
-    while total + total.saturating_sub(1) / group_size < min_width {
-        total += 1;
-    }
+    let total = grouped_digit_count(ndigits, group_size, min_width);
     let zeros = total - ndigits;
 
-    let mut out = String::with_capacity(total + total.saturating_sub(1) / group_size);
+    let capacity = total.saturating_add(total.saturating_sub(1) / group_size);
+    let mut out = format_builder(capacity, tracker)?;
     let mut digit_chars = digits.chars();
     for i in 0..total {
+        tracker.check_time_every(i)?;
         if i > 0 && (total - i).is_multiple_of(group_size) {
-            out.push(sep);
+            out.push(sep)?;
         }
         // The first `zeros` positions are synthesised leading zeros; the rest
         // consume the original digit string left-to-right.
@@ -1949,12 +2031,18 @@ fn insert_grouping(digits: &str, group_size: usize, sep: char, min_width: usize)
             '0'
         } else {
             digit_chars.next().expect("digit_chars yields exactly ndigits items")
-        });
+        })?;
     }
-    out
+    out.finish_raw()
 }
 
-/// Consumes a run of ASCII digits and folds them into a decimal [`usize`].
+/// Returns the smallest count at least `ndigits` whose grouped width reaches `min_width`.
+fn grouped_digit_count(ndigits: usize, group_size: usize, min_width: usize) -> usize {
+    let required = min_width.saturating_sub(min_width.saturating_sub(1) / (group_size + 1));
+    ndigits.max(required)
+}
+
+/// Consumes a run of Unicode decimal digits and folds them into a [`usize`].
 ///
 /// Returns `Ok(None)` when no digit is present, `Ok(Some(n))` for a parsed
 /// number, and `Err(())` if accumulating would overflow [`usize`]. Used for
@@ -1966,16 +2054,32 @@ fn insert_grouping(digits: &str, group_size: usize, sep: char, min_width: usize)
 /// can bail with a parse error rather than silently clamping to 0.
 fn consume_decimal_usize(chars: &mut Peekable<impl Iterator<Item = char>>) -> Result<Option<usize>, ()> {
     let mut value: Option<usize> = None;
-    while let Some(c) = chars.next_if(char::is_ascii_digit) {
-        let digit = c.to_digit(10).expect("char::is_ascii_digit guarantees a 0-9 digit") as usize;
+    while let Some((_, digit)) = chars.next_if_map(|c| decimal_digit_value(c).map_or_else(|| Err(c), |d| Ok((c, d)))) {
         let next = value
             .unwrap_or(0)
             .checked_mul(10)
-            .and_then(|n| n.checked_add(digit))
+            .and_then(|n| n.checked_add(digit as usize))
             .ok_or(())?;
         value = Some(next);
     }
     Ok(value)
+}
+
+/// Returns the numeric value of a Unicode decimal digit.
+pub(crate) fn decimal_digit_value(character: char) -> Option<u32> {
+    if get_general_category(character) != GeneralCategory::DecimalNumber {
+        return None;
+    }
+
+    let code_point = character as u32;
+    let mut run_start = code_point;
+    while let Some(previous) = run_start.checked_sub(1).and_then(char::from_u32) {
+        if get_general_category(previous) != GeneralCategory::DecimalNumber {
+            break;
+        }
+        run_start -= 1;
+    }
+    Some((code_point - run_start) % 10)
 }
 
 /// Maximum precision Rust's `format!` accepts for fixed-point float formatting
@@ -1998,13 +2102,19 @@ const MAX_FMT_PRECISION_EXP: usize = (u16::MAX as usize) - 1;
 /// For finite values beyond the native limit we format at `MAX_FMT_PRECISION`
 /// and append trailing zeros — f64 precision bottoms out long before this, so
 /// every additional digit Python would emit is a zero anyway.
-fn fmt_float_fixed(abs_val: f64, precision: usize) -> String {
+fn fmt_float_fixed(abs_val: f64, precision: usize, tracker: &ResourceTracker) -> RunResult<String> {
     if precision <= MAX_FMT_PRECISION || !abs_val.is_finite() {
-        return format!("{abs_val:.precision$}");
+        return Ok(format!("{abs_val:.precision$}"));
     }
-    let mut s = format!("{abs_val:.MAX_FMT_PRECISION$}");
-    s.extend(iter::repeat_n('0', precision - MAX_FMT_PRECISION));
-    s
+    let base = format!("{abs_val:.MAX_FMT_PRECISION$}");
+    let extra = precision - MAX_FMT_PRECISION;
+    let mut output = format_builder(base.len().saturating_add(extra), tracker)?;
+    output.push_str(&base)?;
+    for i in 0..extra {
+        tracker.check_time_every(i)?;
+        output.push('0')?;
+    }
+    output.finish_raw()
 }
 
 /// Formats a float in exponential notation at an arbitrary precision.
@@ -2012,13 +2122,13 @@ fn fmt_float_fixed(abs_val: f64, precision: usize) -> String {
 /// Same precision-capping strategy as `fmt_float_fixed`, but trailing zeros
 /// are injected into the mantissa (before the exponent marker) rather than
 /// appended to the end.
-fn fmt_float_exp(abs_val: f64, precision: usize, uppercase: bool) -> String {
+fn fmt_float_exp(abs_val: f64, precision: usize, uppercase: bool, tracker: &ResourceTracker) -> RunResult<String> {
     if precision <= MAX_FMT_PRECISION_EXP || !abs_val.is_finite() {
-        return if uppercase {
+        return Ok(if uppercase {
             format!("{abs_val:.precision$E}")
         } else {
             format!("{abs_val:.precision$e}")
-        };
+        });
     }
     let base = if uppercase {
         format!("{abs_val:.MAX_FMT_PRECISION_EXP$E}")
@@ -2029,10 +2139,16 @@ fn fmt_float_exp(abs_val: f64, precision: usize, uppercase: bool) -> String {
     // Inject padding zeros immediately before the exponent marker.
     if let Some(e_pos) = base.find(['e', 'E']) {
         let (mantissa, exp_part) = base.split_at(e_pos);
-        let zeros: String = iter::repeat_n('0', extra).collect();
-        format!("{mantissa}{zeros}{exp_part}")
+        let mut output = format_builder(base.len().saturating_add(extra), tracker)?;
+        output.push_str(mantissa)?;
+        for i in 0..extra {
+            tracker.check_time_every(i)?;
+            output.push('0')?;
+        }
+        output.push_str(exp_part)?;
+        output.finish_raw()
     } else {
-        base
+        Ok(base)
     }
 }
 
@@ -2044,50 +2160,27 @@ fn fmt_float_exp(abs_val: f64, precision: usize, uppercase: bool) -> String {
 /// `=` to right-align since chars have no sign. Routing a SignAware value
 /// here would silently drop width, which `debug_assert!` catches in test
 /// builds; release builds degrade to no-op padding as a safety net.
-fn pad_string(value: &str, width: usize, align: Align, fill: char) -> String {
+fn pad_string(value: &str, width: usize, align: Align, fill: char, tracker: &ResourceTracker) -> RunResult<String> {
     debug_assert!(
         align != Align::SignAware,
         "pad_string received Align::SignAware; callers must handle `=` themselves \
          (numeric formatters via pad_signed_numeric, format_char by mapping to Right)"
     );
     let value_len = value.chars().count();
-    if width <= value_len {
-        return value.to_owned();
-    }
-
-    let padding = width - value_len;
-
-    match align {
-        Align::Left => {
-            let mut s = value.to_owned();
-            for _ in 0..padding {
-                s.push(fill);
-            }
-            s
-        }
-        Align::Right => {
-            let mut s = String::new();
-            for _ in 0..padding {
-                s.push(fill);
-            }
-            s.push_str(value);
-            s
-        }
-        Align::Center => {
-            let left_pad = padding / 2;
-            let right_pad = padding - left_pad;
-            let mut s = String::new();
-            for _ in 0..left_pad {
-                s.push(fill);
-            }
-            s.push_str(value);
-            for _ in 0..right_pad {
-                s.push(fill);
-            }
-            s
-        }
-        Align::SignAware => value.to_owned(),
-    }
+    let padding = width.saturating_sub(value_len);
+    let (left, right) = match align {
+        Align::Left => (0, padding),
+        Align::Right => (padding, 0),
+        Align::Center => (padding / 2, padding - padding / 2),
+        Align::SignAware => (0, 0),
+    };
+    tracker.check_time()?;
+    let capacity = value.len().saturating_add(padding.saturating_mul(fill.len_utf8()));
+    let mut output = format_builder(capacity, tracker)?;
+    push_padding(&mut output, fill, left, tracker)?;
+    output.push_str(value)?;
+    push_padding(&mut output, fill, right, tracker)?;
+    output.finish_raw()
 }
 
 /// Strips trailing zeros from a decimal float string.
@@ -2112,14 +2205,17 @@ fn strip_trailing_zeros(s: &str) -> String {
 /// Splits the string at `e` or `E`, strips zeros from the mantissa part,
 /// then recombines with the exponent. Also normalizes the exponent format
 /// to Python's convention (sign and at least 2 digits).
-fn strip_trailing_zeros_exp(s: &str) -> String {
+fn strip_trailing_zeros_exp(s: &str, tracker: &ResourceTracker) -> RunResult<String> {
     if let Some(e_pos) = s.find(['e', 'E']) {
         let (mantissa, exp_part) = s.split_at(e_pos);
         let trimmed_mantissa = strip_trailing_zeros(mantissa);
-        let fixed_exp = fix_exp_format(exp_part);
-        format!("{trimmed_mantissa}{fixed_exp}")
+        let fixed_exp = fix_exp_format(exp_part, tracker)?;
+        let mut output = format_builder(trimmed_mantissa.len().saturating_add(fixed_exp.len()), tracker)?;
+        output.push_str(&trimmed_mantissa)?;
+        output.push_str(&fixed_exp)?;
+        output.finish_raw()
     } else {
-        strip_trailing_zeros(s)
+        Ok(strip_trailing_zeros(s))
     }
 }
 
@@ -2129,10 +2225,12 @@ fn strip_trailing_zeros_exp(s: &str) -> String {
 /// This function ensures the exponent has:
 /// 1. A sign character ('+' or '-')
 /// 2. At least 2 digits
-fn fix_exp_format(s: &str) -> String {
+fn fix_exp_format(s: &str, tracker: &ResourceTracker) -> RunResult<String> {
     // Find the 'e' or 'E' marker
     let Some(e_pos) = s.find(['e', 'E']) else {
-        return s.to_owned();
+        let mut output = format_builder(s.len(), tracker)?;
+        push_format_str(&mut output, s, tracker)?;
+        return output.finish_raw();
     };
 
     let (before_e, e_and_rest) = s.split_at(e_pos);
@@ -2149,11 +2247,75 @@ fn fix_exp_format(s: &str) -> String {
     };
 
     // Ensure at least 2 digits
-    let padded_digits = if digits.len() < 2 {
-        format!("{digits:0>2}")
-    } else {
-        digits.to_owned()
-    };
+    let padding = 2usize.saturating_sub(digits.len());
+    let capacity = before_e
+        .len()
+        .saturating_add(e_char.len_utf8())
+        .saturating_add(sign.len_utf8())
+        .saturating_add(padding)
+        .saturating_add(digits.len());
+    let mut output = format_builder(capacity, tracker)?;
+    push_format_str(&mut output, before_e, tracker)?;
+    output.push(e_char)?;
+    output.push(sign)?;
+    for _ in 0..padding {
+        output.push('0')?;
+    }
+    output.push_str(digits)?;
+    output.finish_raw()
+}
 
-    format!("{before_e}{e_char}{sign}{padded_digits}")
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use monty_types::{LARGE_RESULT_THRESHOLD, ResourceLimits, ResourceTracker};
+
+    use super::{grouped_digit_count, insert_grouping, push_format_str};
+    use crate::{exception_private::RunError, string_builder::StringBuilder};
+
+    #[test]
+    fn grouped_digit_count_inverts_the_grouped_width() {
+        for group_size in [3, 4] {
+            for width in 0..=512 {
+                let total = grouped_digit_count(1, group_size, width);
+                assert!(total + (total - 1) / group_size >= width);
+                if total > 1 {
+                    assert!(total - 1 + (total - 2) / group_size < width);
+                }
+            }
+        }
+
+        let width = isize::MAX as usize;
+        let total = grouped_digit_count(1, 3, width);
+        assert_eq!(total, 3 * (1usize << 61));
+        assert!(total + (total - 1) / 3 >= width);
+        assert!(total - 1 + (total - 2) / 3 < width);
+    }
+
+    #[test]
+    fn grouped_padding_checks_time_before_allocating() {
+        let tracker = ResourceTracker::new(ResourceLimits::default().max_duration(Duration::ZERO));
+        tracker.on_execution_start();
+        let error = insert_grouping("1", 3, ',', isize::MAX as usize, &tracker).unwrap_err();
+        tracker.on_execution_stop();
+        let RunError::UncatchableExc(error) = error else {
+            panic!("expected uncatchable timeout, got {error:?}");
+        };
+        assert!(error.exc.to_string().contains("time limit exceeded"));
+    }
+
+    #[test]
+    fn large_format_fragment_checks_time_during_copy() {
+        let value = "x".repeat(LARGE_RESULT_THRESHOLD + 1);
+        let tracker = ResourceTracker::new(ResourceLimits::default().max_duration(Duration::ZERO));
+        let mut output = StringBuilder::new(&tracker);
+        tracker.on_execution_start();
+        let error = push_format_str(&mut output, &value, &tracker).unwrap_err();
+        tracker.on_execution_stop();
+        let RunError::UncatchableExc(error) = error else {
+            panic!("expected uncatchable timeout, got {error:?}");
+        };
+        assert!(error.exc.to_string().contains("time limit exceeded"));
+    }
 }

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -356,6 +356,14 @@ pub enum ParseFormatSpecReason {
 }
 
 impl ParseFormatSpecReason {
+    /// Whether CPython appends the formatted value's type to this error.
+    pub(crate) fn needs_type_suffix(&self) -> bool {
+        matches!(
+            self,
+            Self::Malformed | Self::NumberOverflow | Self::UnknownFormatCode(_)
+        )
+    }
+
     /// Builds the [`Self::GroupingConflict`] wording for an integer grouping
     /// `g` immediately followed by the unrecognised trailing char `c`,
     /// reproducing CPython's two distinct messages: `Cannot specify both ','
@@ -390,21 +398,6 @@ impl ParseFormatSpecError {
             spec: spec.to_owned(),
             reason,
         }
-    }
-
-    /// Whether the runtime should append `" for object of type 'T'"` to the
-    /// `Display` message, matching CPython's wording.
-    ///
-    /// CPython suffixes the type for `Invalid format specifier` and `Unknown
-    /// format code` but not for `Format specifier missing precision` or the
-    /// `Cannot specify …` grouping conflicts, which are self-contained.
-    pub fn needs_type_suffix(&self) -> bool {
-        matches!(
-            self.reason,
-            ParseFormatSpecReason::Malformed
-                | ParseFormatSpecReason::NumberOverflow
-                | ParseFormatSpecReason::UnknownFormatCode(_)
-        )
     }
 
     /// Whether this error should be deferred to the runtime (dynamic-spec) path
@@ -444,15 +437,12 @@ impl fmt::Display for ParseFormatSpecError {
     }
 }
 
-impl FromStr for ParsedFormatSpec {
-    type Err = ParseFormatSpecError;
-
+impl ParsedFormatSpec {
     /// Parses a format specification string into its components.
     ///
-    /// Returns a [`ParseFormatSpecError`] for malformed specs, specs that
-    /// rely on flags Monty doesn't implement yet (`#`), or specs whose
-    /// width/precision overflows [`usize`].
-    fn from_str(spec: &str) -> Result<Self, Self::Err> {
+    /// Runtime callers keep the reason separate from the borrowed source so a
+    /// failed parse does not duplicate a guest-sized format spec.
+    pub(crate) fn parse_runtime(spec: &str) -> Result<Self, ParseFormatSpecReason> {
         if spec.is_empty() {
             return Ok(Self {
                 fill: ' ',
@@ -509,7 +499,7 @@ impl FromStr for ParsedFormatSpec {
 
         // Parse width
         result.width = consume_decimal_usize(&mut chars)
-            .map_err(|()| ParseFormatSpecError::new(spec, ParseFormatSpecReason::NumberOverflow))?
+            .map_err(|()| ParseFormatSpecReason::NumberOverflow)?
             .unwrap_or(0);
 
         // Grouping option (`,` or `_` thousands separator). Whether it's
@@ -527,8 +517,7 @@ impl FromStr for ParsedFormatSpec {
         // digits; its legality for the presentation type is checked at format
         // time alongside the integer grouping.
         if chars.next_if_eq(&'.').is_some() {
-            result.precision = consume_decimal_usize(&mut chars)
-                .map_err(|()| ParseFormatSpecError::new(spec, ParseFormatSpecReason::NumberOverflow))?;
+            result.precision = consume_decimal_usize(&mut chars).map_err(|()| ParseFormatSpecReason::NumberOverflow)?;
             result.frac_grouping = chars.next_if(|c| matches!(c, ',' | '_')).map(|c| match c {
                 ',' => Grouping::Comma,
                 _ => Grouping::Underscore,
@@ -536,7 +525,7 @@ impl FromStr for ParsedFormatSpec {
             // A `.` must introduce either precision digits or a fractional
             // grouping option; `.f`/`.`/`.d` are CPython's "missing precision".
             if result.precision.is_none() && result.frac_grouping.is_none() {
-                return Err(ParseFormatSpecError::new(spec, ParseFormatSpecReason::MissingPrecision));
+                return Err(ParseFormatSpecReason::MissingPrecision);
             }
         }
 
@@ -548,7 +537,7 @@ impl FromStr for ParsedFormatSpec {
         // are genuinely malformed.
         let type_pos = chars.next();
         if chars.peek().is_some() {
-            return Err(ParseFormatSpecError::new(spec, ParseFormatSpecReason::Malformed));
+            return Err(ParseFormatSpecReason::Malformed);
         }
         if let Some(c) = type_pos {
             if let Some(tc) = TypeChar::from_char(c) {
@@ -561,11 +550,19 @@ impl FromStr for ParsedFormatSpec {
                     Some(g) => ParseFormatSpecReason::grouping_conflict(g, c),
                     None => ParseFormatSpecReason::UnknownFormatCode(c),
                 };
-                return Err(ParseFormatSpecError::new(spec, reason));
+                return Err(reason);
             }
         }
 
         Ok(result)
+    }
+}
+
+impl FromStr for ParsedFormatSpec {
+    type Err = ParseFormatSpecError;
+
+    fn from_str(spec: &str) -> Result<Self, Self::Err> {
+        Self::parse_runtime(spec).map_err(|reason| ParseFormatSpecError::new(spec, reason))
     }
 }
 

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -32,6 +32,7 @@ mod run;
 mod run_progress;
 mod sorting;
 mod source_map;
+mod str_format;
 mod string_builder;
 mod stringize;
 mod types;

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -4,7 +4,8 @@ use crate::exception_private::{RunError, SimpleException};
 
 const MAX_NATIVE_ALLOCATION: usize = isize::MAX as usize;
 
-/// Rejects capacities that Rust's native string types cannot represent.
+/// Rejects capacities above `isize::MAX`: `String::with_capacity` panics on them
+/// before the allocator can refuse, so `StringBuilder` fences them.
 pub(crate) fn check_native_allocation_size(size: usize) -> Result<(), ResourceError> {
     if size > MAX_NATIVE_ALLOCATION {
         Err(ResourceError::Memory {
@@ -110,7 +111,6 @@ pub fn check_replace_size(
 /// Only calls the tracker when the estimate exceeds `LARGE_RESULT_THRESHOLD`
 /// to avoid overhead on small operations.
 pub(crate) fn check_estimated_size(estimated_bytes: usize, tracker: &ResourceTracker) -> Result<(), ResourceError> {
-    check_native_allocation_size(estimated_bytes)?;
     if estimated_bytes > LARGE_RESULT_THRESHOLD {
         tracker.check_large_result(estimated_bytes)?;
     }

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -4,6 +4,7 @@ use crate::exception_private::{RunError, SimpleException};
 
 const MAX_NATIVE_ALLOCATION: usize = isize::MAX as usize;
 
+/// Rejects capacities that Rust's native string types cannot represent.
 pub(crate) fn check_native_allocation_size(size: usize) -> Result<(), ResourceError> {
     if size > MAX_NATIVE_ALLOCATION {
         Err(ResourceError::Memory {

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -2,6 +2,19 @@ use monty_types::{ExcType, LARGE_RESULT_THRESHOLD, ResourceError, ResourceTracke
 
 use crate::exception_private::{RunError, SimpleException};
 
+const MAX_NATIVE_ALLOCATION: usize = isize::MAX as usize;
+
+pub(crate) fn check_native_allocation_size(size: usize) -> Result<(), ResourceError> {
+    if size > MAX_NATIVE_ALLOCATION {
+        Err(ResourceError::Memory {
+            limit: MAX_NATIVE_ALLOCATION,
+            used: size,
+        })
+    } else {
+        Ok(())
+    }
+}
+
 /// Pre-checks that an operation producing `item_len * count` bytes won't exceed resource limits.
 ///
 /// Used for sequence repeats (`'x' * 999_999_999`), padding operations
@@ -96,6 +109,7 @@ pub fn check_replace_size(
 /// Only calls the tracker when the estimate exceeds `LARGE_RESULT_THRESHOLD`
 /// to avoid overhead on small operations.
 pub(crate) fn check_estimated_size(estimated_bytes: usize, tracker: &ResourceTracker) -> Result<(), ResourceError> {
+    check_native_allocation_size(estimated_bytes)?;
     if estimated_bytes > LARGE_RESULT_THRESHOLD {
         tracker.check_large_result(estimated_bytes)?;
     }

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -2,21 +2,6 @@ use monty_types::{ExcType, LARGE_RESULT_THRESHOLD, ResourceError, ResourceTracke
 
 use crate::exception_private::{RunError, SimpleException};
 
-const MAX_NATIVE_ALLOCATION: usize = isize::MAX as usize;
-
-/// Rejects capacities above `isize::MAX`: `String::with_capacity` panics on them
-/// before the allocator can refuse, so `StringBuilder` fences them.
-pub(crate) fn check_native_allocation_size(size: usize) -> Result<(), ResourceError> {
-    if size > MAX_NATIVE_ALLOCATION {
-        Err(ResourceError::Memory {
-            limit: MAX_NATIVE_ALLOCATION,
-            used: size,
-        })
-    } else {
-        Ok(())
-    }
-}
-
 /// Pre-checks that an operation producing `item_len * count` bytes won't exceed resource limits.
 ///
 /// Used for sequence repeats (`'x' * 999_999_999`), padding operations

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -86,9 +86,11 @@ fn render(
     let mut output = String::new();
     let mut literal_start = 0;
     let mut index = 0;
+    let mut steps = 0;
 
     while index < bytes.len() {
-        vm.heap.tracker.check_time_every(index)?;
+        vm.heap.tracker.check_time_every(steps)?;
+        steps += 1;
         match bytes[index] {
             b'{' => {
                 output = push_tracked(output, &template[literal_start..index], vm)?;

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -1,3 +1,5 @@
+//! Runtime replacement-field handling for `str.format()`.
+
 use std::fmt;
 
 use unicode_general_category::{GeneralCategory, get_general_category};
@@ -15,6 +17,7 @@ use crate::{
 
 const MAX_FORMAT_RECURSION: u8 = 2;
 
+/// Renders a runtime format string with positional and keyword arguments.
 pub(crate) fn str_format(template: &str, args: ArgValues, vm: &mut VM<'_>) -> RunResult<Value> {
     let FormatCallArgs { positional, keywords } = FormatCallArgs::from_args(args, vm)?;
     let keywords = match keywords {
@@ -29,6 +32,7 @@ pub(crate) fn str_format(template: &str, args: ArgValues, vm: &mut VM<'_>) -> Ru
     Ok(allocate_string(rendered, vm.heap))
 }
 
+/// Arguments accepted by `str.format()`.
 #[derive(FromArgs)]
 #[from_args(name = "format")]
 struct FormatCallArgs {
@@ -38,6 +42,7 @@ struct FormatCallArgs {
     keywords: KwargsValues,
 }
 
+/// Owns call arguments until rendering and error cleanup have finished.
 struct FormatArguments {
     positional: Vec<Value>,
     keywords: Vec<(Value, Value)>,
@@ -53,12 +58,14 @@ impl<C: ContainsHeap> DropWithContext<C> for FormatArguments {
     }
 }
 
+/// Tracks field numbering across nested format specs.
 #[derive(Default)]
 struct Numbering {
     mode: NumberingMode,
     next_auto: usize,
 }
 
+/// Enforces Python's rule against mixing automatic and manual numbering.
 #[derive(Default)]
 enum NumberingMode {
     #[default]
@@ -67,6 +74,7 @@ enum NumberingMode {
     Manual,
 }
 
+/// Renders one format-string level within the recursion and resource limits.
 fn render(
     template: &str,
     arguments: &FormatArguments,
@@ -118,6 +126,7 @@ fn render(
     push_tracked(output, &template[literal_start..], vm)
 }
 
+/// Resolves and formats one replacement field in CPython error order.
 fn render_field(
     template: &str,
     start: usize,
@@ -200,6 +209,7 @@ fn render_field(
     }
 }
 
+/// Finds the first field delimiter outside an item lookup.
 fn find_field_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<(usize, u8)> {
     let bytes = template.as_bytes();
     let mut index = start;
@@ -219,6 +229,7 @@ fn find_field_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<(usize
     Err(value_error("expected '}' before end of string"))
 }
 
+/// Finds the closing brace for a possibly nested format spec.
 fn find_spec_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<usize> {
     let bytes = template.as_bytes();
     let mut index = start;
@@ -237,6 +248,7 @@ fn find_spec_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<usize> 
     Err(value_error("unmatched '{' in format spec"))
 }
 
+/// Resolves a root argument followed by attribute or item accesses.
 fn resolve_field(
     field: &str,
     arguments: &FormatArguments,
@@ -296,6 +308,7 @@ fn resolve_field(
     Ok(value.into_inner())
 }
 
+/// Resolves the root argument and updates the field-numbering mode.
 fn resolve_first(
     field: &str,
     arguments: &FormatArguments,
@@ -320,6 +333,7 @@ fn resolve_first(
     }
 }
 
+/// Resolves the next automatic positional field.
 fn resolve_auto(arguments: &FormatArguments, numbering: &mut Numbering, vm: &VM<'_>) -> RunResult<Value> {
     if matches!(numbering.mode, NumberingMode::Manual) {
         return Err(value_error(
@@ -335,6 +349,7 @@ fn resolve_auto(arguments: &FormatArguments, numbering: &mut Numbering, vm: &VM<
     resolve_positional(index, arguments, vm)
 }
 
+/// Clones a positional argument or raises the replacement-index error.
 fn resolve_positional(index: usize, arguments: &FormatArguments, vm: &VM<'_>) -> RunResult<Value> {
     arguments
         .positional
@@ -349,6 +364,7 @@ fn resolve_positional(index: usize, arguments: &FormatArguments, vm: &VM<'_>) ->
         })
 }
 
+/// Clones a keyword argument or raises `KeyError`.
 fn resolve_keyword(name: &str, arguments: &FormatArguments, vm: &mut VM<'_>) -> RunResult<Value> {
     for (index, (key, value)) in arguments.keywords.iter().enumerate() {
         vm.heap.tracker.check_time_every(index)?;
@@ -362,6 +378,7 @@ fn resolve_keyword(name: &str, arguments: &FormatArguments, vm: &mut VM<'_>) -> 
     Err(ExcType::key_error(key, vm))
 }
 
+/// Resolves an attribute without allowing a suspending lookup.
 fn resolve_attribute(value: Value, name: &str, vm: &mut VM<'_>) -> RunResult<Value> {
     defer_drop!(value, vm);
     match value.py_getattr(&EitherStr::Heap(name.to_owned()), vm)? {
@@ -373,6 +390,7 @@ fn resolve_attribute(value: Value, name: &str, vm: &mut VM<'_>) -> RunResult<Val
     }
 }
 
+/// Resolves an integer or string item lookup.
 fn resolve_item(value: Value, item: &str, vm: &mut VM<'_>) -> RunResult<Value> {
     defer_drop!(value, vm);
     let key = item_key(item, vm)?;
@@ -380,6 +398,7 @@ fn resolve_item(value: Value, item: &str, vm: &mut VM<'_>) -> RunResult<Value> {
     value.py_getitem(key, vm)
 }
 
+/// Converts decimal item text to an integer key and other text to a string.
 fn item_key(item: &str, vm: &VM<'_>) -> RunResult<Value> {
     if let Some(index) = decimal_index(item, vm)? {
         Ok(Value::Int(
@@ -390,6 +409,7 @@ fn item_key(item: &str, vm: &VM<'_>) -> RunResult<Value> {
     }
 }
 
+/// Parses Unicode decimal digits using Python's field-index rules.
 fn decimal_index(field: &str, vm: &VM<'_>) -> RunResult<Option<usize>> {
     let mut index = 0usize;
     for (offset, character) in field.chars().enumerate() {
@@ -406,6 +426,7 @@ fn decimal_index(field: &str, vm: &VM<'_>) -> RunResult<Option<usize>> {
     Ok(Some(index))
 }
 
+/// Returns the numeric value of a Unicode decimal digit.
 fn decimal_digit_value(character: char) -> Option<u32> {
     if get_general_category(character) != GeneralCategory::DecimalNumber {
         return None;
@@ -423,12 +444,14 @@ fn decimal_digit_value(character: char) -> Option<u32> {
     Some((code_point - run_start) % 10)
 }
 
+/// Appends a fragment while preserving `StringBuilder` resource accounting.
 fn push_tracked(output: String, text: &str, vm: &VM<'_>) -> RunResult<String> {
     let mut builder = StringBuilder::from_existing(output, &vm.heap.tracker);
     builder.push_str(text)?;
     builder.finish_raw()
 }
 
+/// Builds a `ValueError` for a malformed format string.
 fn value_error(message: impl fmt::Display) -> RunError {
     SimpleException::new_msg(ExcType::ValueError, message).into()
 }

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use num_bigint::BigInt;
 use unicode_general_category::{GeneralCategory, get_general_category};
 
 use crate::{
@@ -8,9 +7,9 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    heap::{ContainsHeap, DropWithContext},
+    heap::{ContainsHeap, DropGuard, DropWithContext},
     string_builder::StringBuilder,
-    types::{LongInt, PyTrait, str::allocate_string},
+    types::{PyTrait, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -133,9 +132,6 @@ fn render_field(
         let Some(conversion) = template[conversion_start..].chars().next() else {
             return Err(value_error("end of string while looking for conversion specifier"));
         };
-        if conversion == '}' {
-            return Err(value_error("unmatched '{' in format spec"));
-        }
         cursor = conversion_start + conversion.len_utf8();
         match template.as_bytes().get(cursor) {
             Some(b':' | b'}') => {}
@@ -164,12 +160,22 @@ fn render_field(
     let value = resolve_field(&template[start..field_end], arguments, numbering, vm)?;
     defer_drop!(value, vm);
     let conversion = match conversion {
-        None => 0,
-        Some('s') => 1,
-        Some('r') => 2,
-        Some('a') => 3,
-        Some(other) => return Err(value_error(format!("Unknown conversion specifier {other}"))),
+        None => None,
+        Some('s') => Some(1),
+        Some('r') => Some(2),
+        Some('a') => Some(3),
+        Some(other) => {
+            let other = if other.is_ascii_graphic() {
+                other.to_string()
+            } else {
+                format!("\\x{:x}", u32::from(other))
+            };
+            return Err(value_error(format!("Unknown conversion specifier {other}")));
+        }
     };
+    let converted = conversion
+        .map(|conversion| vm.convert_value(value, conversion))
+        .transpose()?;
 
     if let Some((spec_start, spec_end)) = spec_range {
         let spec = render(
@@ -179,10 +185,16 @@ fn render_field(
             recursion_remaining - 1,
             vm,
         )?;
-        vm.format_runtime_value(value, conversion, Some(&spec))
-            .map(|formatted| (formatted, spec_end + 1))
+        let formatted = if let Some(converted) = &converted {
+            vm.format_runtime_string(converted, &spec)?
+        } else {
+            vm.format_runtime_value(value, 0, Some(&spec))?
+        };
+        Ok((formatted, spec_end + 1))
+    } else if let Some(converted) = converted {
+        Ok((converted, cursor + 1))
     } else {
-        vm.format_runtime_value(value, conversion, None)
+        vm.format_runtime_value(value, 0, None)
             .map(|formatted| (formatted, cursor + 1))
     }
 }
@@ -235,7 +247,8 @@ fn resolve_field(
         .iter()
         .position(|byte| matches!(byte, b'.' | b'['))
         .unwrap_or(field.len());
-    let mut value = resolve_first(&field[..first_end], arguments, numbering, vm)?;
+    let value = resolve_first(&field[..first_end], arguments, numbering, vm)?;
+    let mut value = DropGuard::new(value, vm);
     let mut cursor = first_end;
 
     while cursor < field.len() {
@@ -247,37 +260,36 @@ fn resolve_field(
                     .position(|byte| matches!(byte, b'.' | b'['))
                     .map_or(field.len(), |offset| start + offset);
                 if start == end {
-                    value.drop_with(vm);
                     return Err(value_error("Empty attribute in format string"));
                 }
-                value = resolve_attribute(value, &field[start..end], vm)?;
+                let (current, vm) = value.into_parts();
+                let next = resolve_attribute(current, &field[start..end], vm)?;
+                value = DropGuard::new(next, vm);
                 cursor = end;
             }
             b'[' => {
                 let start = cursor + 1;
                 let Some(offset) = field[start..].find(']') else {
-                    value.drop_with(vm);
                     return Err(value_error("expected '}' before end of string"));
                 };
                 let end = start + offset;
                 if start == end {
-                    value.drop_with(vm);
                     return Err(value_error("Empty attribute in format string"));
                 }
-                value = resolve_item(value, &field[start..end], vm)?;
+                let (current, vm) = value.into_parts();
+                let next = resolve_item(current, &field[start..end], vm)?;
+                value = DropGuard::new(next, vm);
                 cursor = end + 1;
                 if cursor < field.len() && !matches!(field.as_bytes()[cursor], b'.' | b'[') {
-                    value.drop_with(vm);
                     return Err(value_error("Only '.' or '[' may follow ']' in format field specifier"));
                 }
             }
             _ => {
-                value.drop_with(vm);
                 return Err(value_error("expected '}' before end of string"));
             }
         }
     }
-    Ok(value)
+    Ok(value.into_inner())
 }
 
 fn resolve_first(
@@ -290,7 +302,7 @@ fn resolve_first(
         return resolve_auto(arguments, numbering, vm);
     }
 
-    match decimal_index(field)? {
+    match decimal_index(field, vm)? {
         Some(index) => {
             if matches!(numbering.mode, NumberingMode::Automatic) {
                 return Err(value_error(
@@ -334,7 +346,8 @@ fn resolve_positional(index: usize, arguments: &FormatArguments, vm: &VM<'_>) ->
 }
 
 fn resolve_keyword(name: &str, arguments: &FormatArguments, vm: &mut VM<'_>) -> RunResult<Value> {
-    for (key, value) in &arguments.keywords {
+    for (index, (key, value)) in arguments.keywords.iter().enumerate() {
+        vm.heap.tracker.check_time_every(index)?;
         if key.to_str(vm)? == name {
             return Ok(value.clone_with_heap(vm.heap));
         }
@@ -358,34 +371,32 @@ fn resolve_attribute(value: Value, name: &str, vm: &mut VM<'_>) -> RunResult<Val
 
 fn resolve_item(value: Value, item: &str, vm: &mut VM<'_>) -> RunResult<Value> {
     defer_drop!(value, vm);
-    let key = item_key(item, vm);
+    let key = item_key(item, vm)?;
     defer_drop!(key, vm);
     value.py_getitem(key, vm)
 }
 
-fn item_key(item: &str, vm: &VM<'_>) -> Value {
-    let digits = item.chars().map(decimal_digit_value).collect::<Option<Vec<_>>>();
-    if let Some(digits) = digits {
-        let ascii = digits
-            .into_iter()
-            .map(|digit| char::from_digit(digit, 10).expect("decimal digit is in range"))
-            .collect::<String>();
-        let integer = ascii.parse::<BigInt>().expect("ASCII decimal digits parse as BigInt");
-        LongInt::new(integer).into_value(vm.heap)
+fn item_key(item: &str, vm: &VM<'_>) -> RunResult<Value> {
+    if let Some(index) = decimal_index(item, vm)? {
+        Ok(Value::Int(
+            i64::try_from(index).expect("index is bounded by isize::MAX"),
+        ))
     } else {
-        allocate_string(item, vm.heap)
+        Ok(allocate_string(item, vm.heap))
     }
 }
 
-fn decimal_index(field: &str) -> RunResult<Option<usize>> {
+fn decimal_index(field: &str, vm: &VM<'_>) -> RunResult<Option<usize>> {
     let mut index = 0usize;
-    for character in field.chars() {
+    for (offset, character) in field.chars().enumerate() {
+        vm.heap.tracker.check_time_every(offset)?;
         let Some(digit) = decimal_digit_value(character) else {
             return Ok(None);
         };
         index = index
             .checked_mul(10)
             .and_then(|value| value.checked_add(digit as usize))
+            .filter(|value| isize::try_from(*value).is_ok())
             .ok_or_else(|| value_error("Too many decimal digits in format string"))?;
     }
     Ok(Some(index))

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -251,8 +251,11 @@ fn resolve_field(
     let value = resolve_first(&field[..first_end], arguments, numbering, vm)?;
     let mut value = DropGuard::new(value, vm);
     let mut cursor = first_end;
+    let mut access_index = 0;
 
     while cursor < field.len() {
+        value.ctx().heap.tracker.check_time_every(access_index)?;
+        access_index += 1;
         match field.as_bytes()[cursor] {
             b'.' => {
                 let start = cursor + 1;

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -17,10 +17,11 @@ const MAX_FORMAT_RECURSION: u8 = 2;
 
 pub(crate) fn str_format(template: &str, args: ArgValues, vm: &mut VM<'_>) -> RunResult<Value> {
     let FormatCallArgs { positional, keywords } = FormatCallArgs::from_args(args, vm)?;
-    let arguments = FormatArguments {
-        positional,
-        keywords: keywords.into_iter().collect(),
+    let keywords = match keywords {
+        KwargsValues::Pairs(keywords) => keywords,
+        other => other.into_iter().collect(),
     };
+    let arguments = FormatArguments { positional, keywords };
     defer_drop!(arguments, vm);
 
     let mut numbering = Numbering::default();

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -1,0 +1,419 @@
+use std::fmt;
+
+use num_bigint::BigInt;
+use unicode_general_category::{GeneralCategory, get_general_category};
+
+use crate::{
+    args::{ArgValues, FromArgs, KwargsValues},
+    bytecode::{CallResult, VM},
+    defer_drop,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
+    heap::{ContainsHeap, DropWithContext},
+    string_builder::StringBuilder,
+    types::{LongInt, PyTrait, str::allocate_string},
+    value::{EitherStr, Value},
+};
+
+const MAX_FORMAT_RECURSION: u8 = 2;
+
+pub(crate) fn str_format(template: &str, args: ArgValues, vm: &mut VM<'_>) -> RunResult<Value> {
+    let FormatCallArgs { positional, keywords } = FormatCallArgs::from_args(args, vm)?;
+    let arguments = FormatArguments {
+        positional,
+        keywords: keywords.into_iter().collect(),
+    };
+    defer_drop!(arguments, vm);
+
+    let mut numbering = Numbering::default();
+    let rendered = render(template, arguments, &mut numbering, MAX_FORMAT_RECURSION, vm)?;
+    Ok(allocate_string(rendered, vm.heap))
+}
+
+#[derive(FromArgs)]
+#[from_args(name = "format")]
+struct FormatCallArgs {
+    #[from_args(varargs)]
+    positional: Vec<Value>,
+    #[from_args(varkwargs)]
+    keywords: KwargsValues,
+}
+
+struct FormatArguments {
+    positional: Vec<Value>,
+    keywords: Vec<(Value, Value)>,
+}
+
+impl<C: ContainsHeap> DropWithContext<C> for FormatArguments {
+    fn drop_with(self, ctx: &mut C) {
+        self.positional.drop_with(ctx);
+        for (key, value) in self.keywords {
+            key.drop_with(ctx);
+            value.drop_with(ctx);
+        }
+    }
+}
+
+#[derive(Default)]
+struct Numbering {
+    mode: NumberingMode,
+    next_auto: usize,
+}
+
+#[derive(Default)]
+enum NumberingMode {
+    #[default]
+    Unknown,
+    Automatic,
+    Manual,
+}
+
+fn render(
+    template: &str,
+    arguments: &FormatArguments,
+    numbering: &mut Numbering,
+    recursion_remaining: u8,
+    vm: &mut VM<'_>,
+) -> RunResult<String> {
+    let bytes = template.as_bytes();
+    let mut output = String::new();
+    let mut literal_start = 0;
+    let mut index = 0;
+
+    while index < bytes.len() {
+        vm.heap.tracker.check_time_every(index)?;
+        match bytes[index] {
+            b'{' => {
+                output = push_tracked(output, &template[literal_start..index], vm)?;
+                if bytes.get(index + 1) == Some(&b'{') {
+                    output = push_tracked(output, "{", vm)?;
+                    index += 2;
+                } else {
+                    if index + 1 == bytes.len() {
+                        return Err(value_error("Single '{' encountered in format string"));
+                    }
+                    if recursion_remaining == 0 {
+                        return Err(value_error("Max string recursion exceeded"));
+                    }
+                    let (formatted, next) =
+                        render_field(template, index + 1, arguments, numbering, recursion_remaining, vm)?;
+                    output = push_tracked(output, &formatted, vm)?;
+                    index = next;
+                }
+                literal_start = index;
+            }
+            b'}' => {
+                output = push_tracked(output, &template[literal_start..index], vm)?;
+                if bytes.get(index + 1) == Some(&b'}') {
+                    output = push_tracked(output, "}", vm)?;
+                    index += 2;
+                    literal_start = index;
+                } else {
+                    return Err(value_error("Single '}' encountered in format string"));
+                }
+            }
+            _ => index += 1,
+        }
+    }
+
+    push_tracked(output, &template[literal_start..], vm)
+}
+
+fn render_field(
+    template: &str,
+    start: usize,
+    arguments: &FormatArguments,
+    numbering: &mut Numbering,
+    recursion_remaining: u8,
+    vm: &mut VM<'_>,
+) -> RunResult<(String, usize)> {
+    let (field_end, delimiter) = find_field_end(template, start, vm)?;
+    let mut cursor = field_end;
+    let conversion = if delimiter == b'!' {
+        let conversion_start = cursor + 1;
+        let Some(conversion) = template[conversion_start..].chars().next() else {
+            return Err(value_error("end of string while looking for conversion specifier"));
+        };
+        if conversion == '}' {
+            return Err(value_error("unmatched '{' in format spec"));
+        }
+        cursor = conversion_start + conversion.len_utf8();
+        match template.as_bytes().get(cursor) {
+            Some(b':' | b'}') => {}
+            None => return Err(value_error("unmatched '{' in format spec")),
+            _ => return Err(value_error("expected ':' after conversion specifier")),
+        }
+        Some(conversion)
+    } else {
+        None
+    };
+
+    let delimiter = *template
+        .as_bytes()
+        .get(cursor)
+        .ok_or_else(|| value_error("expected '}' before end of string"))?;
+    let spec_range = match delimiter {
+        b'}' => None,
+        b':' => {
+            let spec_start = cursor + 1;
+            let spec_end = find_spec_end(template, spec_start, vm)?;
+            Some((spec_start, spec_end))
+        }
+        _ => return Err(value_error("expected '}' before end of string")),
+    };
+
+    let value = resolve_field(&template[start..field_end], arguments, numbering, vm)?;
+    defer_drop!(value, vm);
+    let conversion = match conversion {
+        None => 0,
+        Some('s') => 1,
+        Some('r') => 2,
+        Some('a') => 3,
+        Some(other) => return Err(value_error(format!("Unknown conversion specifier {other}"))),
+    };
+
+    if let Some((spec_start, spec_end)) = spec_range {
+        let spec = render(
+            &template[spec_start..spec_end],
+            arguments,
+            numbering,
+            recursion_remaining - 1,
+            vm,
+        )?;
+        vm.format_runtime_value(value, conversion, Some(&spec))
+            .map(|formatted| (formatted, spec_end + 1))
+    } else {
+        vm.format_runtime_value(value, conversion, None)
+            .map(|formatted| (formatted, cursor + 1))
+    }
+}
+
+fn find_field_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<(usize, u8)> {
+    let bytes = template.as_bytes();
+    let mut index = start;
+    let mut in_item = false;
+
+    while index < bytes.len() {
+        vm.heap.tracker.check_time_every(index)?;
+        match bytes[index] {
+            b'[' if !in_item => in_item = true,
+            b']' if in_item => in_item = false,
+            b'{' if !in_item => return Err(value_error("unexpected '{' in field name")),
+            delimiter @ (b'!' | b':' | b'}') if !in_item => return Ok((index, delimiter)),
+            _ => {}
+        }
+        index += 1;
+    }
+    Err(value_error("expected '}' before end of string"))
+}
+
+fn find_spec_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<usize> {
+    let bytes = template.as_bytes();
+    let mut index = start;
+    let mut nesting = 0usize;
+
+    while index < bytes.len() {
+        vm.heap.tracker.check_time_every(index)?;
+        match bytes[index] {
+            b'{' => nesting += 1,
+            b'}' if nesting == 0 => return Ok(index),
+            b'}' => nesting -= 1,
+            _ => {}
+        }
+        index += 1;
+    }
+    Err(value_error("unmatched '{' in format spec"))
+}
+
+fn resolve_field(
+    field: &str,
+    arguments: &FormatArguments,
+    numbering: &mut Numbering,
+    vm: &mut VM<'_>,
+) -> RunResult<Value> {
+    let first_end = field
+        .as_bytes()
+        .iter()
+        .position(|byte| matches!(byte, b'.' | b'['))
+        .unwrap_or(field.len());
+    let mut value = resolve_first(&field[..first_end], arguments, numbering, vm)?;
+    let mut cursor = first_end;
+
+    while cursor < field.len() {
+        match field.as_bytes()[cursor] {
+            b'.' => {
+                let start = cursor + 1;
+                let end = field.as_bytes()[start..]
+                    .iter()
+                    .position(|byte| matches!(byte, b'.' | b'['))
+                    .map_or(field.len(), |offset| start + offset);
+                if start == end {
+                    value.drop_with(vm);
+                    return Err(value_error("Empty attribute in format string"));
+                }
+                value = resolve_attribute(value, &field[start..end], vm)?;
+                cursor = end;
+            }
+            b'[' => {
+                let start = cursor + 1;
+                let Some(offset) = field[start..].find(']') else {
+                    value.drop_with(vm);
+                    return Err(value_error("expected '}' before end of string"));
+                };
+                let end = start + offset;
+                if start == end {
+                    value.drop_with(vm);
+                    return Err(value_error("Empty attribute in format string"));
+                }
+                value = resolve_item(value, &field[start..end], vm)?;
+                cursor = end + 1;
+                if cursor < field.len() && !matches!(field.as_bytes()[cursor], b'.' | b'[') {
+                    value.drop_with(vm);
+                    return Err(value_error("Only '.' or '[' may follow ']' in format field specifier"));
+                }
+            }
+            _ => {
+                value.drop_with(vm);
+                return Err(value_error("expected '}' before end of string"));
+            }
+        }
+    }
+    Ok(value)
+}
+
+fn resolve_first(
+    field: &str,
+    arguments: &FormatArguments,
+    numbering: &mut Numbering,
+    vm: &mut VM<'_>,
+) -> RunResult<Value> {
+    if field.is_empty() {
+        return resolve_auto(arguments, numbering, vm);
+    }
+
+    match decimal_index(field)? {
+        Some(index) => {
+            if matches!(numbering.mode, NumberingMode::Automatic) {
+                return Err(value_error(
+                    "cannot switch from automatic field numbering to manual field specification",
+                ));
+            }
+            numbering.mode = NumberingMode::Manual;
+            resolve_positional(index, arguments, vm)
+        }
+        None => resolve_keyword(field, arguments, vm),
+    }
+}
+
+fn resolve_auto(arguments: &FormatArguments, numbering: &mut Numbering, vm: &VM<'_>) -> RunResult<Value> {
+    if matches!(numbering.mode, NumberingMode::Manual) {
+        return Err(value_error(
+            "cannot switch from manual field specification to automatic field numbering",
+        ));
+    }
+    numbering.mode = NumberingMode::Automatic;
+    let index = numbering.next_auto;
+    numbering.next_auto = numbering
+        .next_auto
+        .checked_add(1)
+        .ok_or_else(|| value_error("Too many decimal digits in format string"))?;
+    resolve_positional(index, arguments, vm)
+}
+
+fn resolve_positional(index: usize, arguments: &FormatArguments, vm: &VM<'_>) -> RunResult<Value> {
+    arguments
+        .positional
+        .get(index)
+        .map(|value| value.clone_with_heap(vm.heap))
+        .ok_or_else(|| {
+            SimpleException::new_msg(
+                ExcType::IndexError,
+                format!("Replacement index {index} out of range for positional args tuple"),
+            )
+            .into()
+        })
+}
+
+fn resolve_keyword(name: &str, arguments: &FormatArguments, vm: &mut VM<'_>) -> RunResult<Value> {
+    for (key, value) in &arguments.keywords {
+        if key.to_str(vm)? == name {
+            return Ok(value.clone_with_heap(vm.heap));
+        }
+    }
+
+    let key = allocate_string(name, vm.heap);
+    defer_drop!(key, vm);
+    Err(ExcType::key_error(key, vm))
+}
+
+fn resolve_attribute(value: Value, name: &str, vm: &mut VM<'_>) -> RunResult<Value> {
+    defer_drop!(value, vm);
+    match value.py_getattr(&EitherStr::Heap(name.to_owned()), vm)? {
+        CallResult::Value(value) => Ok(value),
+        other => {
+            other.drop_with(vm);
+            Err(ExcType::not_implemented("str.format attribute access cannot suspend").into())
+        }
+    }
+}
+
+fn resolve_item(value: Value, item: &str, vm: &mut VM<'_>) -> RunResult<Value> {
+    defer_drop!(value, vm);
+    let key = item_key(item, vm);
+    defer_drop!(key, vm);
+    value.py_getitem(key, vm)
+}
+
+fn item_key(item: &str, vm: &VM<'_>) -> Value {
+    let digits = item.chars().map(decimal_digit_value).collect::<Option<Vec<_>>>();
+    if let Some(digits) = digits {
+        let ascii = digits
+            .into_iter()
+            .map(|digit| char::from_digit(digit, 10).expect("decimal digit is in range"))
+            .collect::<String>();
+        let integer = ascii.parse::<BigInt>().expect("ASCII decimal digits parse as BigInt");
+        LongInt::new(integer).into_value(vm.heap)
+    } else {
+        allocate_string(item, vm.heap)
+    }
+}
+
+fn decimal_index(field: &str) -> RunResult<Option<usize>> {
+    let mut index = 0usize;
+    for character in field.chars() {
+        let Some(digit) = decimal_digit_value(character) else {
+            return Ok(None);
+        };
+        index = index
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(digit as usize))
+            .ok_or_else(|| value_error("Too many decimal digits in format string"))?;
+    }
+    Ok(Some(index))
+}
+
+fn decimal_digit_value(character: char) -> Option<u32> {
+    if get_general_category(character) != GeneralCategory::DecimalNumber {
+        return None;
+    }
+
+    let code_point = character as u32;
+    let mut run_start = code_point;
+    while let Some(previous) = run_start.checked_sub(1).and_then(char::from_u32) {
+        if get_general_category(previous) != GeneralCategory::DecimalNumber {
+            break;
+        }
+        run_start -= 1;
+    }
+    // Adjacent Nd runs still repeat their values every ten code points.
+    Some((code_point - run_start) % 10)
+}
+
+fn push_tracked(output: String, text: &str, vm: &VM<'_>) -> RunResult<String> {
+    let mut builder = StringBuilder::from_existing(output, &vm.heap.tracker);
+    builder.push_str(text)?;
+    builder.finish_raw()
+}
+
+fn value_error(message: impl fmt::Display) -> RunError {
+    SimpleException::new_msg(ExcType::ValueError, message).into()
+}

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -2,13 +2,12 @@
 
 use std::fmt;
 
-use unicode_general_category::{GeneralCategory, get_general_category};
-
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
+    fstring::decimal_digit_value,
     heap::{ContainsHeap, DropGuard, DropWithContext},
     string_builder::StringBuilder,
     types::{PyTrait, str::allocate_string},
@@ -172,7 +171,7 @@ fn render_field(
     let value = resolve_field(&template[start..field_end], arguments, numbering, vm)?;
     defer_drop!(value, vm);
     let conversion = match conversion {
-        None => None,
+        None | Some('\0') => None,
         Some('s') => Some(1),
         Some('r') => Some(2),
         Some('a') => Some(3),
@@ -383,7 +382,7 @@ fn resolve_keyword(name: &str, arguments: &FormatArguments, vm: &mut VM<'_>) -> 
 /// Resolves an attribute without allowing a suspending lookup.
 fn resolve_attribute(value: Value, name: &str, vm: &mut VM<'_>) -> RunResult<Value> {
     defer_drop!(value, vm);
-    match value.py_getattr(&EitherStr::Heap(name.to_owned()), vm)? {
+    match value.py_getattr(&EitherStr::from(name.to_owned()), vm)? {
         CallResult::Value(value) => Ok(value),
         other => {
             other.drop_with(vm);
@@ -426,24 +425,6 @@ fn decimal_index(field: &str, vm: &VM<'_>) -> RunResult<Option<usize>> {
             .ok_or_else(|| value_error("Too many decimal digits in format string"))?;
     }
     Ok(Some(index))
-}
-
-/// Returns the numeric value of a Unicode decimal digit.
-fn decimal_digit_value(character: char) -> Option<u32> {
-    if get_general_category(character) != GeneralCategory::DecimalNumber {
-        return None;
-    }
-
-    let code_point = character as u32;
-    let mut run_start = code_point;
-    while let Some(previous) = run_start.checked_sub(1).and_then(char::from_u32) {
-        if get_general_category(previous) != GeneralCategory::DecimalNumber {
-            break;
-        }
-        run_start -= 1;
-    }
-    // Adjacent Nd runs still repeat their values every ten code points.
-    Some((code_point - run_start) % 10)
 }
 
 /// Appends a fragment while preserving `StringBuilder` resource accounting.

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -100,9 +100,6 @@ fn render(
                     if index + 1 == bytes.len() {
                         return Err(value_error("Single '{' encountered in format string"));
                     }
-                    if recursion_remaining == 0 {
-                        return Err(value_error("Max string recursion exceeded"));
-                    }
                     let (formatted, next) =
                         render_field(template, index + 1, arguments, numbering, recursion_remaining, vm)?;
                     output = push_tracked(output, &formatted, vm)?;
@@ -189,13 +186,17 @@ fn render_field(
         .transpose()?;
 
     if let Some((spec_start, spec_end)) = spec_range {
-        let spec = render(
-            &template[spec_start..spec_end],
-            arguments,
-            numbering,
-            recursion_remaining - 1,
-            vm,
-        )?;
+        let raw_spec = &template[spec_start..spec_end];
+        // Only a spec containing `{` is expanded, and the expansion itself costs a
+        // recursion level, escaped braces included, matching CPython's `build_string`.
+        let spec = if raw_spec.contains('{') {
+            if recursion_remaining <= 1 {
+                return Err(value_error("Max string recursion exceeded"));
+            }
+            render(raw_spec, arguments, numbering, recursion_remaining - 1, vm)?
+        } else {
+            raw_spec.to_owned()
+        };
         let formatted = if let Some(converted) = &converted {
             vm.format_runtime_string(converted, &spec)?
         } else {

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -159,8 +159,8 @@ fn render_field(
         b'}' => None,
         b':' => {
             let spec_start = cursor + 1;
-            let spec_end = find_spec_end(template, spec_start, vm)?;
-            Some((spec_start, spec_end))
+            let (spec_end, needs_expansion) = find_spec_end(template, spec_start, vm)?;
+            Some((spec_start, spec_end, needs_expansion))
         }
         _ => return Err(value_error("expected '}' before end of string")),
     };
@@ -185,11 +185,11 @@ fn render_field(
         .map(|conversion| vm.convert_value(value, conversion))
         .transpose()?;
 
-    if let Some((spec_start, spec_end)) = spec_range {
+    if let Some((spec_start, spec_end, needs_expansion)) = spec_range {
         let raw_spec = &template[spec_start..spec_end];
         // Only a spec containing `{` is expanded, and the expansion itself costs a
         // recursion level, escaped braces included, matching CPython's `build_string`.
-        let spec = if raw_spec.contains('{') {
+        let spec = if needs_expansion {
             if recursion_remaining <= 1 {
                 return Err(value_error("Max string recursion exceeded"));
             }
@@ -231,17 +231,21 @@ fn find_field_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<(usize
     Err(value_error("expected '}' before end of string"))
 }
 
-/// Finds the closing brace for a possibly nested format spec.
-fn find_spec_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<usize> {
+/// Finds the closing brace and whether the spec needs expansion in one checked scan.
+fn find_spec_end(template: &str, start: usize, vm: &VM<'_>) -> RunResult<(usize, bool)> {
     let bytes = template.as_bytes();
     let mut index = start;
     let mut nesting = 0usize;
+    let mut needs_expansion = false;
 
     while index < bytes.len() {
         vm.heap.tracker.check_time_every(index)?;
         match bytes[index] {
-            b'{' => nesting += 1,
-            b'}' if nesting == 0 => return Ok(index),
+            b'{' => {
+                nesting += 1;
+                needs_expansion = true;
+            }
+            b'}' if nesting == 0 => return Ok((index, needs_expansion)),
             b'}' => nesting -= 1,
             _ => {}
         }

--- a/crates/monty/src/str_format.rs
+++ b/crates/monty/src/str_format.rs
@@ -1,6 +1,6 @@
 //! Runtime replacement-field handling for `str.format()`.
 
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
@@ -193,14 +193,14 @@ fn render_field(
             if recursion_remaining <= 1 {
                 return Err(value_error("Max string recursion exceeded"));
             }
-            render(raw_spec, arguments, numbering, recursion_remaining - 1, vm)?
+            Cow::Owned(render(raw_spec, arguments, numbering, recursion_remaining - 1, vm)?)
         } else {
-            raw_spec.to_owned()
+            Cow::Borrowed(raw_spec)
         };
         let formatted = if let Some(converted) = &converted {
-            vm.format_runtime_string(converted, &spec)?
+            vm.format_runtime_string(converted, spec.as_ref())?
         } else {
-            vm.format_runtime_value(value, 0, Some(&spec))?
+            vm.format_runtime_value(value, 0, Some(spec.as_ref()))?
         };
         Ok((formatted, spec_end + 1))
     } else if let Some(converted) = converted {

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -38,7 +38,10 @@ use std::{fmt, mem};
 
 use monty_types::{ResourceError, ResourceTracker};
 
-use crate::{exception_private::RunResult, heap::Heap, types::str::allocate_string, value::Value};
+use crate::{
+    exception_private::RunResult, heap::Heap, resource_checks::check_native_allocation_size,
+    types::str::allocate_string, value::Value,
+};
 
 /// Resource-tracked builder for a `String`.
 ///
@@ -97,6 +100,7 @@ impl<'t> StringBuilder<'t> {
     /// width). One up-front check covers pushes within `capacity`.
     pub fn with_capacity(capacity: usize, tracker: &'t ResourceTracker) -> Result<Self, ResourceError> {
         tracker.check_allocation(capacity)?;
+        check_native_allocation_size(capacity)?;
         Ok(Self {
             inner: String::with_capacity(capacity),
             tracker,
@@ -150,6 +154,7 @@ impl<'t> StringBuilder<'t> {
             let new_capacity = self.approved_capacity.saturating_mul(2).max(needed);
             let additional = new_capacity - self.approved_capacity;
             self.tracker.check_allocation(additional)?;
+            check_native_allocation_size(new_capacity)?;
             self.approved_capacity = new_capacity;
         }
         Ok(())

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -80,6 +80,17 @@ impl<'t> StringBuilder<'t> {
         }
     }
 
+    /// Existing capacity is already tracker-accounted; only later growth needs preflight.
+    pub fn from_existing(inner: String, tracker: &'t ResourceTracker) -> Self {
+        let approved_capacity = inner.capacity();
+        Self {
+            inner,
+            tracker,
+            approved_capacity,
+            pending_error: None,
+        }
+    }
+
     /// Creates a builder with `capacity` bytes reserved up front.
     ///
     /// Use when the final size is known or bounded (e.g. padding to a given

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -38,10 +38,7 @@ use std::{fmt, mem};
 
 use monty_types::{ResourceError, ResourceTracker};
 
-use crate::{
-    exception_private::RunResult, heap::Heap, resource_checks::check_native_allocation_size,
-    types::str::allocate_string, value::Value,
-};
+use crate::{exception_private::RunResult, heap::Heap, types::str::allocate_string, value::Value};
 
 /// Resource-tracked builder for a `String`.
 ///
@@ -100,7 +97,7 @@ impl<'t> StringBuilder<'t> {
     /// width). One up-front check covers pushes within `capacity`.
     pub fn with_capacity(capacity: usize, tracker: &'t ResourceTracker) -> Result<Self, ResourceError> {
         tracker.check_allocation(capacity)?;
-        check_native_allocation_size(capacity)?;
+        check_string_capacity(capacity)?;
         Ok(Self {
             inner: String::with_capacity(capacity),
             tracker,
@@ -154,9 +151,24 @@ impl<'t> StringBuilder<'t> {
             let new_capacity = self.approved_capacity.saturating_mul(2).max(needed);
             let additional = new_capacity - self.approved_capacity;
             self.tracker.check_allocation(additional)?;
-            check_native_allocation_size(new_capacity)?;
+            check_string_capacity(new_capacity)?;
             self.approved_capacity = new_capacity;
         }
+        Ok(())
+    }
+}
+
+const MAX_STRING_CAPACITY: usize = isize::MAX as usize;
+
+/// A capacity above `isize::MAX` panics inside the reservation itself, before
+/// the allocator can refuse it, so both reservation paths fence it here.
+fn check_string_capacity(capacity: usize) -> Result<(), ResourceError> {
+    if capacity > MAX_STRING_CAPACITY {
+        Err(ResourceError::Memory {
+            limit: MAX_STRING_CAPACITY,
+            used: capacity,
+        })
+    } else {
         Ok(())
     }
 }

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     intern::{Interns, StaticStrings, StringId},
     resource_checks::{check_repeat_size, check_replace_size},
+    str_format::str_format,
     string_builder::StringBuilder,
     types::{
         LazyHeapSet, Type,
@@ -403,10 +404,7 @@ pub fn call_str_method(s: &str, method_id: StringId, args: ArgValues, vm: &mut V
 ///
 /// The following Python string methods are not yet implemented:
 ///
-/// - `format()` - Requires implementing the format spec mini-language (PEP 3101),
-///   which is complex and involves parsing format specifications like `{:>10.2f}`.
-/// - `format_map(mapping)` - Similar to `format()` but takes a mapping; depends on
-///   `format()` implementation.
+/// - `format_map(mapping)` - Mapping-only variant of `format()`.
 /// - `maketrans()` / `translate()` - Character translation tables; moderate complexity,
 ///   requires building and applying Unicode translation maps.
 /// - `expandtabs(tabsize=8)` - Tab expansion; simple but rarely used in practice.
@@ -508,6 +506,10 @@ fn call_str_method_impl<'h>(
         StaticStrings::Rjust => str_rjust(s, args, vm),
         StaticStrings::Zfill => str_zfill(s, args, vm),
         StaticStrings::Expandtabs => str_expandtabs(s, args, vm),
+        StaticStrings::Format => {
+            let template = s.get(vm.heap).to_owned();
+            str_format(&template, args, vm)
+        }
         // Additional methods
         StaticStrings::Encode => str_encode(s, args, vm),
         StaticStrings::Isidentifier => {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -507,9 +507,7 @@ fn call_str_method_impl<'h>(
         StaticStrings::Zfill => str_zfill(s, args, vm),
         StaticStrings::Expandtabs => str_expandtabs(s, args, vm),
         StaticStrings::Format => {
-            let template = s.get(vm.heap);
-            vm.heap.tracker.check_allocation(template.len())?;
-            let template = template.to_owned();
+            let template = s.get(vm.heap).to_owned();
             str_format(&template, args, vm)
         }
         // Additional methods

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -507,7 +507,9 @@ fn call_str_method_impl<'h>(
         StaticStrings::Zfill => str_zfill(s, args, vm),
         StaticStrings::Expandtabs => str_expandtabs(s, args, vm),
         StaticStrings::Format => {
-            let template = s.get(vm.heap).to_owned();
+            let template = s.get(vm.heap);
+            vm.heap.tracker.check_allocation(template.len())?;
+            let template = template.to_owned();
             str_format(&template, args, vm)
         }
         // Additional methods

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -4,7 +4,7 @@ use std::{cell::Cell, fmt::Write, ops};
 ///
 /// This type provides Python string semantics. Currently supports basic
 /// operations like length and equality comparison.
-use monty_types::ResourceError;
+use monty_types::{ResourceError, ResourceTracker};
 pub use monty_types::{StringRepr, string_repr_fmt};
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
@@ -394,6 +394,25 @@ pub fn call_str_method(s: &str, method_id: StringId, args: ArgValues, vm: &mut V
     call_str_method_impl(&vm.heap.protect(s), method, args, vm)
 }
 
+const FORMAT_TEMPLATE_COPY_CHUNK: usize = 64 * 1024;
+
+fn copy_format_template(template: &str, tracker: &ResourceTracker) -> RunResult<String> {
+    tracker.check_time()?;
+    let mut copy = StringBuilder::with_capacity(template.len(), tracker)?;
+    let mut start = 0;
+    while start < template.len() {
+        tracker.check_time()?;
+        let mut end = start.saturating_add(FORMAT_TEMPLATE_COPY_CHUNK).min(template.len());
+        while !template.is_char_boundary(end) {
+            end -= 1;
+        }
+        copy.push_str(&template[start..end])?;
+        start = end;
+    }
+    tracker.check_time()?;
+    copy.finish_raw()
+}
+
 /// Dispatches a method call on a string value.
 ///
 /// This is the unified implementation for string method calls, used by both:
@@ -507,7 +526,13 @@ fn call_str_method_impl<'h>(
         StaticStrings::Zfill => str_zfill(s, args, vm),
         StaticStrings::Expandtabs => str_expandtabs(s, args, vm),
         StaticStrings::Format => {
-            let template = s.get(vm.heap).to_owned();
+            let template = match copy_format_template(s.get(vm.heap), &vm.heap.tracker) {
+                Ok(template) => template,
+                Err(error) => {
+                    args.drop_with(vm);
+                    return Err(error);
+                }
+            };
             str_format(&template, args, vm)
         }
         // Additional methods

--- a/crates/monty/test_cases/fstring__all.py
+++ b/crates/monty/test_cases/fstring__all.py
@@ -522,6 +522,8 @@ assert f'{1234:07,}' == '001,234'
 assert f'{1234:05,}' == '1,234'
 assert f'{1234567.891:020,.2f}' == '0,000,001,234,567.89'
 assert f'{255:010_b}' == '0_1111_1111'
+assert f'{1234:0=10,}' == '00,001,234'
+assert f'{1:0=+9_g}' == '+0_000_001'
 
 # === Grouping with explicit alignment (fill is not grouped) ===
 assert f'{1234:=10,}' == '     1,234'

--- a/crates/monty/test_cases/fstring__all.py
+++ b/crates/monty/test_cases/fstring__all.py
@@ -417,6 +417,8 @@ assert f'{42!r:s}' == '42'
 # and its converted form must raise the *same* error. Valid string flags work:
 assert f'{123!s:05}' == '12300'
 assert f'{123!r:>6}' == '   123'
+width = 6
+assert f'{123!r:>{width}}' == '   123'
 assert f'{3.14159!r:.4}' == '3.14'
 
 

--- a/crates/monty/test_cases/fstring__all.py
+++ b/crates/monty/test_cases/fstring__all.py
@@ -232,6 +232,7 @@ assert f'{0.5:.{10**6}%}' == '50.' + '0' * 10**6 + '%'
 # underlying format call still uses the full precision internally.
 assert f'{1.5:.{10**6}g}' == '1.5'
 assert f'{1e-10:.{10**6}g}' == '1.0000000000000000364321973154977415791655470655996396089904010295867919921875e-10'
+assert f'{0.0001:.{2**31 - 1}g}' == ('0.000100000000000000004792173602385929598312941379845142364501953125')
 
 # === Large static width/precision ===
 # Static format specs are parsed at parse time and packed into a compact

--- a/crates/monty/test_cases/fstring__pyformat.py
+++ b/crates/monty/test_cases/fstring__pyformat.py
@@ -1,13 +1,4 @@
 # Every example from https://pyformat.info/ , converted to f-strings.
-#
-# pyformat.info presents each example in old `%` style and new `str.format()`
-# style. Monty implements the format mini-language ONLY through f-strings (no
-# `str.format()` / `%` / general `__format__` protocol — see
-# limitations/format.md), so each `.format()` example is written here as the
-# equivalent f-string. Examples that rely on a user-defined class (`Data`,
-# `Plant`, `HAL9000`) can't be represented verbatim — Monty has no `class`
-# statement — so they are adapted to built-in values that exercise the same
-# formatting feature, with a note.
 
 from datetime import datetime
 

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -1,4 +1,6 @@
-from datetime import datetime
+import re
+from collections import deque
+from datetime import datetime, timedelta
 
 
 def capture_error(template, *args, **kwargs):
@@ -42,11 +44,26 @@ assert '{0[𝟙]}'.format(['zero', 'one']) == 'one'
 unusual_item_keys = '{0[a:b]} {0[a!b]} {0[a}b]}'
 assert unusual_item_keys.format({'a:b': 1, 'a!b': 2, 'a}b': 3}) == '1 2 3'
 
+native_datetime = datetime(2001, 2, 3, 4, 5)
+assert '{0.year}-{0.hour}'.format(native_datetime) == '2001-4'
+assert '{0.days}'.format(timedelta(days=2)) == '2'
+assert '{0.maxlen}'.format(deque(maxlen=4)) == '4'
+native_match = re.match('a', 'abc')
+assert '{0.string}'.format(native_match) == 'abc'
+
+nul = chr(0)
+assert ('{0!' + nul + '}').format('a') == 'a'
+assert ('{0!' + nul + ':04d}').format(1) == '0001'
 assert '{0!s} {0!r} {0!a}'.format('räpr') == "räpr 'räpr' 'r\\xe4pr'"
 assert '{0!a}'.format('😀') == "'\\U0001f600'"
 assert '{0:>10}'.format('test') == '      test'
 assert '{0:_<10.5}'.format('xylophone') == 'xylop_____'
 assert '{0:+06.2f}'.format(3.14159) == '+03.14'
+assert '{:５}'.format(1) == '    1'
+assert '{:.２f}'.format(1.25) == '1.25'
+assert '{:._}'.format(True) == '1'
+assert '{:._}'.format('x') == 'x'
+assert capture_error('{:.6_n}', 1.234567) == ('ValueError', "Cannot specify '_' with 'n'.")
 assert '{0:.2147483647g}'.format(0.0001) == ('0.000100000000000000004792173602385929598312941379845142364501953125')
 assert '{:}'.format(True) == 'True'
 assert '{0!r:>6}'.format(123) == '   123'

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -47,6 +47,7 @@ assert '{0!a}'.format('😀') == "'\\U0001f600'"
 assert '{0:>10}'.format('test') == '      test'
 assert '{0:_<10.5}'.format('xylophone') == 'xylop_____'
 assert '{0:+06.2f}'.format(3.14159) == '+03.14'
+assert '{0:.2147483647g}'.format(0.0001) == ('0.000100000000000000004792173602385929598312941379845142364501953125')
 assert '{:}'.format(True) == 'True'
 assert '{0!r:>6}'.format(123) == '   123'
 assert '{0:{align}{width}}'.format('test', align='^', width=10) == '   test   '

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -27,10 +27,16 @@ class Record:
 
 
 assert '{0.value:04d}'.format(Record(2001)) == '2001'
+assert capture_error('{0.missing}', Record(2001)) == (
+    'AttributeError',
+    "'Record' object has no attribute 'missing'",
+)
 person = {'first': 'Jean-Luc', 'last': 'Picard'}
 assert '{p[first]} {p[last]}'.format(p=person) == 'Jean-Luc Picard'
+assert capture_error('{0[missing]}', person) == ('KeyError', "'missing'")
 plant = {'kinds': [{'name': 'oak'}]}
 assert '{p[kinds][0][name]}'.format(p=plant) == 'oak'
+assert capture_error('{0[2]}', [10, 20]) == ('IndexError', 'list index out of range')
 assert '{0[１]}'.format([10, 20]) == '20'
 assert '{0[𝟙]}'.format(['zero', 'one']) == 'one'
 unusual_item_keys = '{0[a:b]} {0[a!b]} {0[a}b]}'

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -1,6 +1,6 @@
 import re
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 
 
 def capture_error(template, *args, **kwargs):
@@ -172,3 +172,8 @@ assert capture_error('{0:{{}}<9}', 5) == (
     'ValueError',
     "Invalid format specifier '{}<9' for object of type 'int'",
 )
+
+assert '{[0]}'.format(['a']) == 'a'
+assert '{.value}'.format(Record(1)) == '1'
+assert capture_error('{x=}', x=1) == ('KeyError', "'x='")
+assert '{:%H:%M}'.format(time(4, 5)) == '04:05'

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+
+
+def capture_error(template, *args, **kwargs):
+    try:
+        template.format(*args, **kwargs)
+    except Exception as exc:
+        return type(exc).__name__, str(exc)
+    return None
+
+
+assert '{} {}'.format('one', 'two') == 'one two'
+assert '{1} {0}'.format('one', 'two') == 'two one'
+assert '{first} {last}'.format(first='Jean-Luc', last='Picard') == 'Jean-Luc Picard'
+assert '{a-b}'.format(**{'a-b': 7}) == '7'
+unicode_index = '{٠}'
+assert unicode_index.format('zero') == 'zero'
+mathematical_index = '{𝟘}'
+assert mathematical_index.format('zero') == 'zero'
+literal_only = 'unchanged'
+assert literal_only.format(1, ignored=2) == 'unchanged'
+
+
+class Record:
+    def __init__(self, value):
+        self.value = value
+
+
+assert '{0.value:04d}'.format(Record(2001)) == '2001'
+person = {'first': 'Jean-Luc', 'last': 'Picard'}
+assert '{p[first]} {p[last]}'.format(p=person) == 'Jean-Luc Picard'
+plant = {'kinds': [{'name': 'oak'}]}
+assert '{p[kinds][0][name]}'.format(p=plant) == 'oak'
+assert '{0[１]}'.format([10, 20]) == '20'
+assert '{0[𝟙]}'.format(['zero', 'one']) == 'one'
+unusual_item_keys = '{0[a:b]} {0[a!b]} {0[a}b]}'
+assert unusual_item_keys.format({'a:b': 1, 'a!b': 2, 'a}b': 3}) == '1 2 3'
+
+assert '{0!s} {0!r} {0!a}'.format('räpr') == "räpr 'räpr' 'r\\xe4pr'"
+assert '{0:>10}'.format('test') == '      test'
+assert '{0:_<10.5}'.format('xylophone') == 'xylop_____'
+assert '{0:+06.2f}'.format(3.14159) == '+03.14'
+assert '{0:{align}{width}}'.format('test', align='^', width=10) == '   test   '
+assert '{0:{width}.{precision}f}'.format(2.7182, width=5, precision=2) == ' 2.72'
+assert '{0:{spec[align]}}'.format('x', spec={'align': '^5'}) == '  x  '
+assert '{} {:{}}'.format(1, 2, 3) == '1   2'
+dt = datetime(2001, 2, 3, 4, 5)
+assert '{0:%Y-%m-%d %H:%M}'.format(dt) == '2001-02-03 04:05'
+
+assert '{{}}'.format() == '{}'
+assert '{{{0}}}'.format('x') == '{x}'
+assert ''.format() == ''
+shared = {'x': 'value'}
+assert '{0} {0!r} {0[x]}'.format(shared) == "{'x': 'value'} {'x': 'value'} value"
+
+assert capture_error('{} {0}', 'a', 'b') == (
+    'ValueError',
+    'cannot switch from automatic field numbering to manual field specification',
+)
+assert capture_error('{0} {}', 'a', 'b') == (
+    'ValueError',
+    'cannot switch from manual field specification to automatic field numbering',
+)
+assert capture_error('{2}', 'a') == (
+    'IndexError',
+    'Replacement index 2 out of range for positional args tuple',
+)
+assert capture_error('{missing}') == ('KeyError', "'missing'")
+assert capture_error('{') == ('ValueError', "Single '{' encountered in format string")
+assert capture_error('}') == ('ValueError', "Single '}' encountered in format string")
+assert capture_error('{0!x}', 'a') == ('ValueError', 'Unknown conversion specifier x')
+assert capture_error('{0!rs}', 'a') == ('ValueError', "expected ':' after conversion specifier")
+assert capture_error('{0!', 'a') == (
+    'ValueError',
+    'end of string while looking for conversion specifier',
+)
+assert capture_error('{0!s', 'a') == ('ValueError', "unmatched '{' in format spec")
+assert capture_error('{0!}', 'a') == ('ValueError', "unmatched '{' in format spec")
+assert capture_error('{missing:') == ('ValueError', "unmatched '{' in format spec")
+assert capture_error('{missing!rs}') == (
+    'ValueError',
+    "expected ':' after conversion specifier",
+)
+assert capture_error('{missing!x}') == ('KeyError', "'missing'")
+assert capture_error('{0:.2q}', 1) == (
+    'ValueError',
+    "Unknown format code 'q' for object of type 'int'",
+)
+assert capture_error('{0:.}', 1) == ('ValueError', 'Format specifier missing precision')
+assert capture_error('{0{}}', 'a') == ('ValueError', "unexpected '{' in field name")
+assert capture_error('{0..x}', 'a') == ('ValueError', 'Empty attribute in format string')
+assert capture_error('{0[]}', {'': 1}) == ('ValueError', 'Empty attribute in format string')
+assert capture_error('{0[x]x}', {'x': 1}) == (
+    'ValueError',
+    "Only '.' or '[' may follow ']' in format field specifier",
+)
+assert capture_error('{0[x}', {'x': 1}) == ('ValueError', "expected '}' before end of string")
+assert capture_error('{0:{1}', 1, 2) == ('ValueError', "unmatched '{' in format spec")
+assert capture_error('{0:{spec[a}b]}}', 'x', spec={'a}b': '^5'}) == (
+    'ValueError',
+    "expected '}' before end of string",
+)
+assert capture_error('{0:{}}', 1, 2) == (
+    'ValueError',
+    'cannot switch from manual field specification to automatic field numbering',
+)
+assert capture_error('{:{0}}', 1, 2) == (
+    'ValueError',
+    'cannot switch from automatic field numbering to manual field specification',
+)
+assert capture_error('{0:{1:{2}}}', 1, 2, 3) == ('ValueError', 'Max string recursion exceeded')
+assert capture_error('{999999999999999999999999999999999999}', 1) == (
+    'ValueError',
+    'Too many decimal digits in format string',
+)

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -26,7 +26,7 @@ class Record:
         self.value = value
 
 
-assert '{0.value:04d}'.format(Record(2001)) == '2001'
+assert '{0.value:04d}'.format(Record(1)) == '0001'
 assert capture_error('{0.missing}', Record(2001)) == (
     'AttributeError',
     "'Record' object has no attribute 'missing'",

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -160,3 +160,9 @@ assert capture_error('{0[999999999999999999999999999999999999]}', {}) == (
     'ValueError',
     'Too many decimal digits in format string',
 )
+
+assert '{:0=10,}'.format(1234) == '00,001,234'
+assert '{:0=15,.2f}'.format(1234.5) == '0,000,001,234.50'
+assert '{:0=+9_g}'.format(1) == '+0_000_001'
+assert '{:>010,}'.format(1234) == '000001,234'
+assert '{:x=10,}'.format(1234) == 'xxxxx1,234'

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -43,9 +43,12 @@ unusual_item_keys = '{0[a:b]} {0[a!b]} {0[a}b]}'
 assert unusual_item_keys.format({'a:b': 1, 'a!b': 2, 'a}b': 3}) == '1 2 3'
 
 assert '{0!s} {0!r} {0!a}'.format('räpr') == "räpr 'räpr' 'r\\xe4pr'"
+assert '{0!a}'.format('😀') == "'\\U0001f600'"
 assert '{0:>10}'.format('test') == '      test'
 assert '{0:_<10.5}'.format('xylophone') == 'xylop_____'
 assert '{0:+06.2f}'.format(3.14159) == '+03.14'
+assert '{:}'.format(True) == 'True'
+assert '{0!r:>6}'.format(123) == '   123'
 assert '{0:{align}{width}}'.format('test', align='^', width=10) == '   test   '
 assert '{0:{width}.{precision}f}'.format(2.7182, width=5, precision=2) == ' 2.72'
 assert '{0:{spec[align]}}'.format('x', spec={'align': '^5'}) == '  x  '
@@ -75,7 +78,14 @@ assert capture_error('{missing}') == ('KeyError', "'missing'")
 assert capture_error('{') == ('ValueError', "Single '{' encountered in format string")
 assert capture_error('}') == ('ValueError', "Single '}' encountered in format string")
 assert capture_error('{0!x}', 'a') == ('ValueError', 'Unknown conversion specifier x')
+assert capture_error('{0!}}', 'a') == ('ValueError', 'Unknown conversion specifier }')
+assert capture_error('{0!}{', 'a') == ('ValueError', "expected ':' after conversion specifier")
+assert capture_error('{0! }', 'a') == ('ValueError', 'Unknown conversion specifier \\x20')
+assert capture_error('{0!é}', 'a') == ('ValueError', 'Unknown conversion specifier \\xe9')
+assert capture_error('{0!😀}', 'a') == ('ValueError', 'Unknown conversion specifier \\x1f600')
 assert capture_error('{0!rs}', 'a') == ('ValueError', "expected ':' after conversion specifier")
+assert capture_error('{0:=5}', 'a') == ('ValueError', "'=' alignment not allowed in string format specifier")
+assert capture_error('{0[foo}', {'foo': 'a'}) == ('ValueError', "expected '}' before end of string")
 assert capture_error('{0!', 'a') == (
     'ValueError',
     'end of string while looking for conversion specifier',
@@ -88,6 +98,15 @@ assert capture_error('{missing!rs}') == (
     "expected ':' after conversion specifier",
 )
 assert capture_error('{missing!x}') == ('KeyError', "'missing'")
+
+
+class BrokenRepr:
+    def __repr__(self):
+        raise RuntimeError('repr failed')
+
+
+assert capture_error('{0!r:{missing}}', BrokenRepr()) == ('RuntimeError', 'repr failed')
+assert capture_error('{0!r:q}', BrokenRepr()) == ('RuntimeError', 'repr failed')
 assert capture_error('{0:.2q}', 1) == (
     'ValueError',
     "Unknown format code 'q' for object of type 'int'",
@@ -116,6 +135,10 @@ assert capture_error('{:{0}}', 1, 2) == (
 )
 assert capture_error('{0:{1:{2}}}', 1, 2, 3) == ('ValueError', 'Max string recursion exceeded')
 assert capture_error('{999999999999999999999999999999999999}', 1) == (
+    'ValueError',
+    'Too many decimal digits in format string',
+)
+assert capture_error('{0[999999999999999999999999999999999999]}', {}) == (
     'ValueError',
     'Too many decimal digits in format string',
 )

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -177,3 +177,9 @@ assert '{[0]}'.format(['a']) == 'a'
 assert '{.value}'.format(Record(1)) == '1'
 assert capture_error('{x=}', x=1) == ('KeyError', "'x='")
 assert '{:%H:%M}'.format(time(4, 5)) == '04:05'
+
+for width in range(130):
+    grouped = '{:0{},}'.format(7, width)
+    assert grouped.replace(',', '').lstrip('0') == '7'
+    assert len(grouped) in (width, width + 1), grouped
+    assert all(len(group) == 3 for group in grouped.split(',')[1:]), grouped

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -166,3 +166,9 @@ assert '{:0=15,.2f}'.format(1234.5) == '0,000,001,234.50'
 assert '{:0=+9_g}'.format(1) == '+0_000_001'
 assert '{:>010,}'.format(1234) == '000001,234'
 assert '{:x=10,}'.format(1234) == 'xxxxx1,234'
+
+assert capture_error('{0:{1:{{}}}}', 'x', 'y') == ('ValueError', 'Max string recursion exceeded')
+assert capture_error('{0:{{}}<9}', 5) == (
+    'ValueError',
+    "Invalid format specifier '{}<9' for object of type 'int'",
+)

--- a/crates/monty/test_cases/str__format.py
+++ b/crates/monty/test_cases/str__format.py
@@ -73,6 +73,10 @@ assert '{0:{spec[align]}}'.format('x', spec={'align': '^5'}) == '  x  '
 assert '{} {:{}}'.format(1, 2, 3) == '1   2'
 dt = datetime(2001, 2, 3, 4, 5)
 assert '{0:%Y-%m-%d %H:%M}'.format(dt) == '2001-02-03 04:05'
+escaped_datetime_spec = '{0:{{%Y}}}'
+assert escaped_datetime_spec.format(dt) == '{2001}'
+assert '{0:{1}} {0:>3} {0:}'.format(7, '03d') == '007   7 7'
+assert '{0:{1:}}'.format(7, '03d') == '007'
 
 assert '{{}}'.format() == '{}'
 assert '{{{0}}}'.format('x') == '{x}'

--- a/crates/monty/test_cases/str__format_long_int.py
+++ b/crates/monty/test_cases/str__format_long_int.py
@@ -1,0 +1,31 @@
+def capture_error(template, value):
+    try:
+        template.format(value)
+    except Exception as exc:
+        return type(exc).__name__, str(exc)
+    return None
+
+
+long_int = 10**20
+assert '{:b}'.format(long_int) == (
+    '1010110101111000111010111100010110101100011000100000000000000000000'
+)
+assert '{:f}'.format(long_int) == '100000000000000000000.000000'
+assert '{:F}'.format(long_int) == '100000000000000000000.000000'
+assert '{:e}'.format(long_int) == '1.000000e+20'
+assert '{:E}'.format(long_int) == '1.000000E+20'
+assert '{:g}'.format(long_int) == '1e+20'
+assert '{:G}'.format(long_int) == '1E+20'
+assert '{:%}'.format(long_int) == '10000000000000000000000.000000%'
+assert capture_error('{:f}', 10**1000) == (
+    'OverflowError',
+    'int too large to convert to float',
+)
+assert capture_error('{:c}', long_int) == (
+    'OverflowError',
+    'Python int too large to convert to C long',
+)
+assert capture_error('{:s}', long_int) == (
+    'ValueError',
+    "Unknown format code 's' for object of type 'int'",
+)

--- a/crates/monty/test_cases/str__format_long_int.py
+++ b/crates/monty/test_cases/str__format_long_int.py
@@ -7,9 +7,7 @@ def capture_error(template, value):
 
 
 long_int = 10**20
-assert '{:b}'.format(long_int) == (
-    '1010110101111000111010111100010110101100011000100000000000000000000'
-)
+assert '{:b}'.format(long_int) == ('1010110101111000111010111100010110101100011000100000000000000000000')
 assert '{:f}'.format(long_int) == '100000000000000000000.000000'
 assert '{:F}'.format(long_int) == '100000000000000000000.000000'
 assert '{:e}'.format(long_int) == '1.000000e+20'

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use monty::MontyRun;
-use monty_types::{CompileOptions, DictPairs, MontyClassInstance, MontyClassType, MontyObject, MontyUuid};
+use monty_types::{CompileOptions, DictPairs, ExcType, MontyClassInstance, MontyClassType, MontyObject, MontyUuid};
 
 /// Test we can reuse exec without borrow checker issues.
 #[test]
@@ -28,6 +28,23 @@ fn test_get_interned_string() {
     let r = ex.run_no_limits(vec![]).unwrap();
     let int_value: String = r.as_ref().try_into().unwrap();
     assert_eq!(int_value, "foobar");
+}
+
+/// Replacement fields are synchronous, so an OS-backed attribute cannot yield
+/// to the host and must fail before the call escapes the formatter.
+#[test]
+fn str_format_os_attribute_reports_suspension_limit() {
+    let ex = MontyRun::new(
+        "import os\n'{0.environ}'.format(os)".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+
+    let err = ex.run_no_limits(vec![]).unwrap_err();
+    assert_eq!(err.exc_type(), ExcType::NotImplementedError);
+    assert_eq!(err.message(), Some("str.format attribute access cannot suspend"));
 }
 
 /// Test that calling a method on a host class instance in standard execution

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -961,6 +961,23 @@ fn timeout_in_str_format_escaped_braces() {
     );
 }
 
+#[test]
+fn timeout_in_str_format_grouped_padding() {
+    let tracker = ResourceTracker::new(ResourceLimits::default().max_duration(Duration::from_millis(10)));
+    let mut repl = MontyRepl::new("test.py", tracker, CompileOptions::default());
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("'{:09223372036854775807,}'.format(1)", vec![], PrintWriter::Stdout)
+        .expect_err("grouped padding must hit the time limit before allocating the full width");
+    let elapsed = start.elapsed();
+
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "str.format() should terminate promptly, took {elapsed:?}"
+    );
+}
+
 /// Test that `bytes.splitlines()` on large bytes respects the time limit.
 ///
 /// `bytes_splitlines()` scans bytes for line endings and now checks the time limit.

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -978,10 +978,10 @@ fn timeout_in_str_format_grouped_padding() {
     );
 }
 
-/// A str field above the large-result threshold is walked and copied in polled
-/// steps, so a deadline armed before the call fires during the format itself.
+/// A str field above the large-result threshold is walked in polled steps, so a
+/// deadline armed before the call fires inside the format rather than after it.
 #[test]
-fn timeout_in_str_format_large_field_copy() {
+fn timeout_in_str_format_large_str_field() {
     let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
     repl.feed_run("s = 'x' * 20_000_000", vec![], PrintWriter::Stdout)
         .unwrap();
@@ -990,13 +990,13 @@ fn timeout_in_str_format_large_field_copy() {
     let start = Instant::now();
     let exc = repl
         .feed_run("'{0:<1}'.format(s)", vec![], PrintWriter::Stdout)
-        .expect_err("copying a large field must observe the time limit");
+        .expect_err("a large str field must observe the time limit");
     let elapsed = start.elapsed();
 
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
     assert!(
         elapsed < Duration::from_secs(2),
-        "str.format() should stop during the copy, took {elapsed:?}"
+        "str.format() should stop inside the format, took {elapsed:?}"
     );
 }
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -864,6 +864,26 @@ s.splitlines()
     assert_timeout_in_builtin(code, "str.splitlines()");
 }
 
+#[test]
+fn timeout_in_str_format_parser() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("template = '{' + 'x' * 20_000_000", vec![], PrintWriter::Stdout)
+        .unwrap();
+
+    repl.tracker_mut().set_max_duration(Duration::from_millis(50));
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("template.format()", vec![], PrintWriter::Stdout)
+        .expect_err("the format-string parser must hit the time limit");
+    let elapsed = start.elapsed();
+
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "str.format() should terminate promptly, took {elapsed:?}"
+    );
+}
+
 /// Test that `bytes.splitlines()` on large bytes respects the time limit.
 ///
 /// `bytes_splitlines()` scans bytes for line endings and now checks the time limit.

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -978,6 +978,28 @@ fn timeout_in_str_format_grouped_padding() {
     );
 }
 
+/// A str field above the large-result threshold is walked and copied in polled
+/// steps, so a deadline armed before the call fires during the format itself.
+#[test]
+fn timeout_in_str_format_large_field_copy() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("s = 'x' * 20_000_000", vec![], PrintWriter::Stdout)
+        .unwrap();
+
+    repl.tracker_mut().set_max_duration(Duration::from_millis(5));
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("'{0:<1}'.format(s)", vec![], PrintWriter::Stdout)
+        .expect_err("copying a large field must observe the time limit");
+    let elapsed = start.elapsed();
+
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "str.format() should stop during the copy, took {elapsed:?}"
+    );
+}
+
 /// Test that `bytes.splitlines()` on large bytes respects the time limit.
 ///
 /// `bytes_splitlines()` scans bytes for line endings and now checks the time limit.

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -937,6 +937,30 @@ fn timeout_in_str_format_parser() {
     );
 }
 
+#[test]
+fn timeout_in_str_format_escaped_braces() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("template = '{{' * 5_000_000", vec![], PrintWriter::Stdout)
+        .unwrap();
+
+    let start = Instant::now();
+    repl.feed_run("template.format()", vec![], PrintWriter::Stdout).unwrap();
+    let full_scan = start.elapsed();
+
+    repl.tracker_mut().set_max_duration(full_scan / 10);
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("template.format()", vec![], PrintWriter::Stdout)
+        .expect_err("escaped braces must not bypass the time limit");
+    let elapsed = start.elapsed();
+
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < full_scan / 2,
+        "str.format() should stop during the scan; full scan {full_scan:?}, timed scan {elapsed:?}"
+    );
+}
+
 /// Test that `bytes.splitlines()` on large bytes respects the time limit.
 ///
 /// `bytes_splitlines()` scans bytes for line endings and now checks the time limit.

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -513,6 +513,59 @@ fn timeout_in_list_constructor() {
     assert_timeout_in_builtin("list(range(10**18))", "list(range(10**18))");
 }
 
+/// Calibrate parsing separately so this measures traversal polling, not host speed.
+#[test]
+fn timeout_in_str_format_field_access_chain() {
+    let pause_at_interrupt = |code: &str| {
+        let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+        let progress = run
+            .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+            .unwrap();
+        let call = resolve_name_lookups(progress)
+            .unwrap()
+            .into_function_call()
+            .expect("interrupt call");
+        assert_eq!(call.function_name, "interrupt");
+        call
+    };
+
+    let scan_code = r"
+template = '{missing' + '.x' * 1_500_000 + '}'
+interrupt()
+template.format()
+";
+    let scan_call = pause_at_interrupt(scan_code);
+    let scan_started = Instant::now();
+    let scan_result = scan_call.resume(MontyObject::None, PrintWriter::Stdout);
+    let scan_elapsed = scan_started.elapsed();
+    assert_eq!(scan_result.unwrap_err().exc_type(), ExcType::KeyError);
+    let traversal_budget = scan_elapsed.saturating_mul(3);
+
+    let code = r"
+class Value:
+    pass
+
+value = Value()
+value.x = value
+template = '{0' + '.x' * 1_500_000 + '}'
+interrupt()
+template.format(value)
+";
+    let mut call = pause_at_interrupt(code);
+
+    call.tracker_mut().set_max_duration(traversal_budget);
+    let started = Instant::now();
+    let result = call.resume(MontyObject::None, PrintWriter::Stdout);
+    let elapsed = started.elapsed();
+
+    let exc = result.expect_err("field traversal should exceed the time limit");
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < traversal_budget.saturating_mul(4),
+        "field traversal should terminate promptly, took {elapsed:?}"
+    );
+}
+
 /// Covers all four substring scanners; `index`/`rindex` share theirs with
 /// `find`/`rfind`.
 const BYTES_SEARCH_EXPRS: &[&str] = &[

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -923,7 +923,14 @@ fn timeout_in_str_format_parser() {
     repl.feed_run("template = '{' + 'x' * 20_000_000", vec![], PrintWriter::Stdout)
         .unwrap();
 
-    repl.tracker_mut().set_max_duration(Duration::from_millis(50));
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("template.format()", vec![], PrintWriter::Stdout)
+        .expect_err("an unterminated field must fail without a time limit");
+    let full_scan = start.elapsed();
+    assert_eq!(exc.exc_type(), ExcType::ValueError);
+
+    repl.tracker_mut().set_max_duration(full_scan / 10);
     let start = Instant::now();
     let exc = repl
         .feed_run("template.format()", vec![], PrintWriter::Stdout)
@@ -932,8 +939,8 @@ fn timeout_in_str_format_parser() {
 
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
     assert!(
-        elapsed < Duration::from_secs(2),
-        "str.format() should terminate promptly, took {elapsed:?}"
+        elapsed < full_scan / 2,
+        "str.format() should stop during the scan; full scan {full_scan:?}, timed scan {elapsed:?}"
     );
 }
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -945,6 +945,33 @@ fn timeout_in_str_format_parser() {
 }
 
 #[test]
+fn timeout_in_str_format_receiver_snapshot() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("template = '{missing}' + 'x' * 20_000_000", vec![], PrintWriter::Stdout)
+        .unwrap();
+
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("template.format()", vec![], PrintWriter::Stdout)
+        .expect_err("the missing field must fail after snapshotting the receiver");
+    let full_snapshot = start.elapsed();
+    assert_eq!(exc.exc_type(), ExcType::KeyError);
+
+    repl.tracker_mut().set_max_duration(full_snapshot / 10);
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("template.format()", vec![], PrintWriter::Stdout)
+        .expect_err("the receiver snapshot must hit the time limit before field lookup");
+    let elapsed = start.elapsed();
+
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < full_snapshot / 2,
+        "str.format() should stop while copying the receiver; full snapshot {full_snapshot:?}, timed snapshot {elapsed:?}"
+    );
+}
+
+#[test]
 fn timeout_in_str_format_escaped_braces() {
     let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
     repl.feed_run("template = '{{' * 5_000_000", vec![], PrintWriter::Stdout)

--- a/docs/limitations/datetime.md
+++ b/docs/limitations/datetime.md
@@ -151,7 +151,7 @@ CPython (`strftime('%Q') == '%Q'`, `strftime('%') == '%'`). This is a choice
 of *one* CPython, not all of them: macOS CPython instead drops the `%`
 (`strftime('%Q') == 'Q'`), because unknown-directive handling is delegated to
 the platform C library and is genuinely platform-dependent. The same
-pass-through applies to f-string formatting (below).
+pass-through applies to f-string and `str.format()` formatting (below).
 
 ### Directives that need data the value lacks
 
@@ -169,11 +169,11 @@ the way CPython does. The known cases:
     yields `'+0200'` / `'CEST'`. Threading the timezone through formatting is not
     yet implemented.
 
-f-strings format `date`, `datetime` and `time` values through `strftime`, matching
-CPython's `__format__`: `f'{dt:%Y-%m-%d}'` is equivalent to
-`dt.strftime('%Y-%m-%d')`, and an empty spec (`f'{dt}'` or `f'{dt:}'`) uses
-`str(dt)`. One edge-case divergence: a spec that also happens to be a valid
-format mini-language spec (e.g. `f'{dt:>10}'` or a lone `f'{dt:%}'`) is
-applied as generic string formatting rather than handed to `strftime`, where
-CPython treats the *entire* spec as a `strftime` string. Real strftime specs
-(those containing `%` directives like `%Y`) are unaffected.
+f-strings and `str.format()` format `date`, `datetime` and `time` values through
+`strftime`, matching CPython's `__format__`: `f'{dt:%Y-%m-%d}'` and
+`'{:%Y-%m-%d}'.format(dt)` are equivalent to `dt.strftime('%Y-%m-%d')`, and
+an empty spec uses `str(dt)`. One edge-case divergence remains for a literal
+f-string spec that is also a valid format mini-language spec (e.g.
+`f'{dt:>10}'` or a lone `f'{dt:%}'`): Monty applies generic string formatting,
+where CPython treats the entire spec as a `strftime` string. Dynamically built
+f-string specs and `str.format()` specs are handed to `strftime`.

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -39,6 +39,12 @@ like `d` for integers and `g` for floats, with no digit grouping. CPython
 under a grouping locale would insert locale-specific separators; Monty never
 does.
 
+## Grouped zero-padding
+
+With explicit `=` alignment, zero fill, and `_` grouping, `g` formatting can
+omit separators: `'{0:0=+9_g}'.format(1)` returns `+00000001` instead of
+CPython's `+0_000_001`.
+
 ## `repr` of non-printable Unicode
 
 `repr` escapes non-printable code points via the `unicode-general-category`

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -39,12 +39,6 @@ like `d` for integers and `g` for floats, with no digit grouping. CPython
 under a grouping locale would insert locale-specific separators; Monty never
 does.
 
-## Grouped zero-padding
-
-With explicit `=` alignment, zero fill, and `_` grouping, `g` formatting can
-omit separators: `'{0:0=+9_g}'.format(1)` returns `+00000001` instead of
-CPython's `+0_000_001`.
-
 ## `repr` of non-printable Unicode
 
 `repr` escapes non-printable code points via the `unicode-general-category`

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -6,6 +6,12 @@ positional and keyword fields, automatic and manual numbering, attribute and
 item access, `!s` / `!r` / `!a` conversions, nested replacement fields in
 format specs, and escaped braces.
 
+Attribute access is limited to lookups that complete inside the sandbox.
+If a replacement field needs a host operation, such as
+`'{0.environ}'.format(os)`, Monty raises
+`NotImplementedError: str.format attribute access cannot suspend` instead of
+returning the attribute as CPython does.
+
 The other CPython formatting entry points are not implemented:
 
 - The `format()` builtin raises `NameError`, and `str.format_map()` raises

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -1,12 +1,15 @@
-# Format mini-language (f-string specs)
+# String formatting
 
 Monty implements CPython 3.14's format mini-language for f-string
-interpolations. The mini-language is only reachable through f-strings.
+interpolations and `str.format()` replacement fields. `str.format()` supports
+positional and keyword fields, automatic and manual numbering, attribute and
+item access, `!s` / `!r` / `!a` conversions, nested replacement fields in
+format specs, and escaped braces.
 
-The other CPython formatting mechanisms are not implemented:
+The other CPython formatting entry points are not implemented:
 
-- The `format()` builtin raises `NameError` and the `str.format()` method
-    raises `AttributeError` (see [builtins.md](builtins.md)).
+- The `format()` builtin raises `NameError`, and `str.format_map()` raises
+    `AttributeError` (see [builtins.md](builtins.md)).
 - Printf-style `%` formatting (`'%5.3f' % math.pi`, `'%s %s' % (a, b)`) is not
     implemented. `str` has no `__mod__`, so `str % value` raises
     `TypeError: unsupported operand type(s) for %: 'str' and '...'`. Use an
@@ -14,8 +17,9 @@ The other CPython formatting mechanisms are not implemented:
 
 ## Custom `__format__`
 
-f-strings dispatch to a type's `__format__` only for `date`, `datetime` and
-`time`, which interpret the spec as a `strftime` string (`f'{dt:%Y-%m-%d}'`); see
+f-strings and `str.format()` dispatch to a type's `__format__` only for
+`date`, `datetime` and `time`, which interpret the spec as a `strftime` string
+(`f'{dt:%Y-%m-%d}'` or `'{:%Y-%m-%d}'.format(dt)`); see
 [datetime.md](datetime.md). There is no general `__format__` protocol: user
 classes can't customise formatting (see [classes.md](classes.md)), and all
 other types use the builtin mini-language formatter. A format spec on a
@@ -46,13 +50,16 @@ CPython prints it literally, or the reverse. Common text is unaffected.
 
 ## When spec errors are raised
 
-CPython validates a *static* (literal) spec only when the f-string executes, so
-a malformed spec in dead code never raises. Monty validates literal specs at
-**compile time** for the structurally-malformed cases: two or more trailing
+CPython validates a *static* (literal) f-string spec only when the f-string
+executes, so a malformed spec in dead code never raises. Monty validates
+literal f-string specs at **compile time** for the structurally-malformed cases:
+two or more trailing
 characters after the type field (`f'{1:kk}'`, `f'{1:10xyz}'`) and `usize`
 overflow, raising `SyntaxError` instead of CPython's runtime `ValueError`. The
 message text otherwise matches, minus CPython's `for object of type '...'`
 suffix, which needs the runtime value type. Specs whose error *is*
-value-type-dependent or only resolvable at format time (`Unknown format code 'k'`, the `Cannot specify …` grouping
-conflicts, and `Format specifier missing precision`) are deferred to runtime and raise the exact CPython `ValueError`,
-as do all dynamically-built specs (`f'{1:{spec}}'`).
+value-type-dependent or only resolvable at format time (`Unknown format code
+'k'`, the `Cannot specify …` grouping conflicts, and `Format specifier missing
+precision`) are deferred to runtime and raise the exact CPython `ValueError`,
+as do all dynamically-built specs (`f'{1:{spec}}'`) and all `str.format()`
+specs.

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -64,8 +64,6 @@ characters after the type field (`f'{1:kk}'`, `f'{1:10xyz}'`) and `usize`
 overflow, raising `SyntaxError` instead of CPython's runtime `ValueError`. The
 message text otherwise matches, minus CPython's `for object of type '...'`
 suffix, which needs the runtime value type. Specs whose error *is*
-value-type-dependent or only resolvable at format time (`Unknown format code
-'k'`, the `Cannot specify …` grouping conflicts, and `Format specifier missing
-precision`) are deferred to runtime and raise the exact CPython `ValueError`,
+value-type-dependent or only resolvable at format time (`Unknown format code 'k'`, the `Cannot specify …` grouping conflicts, and `Format specifier missing precision`) are deferred to runtime and raise the exact CPython `ValueError`,
 as do all dynamically-built specs (`f'{1:{spec}}'`) and all `str.format()`
 specs.

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -49,8 +49,9 @@ CPython prints it literally, or the reverse. Common text is unaffected.
 ## Width / precision bounds
 
 - A `width` or `precision` whose decimal value overflows `usize` raises
-    `SyntaxError: Invalid format specifier '...': width or precision overflows usize` rather than being accepted.
-    CPython is bounded only by memory.
+    `SyntaxError: Invalid format specifier '...': width or precision overflows usize` in a literal f-string spec.
+    Runtime specs, including `str.format()`, raise `ValueError` instead, with an additional
+    `for object of type '...'` suffix.
 - Very large widths/precisions are additionally bounded by the resource
     tracker; see [resource_limits.md](resource_limits.md).
 

--- a/docs/limitations/index.md
+++ b/docs/limitations/index.md
@@ -31,7 +31,7 @@ They exist for development and for agents debugging code that runs on Monty; mos
 - `try` / `except` / `else` / `finally`, `raise ... from ...`
 - `for`, `while`, `if` / `elif` / `else`, `break`, `continue`, `pass`, `assert`, `global`, `nonlocal`, `return`
 - `with` statements, for files and for classes implementing `__enter__` / `__exit__`
-- f-strings, including `=`, `!r` / `!s` / `!a` and format specs
+- f-strings and `str.format()`, including `!r` / `!s` / `!a`, format specs and nested replacement fields
 - `async` / `await`, and `asyncio.run` / `asyncio.gather`
 - `import x`, `import x.y`, `from x import y, z as w`
 - Starred unpacking everywhere CPython allows it
@@ -116,8 +116,8 @@ Each links to the page that owns it, which is where the full account lives:
     `run` and `gather`, the latter running host calls concurrently.
     `create_task`, `sleep` and everything else do not exist
     ([asyncio.md](asyncio.md)).
-- **`str.format()` and `%`-formatting are not implemented.** Use f-strings
-    ([format.md](format.md)).
+- **`str.format_map()`, the `format()` builtin and `%`-formatting are not implemented.** Use `str.format()` or
+    f-strings ([format.md](format.md)).
 - **Only UTF-8, ASCII, UTF-16 and UTF-32 codecs exist.** `latin-1` and friends raise `LookupError`
     ([encoding.md](encoding.md)).
 

--- a/docs/limitations/index.md
+++ b/docs/limitations/index.md
@@ -31,7 +31,7 @@ They exist for development and for agents debugging code that runs on Monty; mos
 - `try` / `except` / `else` / `finally`, `raise ... from ...`
 - `for`, `while`, `if` / `elif` / `else`, `break`, `continue`, `pass`, `assert`, `global`, `nonlocal`, `return`
 - `with` statements, for files and for classes implementing `__enter__` / `__exit__`
-- f-strings and `str.format()`, including `!r` / `!s` / `!a`, format specs and nested replacement fields
+- f-strings and `str.format()`, including `=`, `!r` / `!s` / `!a`, format specs and nested replacement fields
 - `async` / `await`, and `asyncio.run` / `asyncio.gather`
 - `import x`, `import x.y`, `from x import y, z as w`
 - Starred unpacking everywhere CPython allows it

--- a/docs/limitations/index.md
+++ b/docs/limitations/index.md
@@ -117,7 +117,7 @@ Each links to the page that owns it, which is where the full account lives:
     `run` and `gather`, the latter running host calls concurrently.
     `create_task`, `sleep` and everything else do not exist
     ([asyncio.md](asyncio.md)).
-- **`str.format_map()`, the `format()` builtin and `%`-formatting are not implemented.** Use `str.format()` or
+- **The `format()` builtin and `%`-formatting are not implemented.** Use `str.format()` or
     f-strings ([format.md](format.md)).
 - **Only UTF-8, ASCII, UTF-16 and UTF-32 codecs exist.** `latin-1` and friends raise `LookupError`
     ([encoding.md](encoding.md)).

--- a/docs/limitations/index.md
+++ b/docs/limitations/index.md
@@ -31,7 +31,8 @@ They exist for development and for agents debugging code that runs on Monty; mos
 - `try` / `except` / `else` / `finally`, `raise ... from ...`
 - `for`, `while`, `if` / `elif` / `else`, `break`, `continue`, `pass`, `assert`, `global`, `nonlocal`, `return`
 - `with` statements, for files and for classes implementing `__enter__` / `__exit__`
-- f-strings and `str.format()`, including `=`, `!r` / `!s` / `!a`, format specs and nested replacement fields
+- f-strings (including the `=` debug form) and `str.format()`, with `!r` / `!s` / `!a` conversions, format specs and
+    nested replacement fields
 - `async` / `await`, and `asyncio.run` / `asyncio.gather`
 - `import x`, `import x.y`, `from x import y, z as w`
 - Starred unpacking everywhere CPython allows it

--- a/docs/limitations/resource_limits.md
+++ b/docs/limitations/resource_limits.md
@@ -32,9 +32,10 @@ WebAssembly runtimes do.
     (`str.replace`, `bytes.replace`), `re.sub`, padding (`str.ljust`, `str.center`,
     `str.zfill`, `bytes.ljust`, …), integer division and `divmod`, deque
     rotation, slicing and repeat, materialising an iterator into a
-    container, and f-string formatting
-    (both dynamic width `f"{v:>{w}}"` and dynamic precision on float
-    formats `f"{v:.{p}f}"` / `e` / `%`). The pre-check threshold is 100 KB:
+    container, and string formatting with dynamic width or precision, for
+    both f-strings (`f"{v:>{w}}"`, `f"{v:.{p}f}"`) and `str.format()`
+    (`"{0:>{1}}".format(v, w)`, `"{0:.{1}f}".format(v, p)`). The pre-check
+    threshold is 100 KB:
     estimates above that are checked against the remaining budget and rejected
     with `MemoryError` before allocation when they would exceed it.
 - `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -78,7 +78,7 @@ Size the limit with headroom, and use an OS or cgroup limit to bound the process
 Operations whose result size is predictable from their inputs are **pre-checked before allocating**, above a 100 KB
 threshold, including integer multiplication, division and `divmod`, left shift, integer power, sequence repeat
 (`'x' * n`), `str.replace` / `bytes.replace`, `re.sub`, the padding methods, deque rotation and slicing, materialising
-an iterator into a container, and f-string formatting with a dynamic width or precision.
+an iterator into a container, and f-string or `str.format()` formatting with a dynamic width or precision.
 So `'x' * 10**12` fails immediately rather than after consuming the machine's memory.
 
 A few integer operations carry their own caps regardless of `max_memory`:


### PR DESCRIPTION
`str.format()` currently raises `AttributeError`, even though Monty already supports the equivalent f-string format machinery.
This adds a runtime replacement-field parser and reuses the existing formatter.

The implemented scope covers automatic, positional and named fields, attribute and item lookups, conversions, nested format specs, and escaped braces.
The parser and mini-language amplification paths use the existing resource and deadline controls. Temporal formatting reuses the pre-existing date / datetime / time strftime path.
The shared formatter also fixes grouped zero fill under an explicit `0=` for both f-strings and `str.format()`, removing the corresponding `limitations/format.md` entry. Grouped-width sizing is now computed directly rather than with an incremental loop.

`format_map`, `%` formatting, the `format()` builtin, and general custom `__format__` dispatch are unchanged.

Tests cover CPython comparisons, f-string regressions, reference cleanup, Unicode decimal indexes, memory limits, and parser deadlines.

Rebased after #773 and #682, preserving `datetime.time` formatting and the current `ClassInstance` integration.

Deferred follow-ups:

- `push_tracked` in `str_format.rs` stays until #591 moves the tracker to the VM.
- A literal f-string spec on `date`, `datetime` or `time` still takes the mini-language path (limitations/datetime.md); fixing it is a bytecode-format change.
- Temporal `strftime` output is built outside `StringBuilder`; it is a constant multiple of the spec, so it stays on the hard limit for now.

Closes #766
