### PR TITLE
Clamp sequence-search bounds the way CPython does

### DIFF
--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -88,7 +88,7 @@ use crate::{
     types::{
         List,
         long_int::repeat_count,
-        slice::{normalize_sequence_index, slice_collect_iterator},
+        slice::{optional_sequence_bound, slice_collect_iterator},
     },
     value::{EitherStr, Value, eq_bytes},
 };
@@ -798,13 +798,13 @@ fn parse_bytes_prefix_suffix_args(
         }
         [prefix_value, start_value] => {
             let prefix = extract_bytes_for_prefix_suffix(prefix_value, method, vm)?;
-            let start = normalize_sequence_index(start_value.as_int(vm)?, len);
+            let start = optional_sequence_bound(start_value, 0, len, vm)?;
             (prefix, start, len)
         }
         [prefix_value, start_value, end_value] => {
             let prefix = extract_bytes_for_prefix_suffix(prefix_value, method, vm)?;
-            let start = normalize_sequence_index(start_value.as_int(vm)?, len);
-            let end = normalize_sequence_index(end_value.as_int(vm)?, len);
+            let start = optional_sequence_bound(start_value, 0, len, vm)?;
+            let end = optional_sequence_bound(end_value, len, len, vm)?;
             (prefix, start, end)
         }
         [] => return Err(ExcType::type_error_at_least(method, 1, 0)),
@@ -911,12 +911,12 @@ fn parse_bytes_sub_args(
     let (sub_value, start, end) = match pos.as_slice() {
         [sub_value] => (sub_value, 0, len),
         [sub_value, start_value] => {
-            let start = normalize_sequence_index(start_value.as_int(vm)?, len);
+            let start = optional_sequence_bound(start_value, 0, len, vm)?;
             (sub_value, start, len)
         }
         [sub_value, start_value, end_value] => {
-            let start = normalize_sequence_index(start_value.as_int(vm)?, len);
-            let end = normalize_sequence_index(end_value.as_int(vm)?, len);
+            let start = optional_sequence_bound(start_value, 0, len, vm)?;
+            let end = optional_sequence_bound(end_value, len, len, vm)?;
             (sub_value, start, end)
         }
         [] => return Err(ExcType::type_error_at_least(method, 1, 0)),

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -9,7 +9,12 @@ use crate::{
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource_checks::{check_estimated_size, check_repeat_size},
-    types::{LazyHeapSet, Type, list::repr_items_fmt, long_int::repeat_count},
+    types::{
+        LazyHeapSet, Type,
+        list::repr_items_fmt,
+        long_int::repeat_count,
+        slice::{normalize_sequence_index, value_to_i64_bound},
+    },
     value::{EitherStr, VALUE_SIZE, Value},
 };
 
@@ -971,31 +976,11 @@ fn count<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>) 
 ///
 /// `None` means "not supplied" and falls back to `default`; an explicit
 /// `Value::None` is a *bad argument*, matching CPython (`index()` bounds go through
-/// `_PyEval_SliceIndexNotNone`, unlike real slicing which accepts `None`). Big ints
-/// clamp by sign rather than erroring, since CPython's `__index__` path accepts any
-/// int and then clamps.
+/// `_PyEval_SliceIndexNotNone`, unlike real slicing which accepts `None`).
 fn bound_arg(value: Option<Value>, default: usize, len: usize, vm: &mut VM<'_>) -> RunResult<usize> {
-    let len_i64 = i64::try_from(len).expect("len fits in i64");
     let Some(value) = value else { return Ok(default) };
-    // Match by reference so there is exactly one `drop_with` for the bound, on
-    // every path — the accepted ones as well as the rejection below.
-    let raw = match &value {
-        Value::Int(i) => Some(*i),
-        Value::Bool(b) => Some(i64::from(*b)),
-        // Out of `i64` range entirely — saturate to the end the sign points at.
-        Value::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
-            Some(li.to_i64().unwrap_or(if li.is_negative() { 0 } else { len_i64 }))
-        }
-        _ => None,
-    };
-    value.drop_with(vm);
-    let raw = raw.ok_or_else(ExcType::type_error_slice_indices_no_none)?;
-    let normalized = if raw < 0 {
-        (raw + len_i64).max(0)
-    } else {
-        raw.min(len_i64)
-    };
-    Ok(usize::try_from(normalized).expect("bound clamped non-negative"))
+    defer_drop!(value, vm);
+    Ok(normalize_sequence_index(value_to_i64_bound(value, vm)?, len))
 }
 
 /// Which end [`deque_extend`] appends each item to.

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -916,23 +916,22 @@ fn index<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>) 
         stop,
     } = IndexArgs::from_args(args, vm)?;
     defer_drop!(target, vm);
+    defer_drop!(start, vm);
+    defer_drop!(stop, vm);
+
+    // Both bounds are coerced before the length is read, because coercion can run a
+    // user `__index__` that mutates this deque. Reading the length first would
+    // resolve a negative bound against a stale size and let the walk below index
+    // past the end of a shortened deque, which panics.
+    let start_arg = coerce_bound(start.as_ref(), vm)?;
+    let stop_arg = coerce_bound(stop.as_ref(), vm)?;
 
     let len = deque.get(vm.heap).len();
-    // `stop` is already bound, so a failure resolving `start` has to release it
-    // before propagating — `bound_arg` only owns the value it was handed.
-    let start = match bound_arg(start, 0, len, vm) {
-        Ok(start) => start,
-        Err(e) => {
-            if let Some(stop) = stop {
-                stop.drop_with(vm);
-            }
-            return Err(e);
-        }
-    };
-    let stop = bound_arg(stop, len, len, vm)?;
+    let start = start_arg.map_or(0, |i| normalize_sequence_index(i, len));
+    let stop = stop_arg.map_or(len, |i| normalize_sequence_index(i, len));
 
     let start_state = deque.get(vm.heap).state();
-    for i in start..stop.min(len) {
+    for i in start..stop {
         let item = deque.get(vm.heap).items[i].clone_with_heap(vm.heap);
         defer_drop!(item, vm);
         if item.py_eq(target, vm)? {
@@ -972,15 +971,16 @@ fn count<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>) 
     Ok(Value::Int(total))
 }
 
-/// Normalizes an optional `start`/`stop` bound for `index`, clamping to `[0, len]`.
+/// Coerces an optional `index` bound to an `i64`, leaving normalization to the caller.
 ///
-/// `None` means "not supplied" and falls back to `default`; an explicit
-/// `Value::None` is a *bad argument*, matching CPython (`index()` bounds go through
-/// `_PyEval_SliceIndexNotNone`, unlike real slicing which accepts `None`).
-fn bound_arg(value: Option<Value>, default: usize, len: usize, vm: &mut VM<'_>) -> RunResult<usize> {
-    let Some(value) = value else { return Ok(default) };
-    defer_drop!(value, vm);
-    Ok(normalize_sequence_index(value_to_i64_bound(value, vm)?, len))
+/// `None` means "not supplied"; an explicit `Value::None` is a *bad argument*, matching
+/// CPython (`index()` bounds go through `_PyEval_SliceIndexNotNone`, unlike real slicing
+/// which accepts `None`). Normalization is deliberately not done here — see [`index`].
+fn coerce_bound(value: Option<&Value>, vm: &mut VM<'_>) -> RunResult<Option<i64>> {
+    match value {
+        Some(value) => Ok(Some(value_to_i64_bound(value, vm)?)),
+        None => Ok(None),
+    }
 }
 
 /// Which end [`deque_extend`] appends each item to.

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{
         LazyHeapSet, Type,
         long_int::repeat_count,
-        slice::{normalize_sequence_index, slice_collect_iterator},
+        slice::{normalize_sequence_index, slice_collect_iterator, value_to_i64_bound},
     },
     value::{EitherStr, VALUE_SIZE, Value},
 };
@@ -826,15 +826,19 @@ fn list_index<'h>(list: &HeapRead<'h, List>, args: ArgValues, vm: &mut VM<'h>) -
     let pos_args = args.into_pos_only("list.index", vm.heap)?;
     defer_drop!(pos_args, vm);
 
-    // Bounds are coerced before the length is read: `as_int` may dispatch a user
-    // `__index__` that mutates this list, and CPython normalizes against the
+    // Bounds are coerced before the length is read: the coercion may dispatch a
+    // user `__index__` that mutates this list, and CPython normalizes against the
     // length *after* argument parsing. Reading it first would resolve a negative
     // bound against a stale length and search the wrong window.
     let (value, start_arg, end_arg) = match pos_args.as_slice() {
         [] => return Err(ExcType::type_error_at_least("list.index", 1, 0)),
         [value] => (value, None, None),
-        [value, start_arg] => (value, Some(start_arg.as_int(vm)?), None),
-        [value, start_arg, end_arg] => (value, Some(start_arg.as_int(vm)?), Some(end_arg.as_int(vm)?)),
+        [value, start_arg] => (value, Some(value_to_i64_bound(start_arg, vm)?), None),
+        [value, start_arg, end_arg] => (
+            value,
+            Some(value_to_i64_bound(start_arg, vm)?),
+            Some(value_to_i64_bound(end_arg, vm)?),
+        ),
         other => return Err(ExcType::type_error_at_most("list.index", 3, other.len())),
     };
 

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -42,7 +42,7 @@ use crate::{
         iter::collect_owned_iterable,
         long_int::repeat_count,
         py_trait::LazyHeapSet,
-        slice::{normalize_sequence_index, slice_collect_iterator},
+        slice::{normalize_sequence_index, slice_collect_iterator, value_to_i64_bound},
         str::allocate_string,
         tuple::TupleVec,
     },
@@ -674,12 +674,12 @@ impl<'h> HeapRead<'h, NamedTuple> {
             [] => return Err(ExcType::type_error_at_least("tuple.index", 1, 0)),
             [value] => (value, 0, len),
             [value, start_arg] => {
-                let start = normalize_sequence_index(start_arg.as_int(vm)?, len);
+                let start = normalize_sequence_index(value_to_i64_bound(start_arg, vm)?, len);
                 (value, start, len)
             }
             [value, start_arg, end_arg] => {
-                let start = normalize_sequence_index(start_arg.as_int(vm)?, len);
-                let end = normalize_sequence_index(end_arg.as_int(vm)?, len).max(start);
+                let start = normalize_sequence_index(value_to_i64_bound(start_arg, vm)?, len);
+                let end = normalize_sequence_index(value_to_i64_bound(end_arg, vm)?, len).max(start);
                 (value, start, end)
             }
             other => return Err(ExcType::type_error_at_most("tuple.index", 3, other.len())),

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -134,34 +134,61 @@ impl Slice {
     }
 }
 
-/// Converts a Value to Option<i64>, treating None as None.
+/// Converts a slice bound to `Option<i64>`, treating `None` as "no bound".
 ///
-/// Used for slice construction from both `slice()` builtin and `[start:stop:step]` syntax.
-/// Returns Ok(None) for Value::None, Ok(Some(i)) for integers/bools, a user
-/// `__index__` result for instances, or Err(TypeError) for other types — which
-/// is what the "or have an `__index__` method" in the error message promises.
-///
-/// Ints too large for `i64` saturate to `i64::MIN`/`i64::MAX` instead of
-/// raising, matching CPython's clamping of slice bounds — unlike plain indexing,
-/// which raises `IndexError` on the same input.
+/// Used for slice construction from both the `slice()` builtin and
+/// `[start:stop:step]` syntax, and for the `start`/`end` arguments of the
+/// sequence searches (`str.find`, `bytes.startswith`, ...) that accept `None`
+/// for the same purpose — CPython gives them all the same converter, hence the
+/// same "or None" in the `TypeError`.
 pub(crate) fn value_to_option_i64(value: &Value, vm: &mut VM<'_>) -> RunResult<Option<i64>> {
     match value {
         Value::None => Ok(None),
+        _ => match saturating_slice_index(value, vm)? {
+            Some(index) => Ok(Some(index)),
+            None => Err(ExcType::type_error_slice_indices()),
+        },
+    }
+}
+
+/// [`value_to_option_i64`] for the `index()` searches that do **not** accept
+/// `None` (`list.index`, `tuple.index`, `deque.index`), whose `TypeError` drops
+/// the "or None" because they have no bound to leave unset.
+pub(crate) fn value_to_i64_bound(value: &Value, vm: &mut VM<'_>) -> RunResult<i64> {
+    saturating_slice_index(value, vm)?.ok_or_else(ExcType::type_error_slice_indices_no_none)
+}
+
+/// [`value_to_option_i64`] normalized against a sequence length, which is the
+/// shape the searches want: `None` selects `default`, anything else is coerced,
+/// saturated and clamped into `0..=len`.
+pub(crate) fn optional_sequence_bound(value: &Value, default: usize, len: usize, vm: &mut VM<'_>) -> RunResult<usize> {
+    let bound = value_to_option_i64(value, vm)?;
+    Ok(bound.map_or(default, |i| normalize_sequence_index(i, len)))
+}
+
+/// CPython's `_PyEval_SliceIndex`: an `int`, or the `__index__` of an object
+/// that has one, **saturated** to `i64` rather than raised on. `Ok(None)` means
+/// the value is not `__index__`-able, leaving the `TypeError` to the caller,
+/// whose wording depends on whether it also accepts `None`.
+///
+/// Saturating is what separates a bound from an index: `[1, 2, 3][10**30:]` is
+/// `[]` and `'abc'.find('a', 10**30)` is `-1`, where the same value used as a
+/// subscript raises `IndexError`.
+fn saturating_slice_index(value: &Value, vm: &mut VM<'_>) -> RunResult<Option<i64>> {
+    match value {
         Value::Int(i) => Ok(Some(*i)),
         Value::Bool(b) => Ok(Some(i64::from(*b))),
-        // Bounds beyond `i64` saturate rather than raise: CPython clamps slice
-        // bounds to the sequence, so `[1, 2, 3][10**30:]` is `[]`, not an error.
-        // This arm also catches an `__index__` that returns a `LongInt`, which
-        // the recursion below funnels back through here.
+        // Also catches an `__index__` that returns a `LongInt`, which the
+        // recursion below funnels back through here.
         _ if let Some(index) = value.long_int_to_i64_saturating(vm) => Ok(Some(index)),
         _ => match value.py_index_impl(vm)? {
             // Recurses exactly once: `py_index_impl` validates an int result, so
             // the arms above take it on the way back in.
             Some(index) => {
                 defer_drop!(index, vm);
-                value_to_option_i64(index, vm)
+                saturating_slice_index(index, vm)
             }
-            None => Err(ExcType::type_error_slice_indices()),
+            None => Ok(None),
         },
     }
 }

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -6,7 +6,6 @@ use std::{cell::Cell, fmt::Write, ops};
 /// operations like length and equality comparison.
 use monty_types::ResourceError;
 pub use monty_types::{StringRepr, string_repr_fmt};
-use num_traits::ToPrimitive;
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
 
@@ -27,7 +26,7 @@ use crate::{
     types::{
         LazyHeapSet, Type,
         long_int::repeat_count,
-        slice::{normalize_sequence_index, slice_collect_iterator},
+        slice::{optional_sequence_bound, slice_collect_iterator},
     },
     value::{EitherStr, Value, eq_str},
 };
@@ -1061,11 +1060,11 @@ fn str_starts_ends_with<'h>(
         return Err(ExcType::type_error_at_most(method, 3, pos.len()));
     }
     let start = match rest.first() {
-        Some(value) => optional_index(value, 0, str_len, vm)?,
+        Some(value) => optional_sequence_bound(value, 0, str_len, vm)?,
         None => 0,
     };
     let end = match rest.get(1) {
-        Some(value) => optional_index(value, str_len, str_len, vm)?,
+        Some(value) => optional_sequence_bound(value, str_len, str_len, vm)?,
         None => str_len,
     };
     let slice = slice_string(s.get(vm.heap), start, end);
@@ -1143,13 +1142,13 @@ fn parse_search_args(
         }
         [sub_value, start_value] => {
             let sub = extract_string_arg(sub_value, vm)?;
-            let start = optional_index(start_value, 0, str_len, vm)?;
+            let start = optional_sequence_bound(start_value, 0, str_len, vm)?;
             Ok((sub, start, str_len))
         }
         [sub_value, start_value, end_value] => {
             let sub = extract_string_arg(sub_value, vm)?;
-            let start = optional_index(start_value, 0, str_len, vm)?;
-            let end = optional_index(end_value, str_len, str_len, vm)?;
+            let start = optional_sequence_bound(start_value, 0, str_len, vm)?;
+            let end = optional_sequence_bound(end_value, str_len, str_len, vm)?;
             Ok((sub, start, end))
         }
         [] => Err(ExcType::type_error_at_least(method, 1, 0)),
@@ -1192,48 +1191,6 @@ fn extract_int_arg(value: &Value, vm: &mut VM<'_>) -> RunResult<i64> {
 fn extract_c_int_arg(value: &Value, vm: &mut VM<'_>) -> RunResult<i32> {
     let as_i64 = value.as_int_with_overflow(vm, ExcType::overflow_c_int)?;
     i32::try_from(as_i64).map_err(|_| ExcType::overflow_c_int())
-}
-
-/// Extracts an optional slice index from a `Value`, treating `None` as `default`.
-///
-/// Used by argument parsers where `None` means "use the default index" and
-/// any other value is interpreted as an integer and normalized against `str_len`.
-/// Accepts `bool` like CPython (an `int` subtype); non-integers raise CPython's
-/// `slice indices must be integers or None ...` rather than the generic
-/// `expected int` used for non-slice integer args.
-fn optional_index(value: &Value, default: usize, str_len: usize, vm: &mut VM<'_>) -> RunResult<usize> {
-    match value {
-        Value::None => Ok(default),
-        Value::Int(i) => Ok(normalize_sequence_index(*i, str_len)),
-        Value::Bool(b) => Ok(normalize_sequence_index(i64::from(*b), str_len)),
-        // Both `LongInt` representations answer here. As well as sharing one
-        // error, this keeps an interned one out of the `_` arm below, whose
-        // recursion would otherwise hand it straight back to itself.
-        Value::InternLongInt(id) => {
-            let i = vm
-                .interns
-                .get_long_int(*id)
-                .to_i64()
-                .ok_or_else(|| ExcType::type_error("integer too large"))?;
-            Ok(normalize_sequence_index(i, str_len))
-        }
-        Value::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
-            let i = li.to_i64().ok_or_else(|| ExcType::type_error("integer too large"))?;
-            Ok(normalize_sequence_index(i, str_len))
-        }
-        _ => match value.py_index_impl(vm)? {
-            // Recurses exactly once: `py_index_impl` validates an int result, so
-            // the arms above take it. Recursing rather than narrowing here keeps a
-            // too-large result on the same path as a directly-passed `LongInt` —
-            // which raises `TypeError: integer too large` where CPython clamps,
-            // a pre-existing divergence this arm inherits rather than widens.
-            Some(index) => {
-                defer_drop!(index, vm);
-                optional_index(index, default, str_len, vm)
-            }
-            None => Err(ExcType::type_error_slice_indices()),
-        },
-    }
 }
 
 /// Returns a substring of s from character index start to end.

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -39,7 +39,7 @@ use crate::{
         LazyHeapSet, Type,
         list::repr_sequence_fmt,
         long_int::repeat_count,
-        slice::{normalize_sequence_index, slice_collect_iterator},
+        slice::{normalize_sequence_index, slice_collect_iterator, value_to_i64_bound},
     },
     value::{EitherStr, VALUE_SIZE, Value},
 };
@@ -536,12 +536,12 @@ fn tuple_index<'h>(tuple: &HeapRead<'h, Tuple>, args: ArgValues, vm: &mut VM<'h>
         [] => return Err(ExcType::type_error_at_least("tuple.index", 1, 0)),
         [value] => (value, 0, len),
         [value, start_arg] => {
-            let start = normalize_sequence_index(start_arg.as_int(vm)?, len);
+            let start = normalize_sequence_index(value_to_i64_bound(start_arg, vm)?, len);
             (value, start, len)
         }
         [value, start_arg, end_arg] => {
-            let start = normalize_sequence_index(start_arg.as_int(vm)?, len);
-            let end = normalize_sequence_index(end_arg.as_int(vm)?, len).max(start);
+            let start = normalize_sequence_index(value_to_i64_bound(start_arg, vm)?, len);
+            let end = normalize_sequence_index(value_to_i64_bound(end_arg, vm)?, len).max(start);
             (value, start, end)
         }
         other => return Err(ExcType::type_error_at_most("tuple.index", 3, other.len())),

--- a/crates/monty/test_cases/sequence__search_bounds.py
+++ b/crates/monty/test_cases/sequence__search_bounds.py
@@ -1,0 +1,109 @@
+# `start`/`end` bounds of the sequence searches follow CPython's slice-index
+# rules: `__index__` is dispatched, and an out-of-range int clamps to the
+# sequence rather than raising.
+from collections import deque, namedtuple
+
+P = namedtuple('P', 'a b')
+
+
+class Idx:
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        return self.value
+
+
+# === Oversized bounds clamp instead of raising ===
+BIG = 10**30
+assert 'abcabc'.find('b', BIG) == -1
+assert 'abcabc'.find('b', -BIG) == 1
+assert 'abcabc'.find('b', 0, BIG) == 1
+assert 'abcabc'.count('b', BIG) == 0
+assert 'abcabc'.startswith('b', BIG) is False
+assert 'abcabc'.endswith('c', 0, BIG) is True
+assert b'abcabc'.find(b'b', BIG) == -1
+assert b'abcabc'.find(b'b', -BIG) == 1
+assert b'abcabc'.count(b'b', 0, BIG) == 2
+assert b'abcabc'.startswith(b'a', -BIG) is True
+assert [1, 2, 3].index(2, -BIG) == 1
+assert (1, 2, 3).index(2, -BIG) == 1
+assert P(1, 2).index(2, -BIG) == 1
+assert deque([1, 2, 3]).index(2, -BIG) == 1
+
+# A bound past the end still finds nothing, reported by each search's own error.
+try:
+    'abcabc'.index('b', BIG)
+    assert False, 'expected ValueError'
+except ValueError as exc:
+    assert str(exc) == 'substring not found'
+
+try:
+    [1, 2, 3].index(2, BIG)
+    assert False, 'expected ValueError'
+except ValueError as exc:
+    assert str(exc) == 'list.index(x): x not in list'
+
+try:
+    (1, 2, 3).index(2, BIG)
+    assert False, 'expected ValueError'
+except ValueError as exc:
+    assert str(exc) == 'tuple.index(x): x not in tuple'
+
+# === `__index__` bounds ===
+assert 'abcabc'.find('b', Idx(2)) == 4
+assert b'abcabc'.find(b'b', Idx(2)) == 4
+assert [1, 2, 3].index(2, Idx(0)) == 1
+assert (1, 2, 3).index(2, Idx(0)) == 1
+assert deque([1, 2, 3]).index(2, Idx(0)) == 1
+# One whose `__index__` overflows clamps like a literal of the same size.
+assert 'abcabc'.find('b', Idx(-BIG)) == 1
+assert [1, 2, 3].index(2, Idx(-BIG)) == 1
+
+# `bool` is an int, so it indexes directly.
+assert 'abcabc'.find('b', True) == 1
+assert [1, 2, 3].index(2, True) == 1
+
+# === `None` bounds ===
+# Real slicing accepts `None` for "no bound", and so do the string searches.
+assert 'abcabc'.find('b', None) == 1
+assert 'abcabc'.find('b', None, None) == 1
+assert b'abcabc'.find(b'b', None) == 1
+assert b'abcabc'.startswith(b'b', None, None) is False
+
+# `index()` on a sequence does not: there is no bound to leave unset.
+for call in (
+    lambda: [1, 2, 3].index(2, None),
+    lambda: (1, 2, 3).index(2, None),
+    lambda: deque([1, 2, 3]).index(2, None),
+):
+    try:
+        call()
+        assert False, 'expected TypeError'
+    except TypeError as exc:
+        assert str(exc) == 'slice indices must be integers or have an __index__ method'
+
+# === Bounds that are not integers at all ===
+for call in (
+    lambda: 'abcabc'.find('b', 'x'),
+    lambda: 'abcabc'.find('b', 1.0),
+    lambda: b'abcabc'.find(b'b', 'x'),
+    lambda: b'abcabc'.startswith(b'b', []),
+):
+    try:
+        call()
+        assert False, 'expected TypeError'
+    except TypeError as exc:
+        assert str(exc) == 'slice indices must be integers or None or have an __index__ method'
+
+for call in (
+    lambda: [1, 2, 3].index(2, 'x'),
+    lambda: (1, 2, 3).index(2, 1.0),
+    lambda: P(1, 2).index(2, 'x'),
+    lambda: deque([1, 2, 3]).index(2, 1.0),
+):
+    try:
+        call()
+        assert False, 'expected TypeError'
+    except TypeError as exc:
+        assert str(exc) == 'slice indices must be integers or have an __index__ method'

--- a/crates/monty/test_cases/sequence__search_bounds.py
+++ b/crates/monty/test_cases/sequence__search_bounds.py
@@ -107,3 +107,43 @@ for call in (
         assert False, 'expected TypeError'
     except TypeError as exc:
         assert str(exc) == 'slice indices must be integers or have an __index__ method'
+
+
+# === A bound whose `__index__` mutates the sequence ===
+# The length is read after every bound is coerced, so a negative bound resolves
+# against the mutated sequence and the walk never runs off the end of a
+# shortened one.
+class Clear:
+    def __init__(self, target):
+        self.target = target
+
+    def __index__(self):
+        self.target.clear()
+        return 0
+
+
+for empty in (deque([1, 2, 3]), [1, 2, 3]):
+    try:
+        empty.index(2, Clear(empty))
+        assert False, 'expected ValueError'
+    except ValueError:
+        pass
+
+cleared = deque([1, 2, 3])
+try:
+    cleared.index(2, 0, Clear(cleared))
+    assert False, 'expected ValueError'
+except ValueError as exc:
+    assert str(exc) == 'deque.index(x): x not in deque'
+
+grown = deque([1, 2, 3])
+
+
+class Grow:
+    def __index__(self):
+        grown.extend([2, 2, 2])
+        return -1
+
+
+assert grown.index(2, Grow()) == 5
+assert list(grown) == [1, 2, 3, 2, 2, 2]


### PR DESCRIPTION
A bound is not an index: an out-of-range index is an error, but an out-of-range bound just names an empty window, so CPython saturates bounds rather than rejecting them — Monty did that only for slicing, leaving every search method to raise where CPython returns a result.

The fix gives bounds their own coercion, shared with slicing, so an oversized bound clips to the end of the sequence instead of ending the call.

Note some difference in implementation for bounds that do/don't accept `None`

```
# None-accepting: None means "the default bound", same as omitting it
'abcabc'.find('b', None)          # 1
'abcabc'.find('b', None, None)    # 1
b'abcabc'.find(b'b', None)        # 1
'abcabc'.startswith('b', None)    # False

# No None bound to express: omit it, or pass an int
[1, 2, 3].index(2)                # 1
[1, 2, 3].index(2, 0)             # 1
[1, 2, 3].index(2, None)          # TypeError: slice indices must be integers or have an __index__ method
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes sequence search bounds (`start`/`end` to `find`, `index`, `count`, `startswith`, etc.) behave like CPython: out-of-range bounds now clamp to the sequence end instead of raising, and `__index__` is honored for every search type.

- All search types now share one converter in `slice.rs` that saturates to `i64` and normalizes to the sequence length.
- `str` and `bytes` searches accept `None` bounds; `list.index`, `tuple.index`, `namedtuple.index`, and `deque.index` reject `None` with CPython's error message.
- `bytes` searches now accept `None` bounds, matching CPython.
- `deque.index` coerces both bounds before reading the length, so a bound whose `__index__` mutates the deque can no longer panic the walk with a stale length.

<sup>Written for commit d0b1797b5344efdbf29ae46f4e0c7ddaad90def4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

