### PR TITLE
Fix REPL continuation after decorators

### DIFF
--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -873,12 +873,15 @@ pub fn detect_repl_continuation_mode(source: &str) -> ReplContinuationMode {
     let Err(error) = parse_module(source) else {
         return ReplContinuationMode::Complete;
     };
+    let error_is_at_end = error.location.is_empty() && error.location.start().to_usize() == source.len();
 
     match error.error {
         ParseErrorType::OtherError(msg) => {
             if msg.starts_with("Expected an indented block after ") {
                 ReplContinuationMode::IncompleteBlock
-            } else if msg == "Expected class, function definition or async function definition after decorator" {
+            } else if msg == "Expected class, function definition or async function definition after decorator"
+                && error_is_at_end
+            {
                 ReplContinuationMode::IncompleteImplicit
             } else {
                 ReplContinuationMode::Complete

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -863,6 +863,7 @@ pub enum ReplContinuationMode {
 ///
 /// This mirrors CPython's broad interactive behavior:
 /// - Incomplete bracketed / parenthesized / triple-quoted constructs continue.
+/// - Decorators continue until their class or function definition arrives.
 /// - Clause headers (`if:`, `def:`, etc.) require an indented body and then a
 ///   terminating blank line before execution.
 /// - All other parse outcomes are treated as complete (either valid code or a
@@ -877,6 +878,8 @@ pub fn detect_repl_continuation_mode(source: &str) -> ReplContinuationMode {
         ParseErrorType::OtherError(msg) => {
             if msg.starts_with("Expected an indented block after ") {
                 ReplContinuationMode::IncompleteBlock
+            } else if msg == "Expected class, function definition or async function definition after decorator" {
+                ReplContinuationMode::IncompleteImplicit
             } else {
                 ReplContinuationMode::Complete
             }

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -222,6 +222,14 @@ fn repl_detects_continuation_mode_for_common_cases() {
         ReplContinuationMode::IncompleteImplicit
     );
     assert_eq!(
+        detect_repl_continuation_mode("@decorator\nvalue = 1"),
+        ReplContinuationMode::Complete
+    );
+    assert_eq!(
+        detect_repl_continuation_mode("@decorator\nvalue = 1\n"),
+        ReplContinuationMode::Complete
+    );
+    assert_eq!(
         detect_repl_continuation_mode("@decorator\nclass SearchResult:\n"),
         ReplContinuationMode::IncompleteBlock
     );

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -213,6 +213,27 @@ fn repl_detects_continuation_mode_for_common_cases() {
         detect_repl_continuation_mode("[1,\n"),
         ReplContinuationMode::IncompleteImplicit
     );
+    assert_eq!(
+        detect_repl_continuation_mode("@decorator\n"),
+        ReplContinuationMode::IncompleteImplicit
+    );
+    assert_eq!(
+        detect_repl_continuation_mode("@first\n@second\n"),
+        ReplContinuationMode::IncompleteImplicit
+    );
+    assert_eq!(
+        detect_repl_continuation_mode("@decorator\nclass SearchResult:\n"),
+        ReplContinuationMode::IncompleteBlock
+    );
+    assert_eq!(
+        detect_repl_continuation_mode("@decorator\ndef search():\n"),
+        ReplContinuationMode::IncompleteBlock
+    );
+    assert_eq!(
+        detect_repl_continuation_mode("@decorator\nasync def search():\n"),
+        ReplContinuationMode::IncompleteBlock
+    );
+    assert_eq!(detect_repl_continuation_mode("@\n"), ReplContinuationMode::Complete);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep collecting REPL input after one or more decorators
- transition to block continuation once the decorated class or function header arrives
- preserve immediate syntax errors for malformed decorator input

## Tests

- `cargo test -p monty`
- `cargo test -p monty --test repl`
- `make format-rs`
- `make lint-rs` *(blocked by an unrelated Clippy 1.96 `unnecessary_box_returns` warning in `crates/monty/src/heap/stable_heap.rs:226`)*