### PR TITLE
Continue REPL input for triple-quoted strings

### DIFF
--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -929,10 +929,10 @@ fn starts_with_triple_quote(source: &str) -> bool {
     // quote distinguishes the forms without treating `"unfinished` as input
     // that should continue.
     let bytes = source.as_bytes();
-    let Some(quote_start) = bytes.iter().position(|byte| matches!(byte, b'\'' | b'"')) else {
-        return false;
-    };
-    matches!(bytes.get(quote_start..quote_start + 3), Some(b"'''" | b"\"\"\""))
+    bytes
+        .iter()
+        .position(|byte| matches!(byte, b'\'' | b'"'))
+        .is_some_and(|quote_start| matches!(bytes.get(quote_start..quote_start + 3), Some(b"'''" | b"\"\"\"")))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -887,6 +887,9 @@ pub fn detect_repl_continuation_mode(source: &str) -> ReplContinuationMode {
         return ReplContinuationMode::Complete;
     };
     let error_is_at_end = error.location.is_empty() && error.location.start().to_usize() == source.len();
+    let error_source = source
+        .get(error.location.start().to_usize()..error.location.end().to_usize())
+        .unwrap_or_default();
 
     match error.error {
         ParseErrorType::OtherError(msg) => {
@@ -900,7 +903,11 @@ pub fn detect_repl_continuation_mode(source: &str) -> ReplContinuationMode {
                 ReplContinuationMode::Complete
             }
         }
-        ParseErrorType::Lexical(LexicalErrorType::Eof)
+        ParseErrorType::Lexical(
+            LexicalErrorType::Eof
+            | LexicalErrorType::FStringError(InterpolatedStringErrorType::UnterminatedTripleQuotedString)
+            | LexicalErrorType::TStringError(InterpolatedStringErrorType::UnterminatedTripleQuotedString),
+        )
         | ParseErrorType::ExpectedToken {
             found: TokenKind::EndOfFile,
             ..
@@ -909,8 +916,23 @@ pub fn detect_repl_continuation_mode(source: &str) -> ReplContinuationMode {
         | ParseErrorType::TStringError(InterpolatedStringErrorType::UnterminatedTripleQuotedString) => {
             ReplContinuationMode::IncompleteImplicit
         }
+        ParseErrorType::Lexical(LexicalErrorType::UnclosedStringError) if starts_with_triple_quote(error_source) => {
+            ReplContinuationMode::IncompleteImplicit
+        }
         _ => ReplContinuationMode::Complete,
     }
+}
+
+fn starts_with_triple_quote(source: &str) -> bool {
+    // Ruff uses `UnclosedStringError` for both single- and triple-quoted plain
+    // strings. Its error range starts at the optional prefix, so the first
+    // quote distinguishes the forms without treating `"unfinished` as input
+    // that should continue.
+    let bytes = source.as_bytes();
+    let Some(quote_start) = bytes.iter().position(|byte| matches!(byte, b'\'' | b'"')) else {
+        return false;
+    };
+    matches!(bytes.get(quote_start..quote_start + 3), Some(b"'''" | b"\"\"\""))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -215,6 +215,31 @@ fn repl_detects_continuation_mode_for_common_cases() {
         detect_repl_continuation_mode("[1,\n"),
         ReplContinuationMode::IncompleteImplicit
     );
+    for source in [
+        "value = '''first line\n",
+        "value = \"\"\"first line\n",
+        "value = r\"\"\"first line\n",
+        "value = b\"\"\"first line\n",
+        "value = f\"\"\"first line\n",
+        "value = t\"\"\"first line\n",
+    ] {
+        assert_eq!(
+            detect_repl_continuation_mode(source),
+            ReplContinuationMode::IncompleteImplicit,
+            "source: {source:?}",
+        );
+    }
+    for source in ["value = 'first line\n", "value = \"first line\n"] {
+        assert_eq!(
+            detect_repl_continuation_mode(source),
+            ReplContinuationMode::Complete,
+            "source: {source:?}",
+        );
+    }
+    assert_eq!(
+        detect_repl_continuation_mode("value = \"\"\"first line\nsecond line\"\"\"\n"),
+        ReplContinuationMode::Complete
+    );
     assert_eq!(
         detect_repl_continuation_mode("@decorator\n"),
         ReplContinuationMode::IncompleteImplicit


### PR DESCRIPTION
## Summary

- recognize unfinished plain triple-quoted strings as implicit REPL continuation while preserving immediate errors for ordinary unclosed strings
- handle lexer-wrapped unterminated triple-quoted f- and t-string errors
- cover single-quote, double-quote, raw, bytes, f-string, and t-string forms

## Tests

- `cargo test -p monty`
- manual `monty` REPL multiline assignment and evaluation
- `make format-rs`
- `cargo clippy -p monty --tests -- -D warnings -A clippy::unnecessary_box_returns`

`make lint-rs` is otherwise blocked locally by the unrelated Clippy 1.96 `unnecessary_box_returns` warning in `crates/monty/src/heap/stable_heap.rs:226`.