### PR TITLE
add `allocate_as` helper for typed allocation

### DIFF
--- a/crates/monty/src/heap/mod.rs
+++ b/crates/monty/src/heap/mod.rs
@@ -20,26 +20,18 @@ use std::{
 use monty_types::ResourceTracker;
 use serde::ser::SerializeStruct;
 
-// Re-export items moved to `heap_traits` so that `crate::heap::DropGuard` etc. continue
-// to resolve (used by the `defer_drop!` macros and throughout the codebase).
-pub(crate) use crate::heap_data::HeapData;
-pub(crate) use crate::heap_traits::{ContainsHeap, DropGuard, DropWithContext, HeapItem};
 #[cfg(feature = "ref-count-return")]
 use crate::types::Type;
 use crate::{
-    asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
-    exception_private::SimpleException,
-    heap_data::{CellValue, Closure, FunctionDefaults},
-    modules::dataclasses::{DataclassField, DataclassParams},
-    types::{
-        BoundMethod, Bytes, BytesIterator, Class, Dataclass, Deque, Dict, DictItemIterator, DictItemsView,
-        DictKeyIterator, DictKeysView, DictValueIterator, DictValuesView, ExtFunction, FrozenSet, Instance,
-        ItertoolsIter, List, LongInt, Module, NamedTuple, NamedTupleClass, OpenFile, Path, Range, RangeIterator,
-        ReMatch, RePattern, Set, SetIterator, Slice, Str, StringIterator, TimeZone, Tuple, TupleIterator,
-        callable_iterator::CallableIterator, date, datetime, deque::DequeIterator, list::ListIterator, timedelta,
-        timezone,
-    },
+    asyncio::{Awaiter, ExternalFutureState, GatherState},
+    types::{ExtFunction, TimeZone, Tuple},
     value::Value,
+};
+// Re-export items moved to `heap_traits` so that `crate::heap::DropGuard` etc. continue
+// to resolve (used by the `defer_drop!` macros and throughout the codebase).
+pub(crate) use crate::{
+    heap_data::HeapData,
+    heap_traits::{ContainsHeap, DropGuard, DropWithContext, HeapItem},
 };
 
 mod free_list;
@@ -171,6 +163,30 @@ impl<'a> HeapReader<'a> {
         self.read_ptr(id).read(id, self)
     }
 
+    /// Reads `id` as the requested concrete payload type.
+    ///
+    /// Returns `None` when the live entry stores a different payload type.
+    pub fn read_as<T: HeapPayload>(&self, id: HeapId) -> Option<HeapObjectRead<'a, T>> {
+        T::try_from_read(self.read(id)).ok()
+    }
+
+    /// Allocates a concrete payload and returns an owning, typed handle to it.
+    ///
+    /// The allocation's initial reference must eventually be transferred with
+    /// `into_value`/`into_id`, or released by guarding the handle with `DropGuard`.
+    pub fn allocate_as<T: HeapPayload>(&self, value: T) -> HeapAllocation<'a, T> {
+        let entry = self.heap.new_entry(value.into_heap_data());
+        let (id, slot) = self.heap.entries.allocate_with_slot(entry);
+        HeapAllocation {
+            id,
+            ptr: HeapPtr {
+                inner: NonNull::from(slot),
+                brand: PhantomData,
+            },
+            read: None,
+        }
+    }
+
     #[expect(clippy::unused_self, reason = "'a lifetime is used to create the safety guarantees")]
     pub fn protect<'t, U: ?Sized>(&mut self, value: &'t U) -> BorrowedHeapRead<'t, 'a, U> {
         BorrowedHeapRead {
@@ -219,58 +235,110 @@ impl DerefMut for HeapReader<'_> {
     }
 }
 
-pub enum HeapReadOutput<'a> {
-    Str(HeapObjectRead<'a, Str>),
-    Bytes(HeapObjectRead<'a, Bytes>),
-    List(HeapObjectRead<'a, List>),
-    Deque(HeapObjectRead<'a, Deque>),
-    Tuple(HeapObjectRead<'a, Tuple>),
-    NamedTuple(HeapObjectRead<'a, NamedTuple>),
-    NamedTupleClass(HeapObjectRead<'a, NamedTupleClass>),
-    Dict(HeapObjectRead<'a, Dict>),
-    DictItemsView(HeapObjectRead<'a, DictItemsView>),
-    DictKeysView(HeapObjectRead<'a, DictKeysView>),
-    DictValuesView(HeapObjectRead<'a, DictValuesView>),
-    Set(HeapObjectRead<'a, Set>),
-    FrozenSet(HeapObjectRead<'a, FrozenSet>),
-    Closure(HeapObjectRead<'a, Closure>),
-    FunctionDefaults(HeapObjectRead<'a, FunctionDefaults>),
-    ExtFunction(HeapObjectRead<'a, ExtFunction>),
-    Cell(HeapObjectRead<'a, CellValue>),
-    Range(HeapObjectRead<'a, Range>),
-    Slice(HeapObjectRead<'a, Slice>),
-    Exception(HeapObjectRead<'a, SimpleException>),
-    Dataclass(HeapObjectRead<'a, Dataclass>),
-    Class(HeapObjectRead<'a, Class>),
-    Instance(HeapObjectRead<'a, Instance>),
-    BoundMethod(HeapObjectRead<'a, BoundMethod>),
-    DataclassField(HeapObjectRead<'a, DataclassField>),
-    DataclassParams(HeapObjectRead<'a, DataclassParams>),
-    ListIterator(HeapObjectRead<'a, ListIterator>),
-    DequeIterator(HeapObjectRead<'a, DequeIterator>),
-    TupleIterator(HeapObjectRead<'a, TupleIterator>),
-    StringIterator(HeapObjectRead<'a, StringIterator>),
-    BytesIterator(HeapObjectRead<'a, BytesIterator>),
-    RangeIterator(HeapObjectRead<'a, RangeIterator>),
-    DictKeyIterator(HeapObjectRead<'a, DictKeyIterator>),
-    DictItemIterator(HeapObjectRead<'a, DictItemIterator>),
-    DictValueIterator(HeapObjectRead<'a, DictValueIterator>),
-    SetIterator(HeapObjectRead<'a, SetIterator>),
-    CallableIterator(HeapObjectRead<'a, CallableIterator>),
-    Itertools(HeapObjectRead<'a, ItertoolsIter>),
-    LongInt(HeapObjectRead<'a, LongInt>),
-    Module(HeapObjectRead<'a, Module>),
-    Coroutine(HeapObjectRead<'a, Coroutine>),
-    GatherFuture(HeapObjectRead<'a, GatherFuture>),
-    ExternalFuture(HeapObjectRead<'a, ExternalFuture>),
-    Path(HeapObjectRead<'a, Path>),
-    OpenFile(HeapObjectRead<'a, OpenFile>),
-    RePattern(HeapObjectRead<'a, RePattern>),
-    ReMatch(HeapObjectRead<'a, ReMatch>),
-    Date(HeapObjectRead<'a, date::Date>),
-    DateTime(HeapObjectRead<'a, datetime::DateTime>),
-    TimeDelta(HeapObjectRead<'a, timedelta::TimeDelta>),
-    TimeZone(HeapObjectRead<'a, timezone::TimeZone>),
+macro_rules! heap_storage_value {
+    (inline $value:expr) => {
+        $value
+    };
+    (boxed $value:expr) => {
+        Box::new($value)
+    };
+}
+
+/// Maps a concrete Rust payload to its heap representation and typed read variant.
+///
+/// Implementations are generated from `heap_data::heap_payloads`, keeping each
+/// payload's storage conversion and typed read extraction in the central registry.
+pub(crate) trait HeapPayload: Sized {
+    /// Wraps this payload in its corresponding `HeapData` variant.
+    fn into_heap_data(self) -> HeapData;
+
+    /// Extracts this payload's typed handle from a dynamic heap read.
+    fn try_from_read(read: HeapReadOutput<'_>) -> Result<HeapObjectRead<'_, Self>, HeapReadOutput<'_>>;
+}
+
+macro_rules! define_heap_read_support {
+    ($(
+        $(#[$meta:meta])*
+        $variant:ident($storage:ident $payload:ty)
+    ),* $(,)?) => {
+        /// A type-safe read handle for any payload stored in the heap.
+        pub enum HeapReadOutput<'a> {
+            $(
+                $(#[$meta])*
+                $variant(HeapObjectRead<'a, $payload>),
+            )*
+        }
+
+        $(
+            impl HeapPayload for $payload {
+                #[inline]
+                fn into_heap_data(self) -> HeapData {
+                    HeapData::$variant(heap_storage_value!($storage self))
+                }
+
+                #[inline]
+                fn try_from_read(
+                    read: HeapReadOutput<'_>,
+                ) -> Result<HeapObjectRead<'_, Self>, HeapReadOutput<'_>> {
+                    if let HeapReadOutput::$variant(value) = read {
+                        Ok(value)
+                    } else {
+                        Err(read)
+                    }
+                }
+            }
+        )*
+
+    };
+}
+
+crate::heap_data::heap_payloads!(define_heap_read_support);
+
+/// A newly allocated heap object with its initial owned reference.
+///
+/// Typed access is created lazily by [`Self::read`], so transferring an allocation
+/// directly into a `Value` or raw ID does not touch the entry's reader count.
+#[must_use = "the allocation's initial reference must be transferred"]
+pub struct HeapAllocation<'a, T> {
+    id: HeapId,
+    ptr: HeapPtr<'a>,
+    read: Option<HeapObjectRead<'a, T>>,
+}
+
+impl<'a, T: HeapPayload> HeapAllocation<'a, T> {
+    /// Returns the allocated object's identity without transferring ownership.
+    pub fn id(&self) -> HeapId {
+        self.id
+    }
+
+    /// Creates the typed read handle on first access and reuses it thereafter.
+    pub fn read(&mut self, heap: &HeapReader<'a>) -> &mut HeapObjectRead<'a, T> {
+        let id = self.id;
+        let ptr = self.ptr;
+        self.read.get_or_insert_with(|| {
+            T::try_from_read(ptr.read(id, heap))
+                .unwrap_or_else(|_| unreachable!("allocated payload has its registered type"))
+        })
+    }
+
+    /// Transfers the allocation's initial reference into a `Value`.
+    pub fn into_value(self) -> Value {
+        Value::Ref(self.into_id())
+    }
+
+    /// Transfers the allocation's initial reference as an owned raw ID.
+    pub fn into_id(mut self) -> HeapId {
+        let id = self.id();
+        drop(self.read.take());
+        id
+    }
+}
+
+impl<C: ContainsHeap, T> DropWithContext<C> for HeapAllocation<'_, T> {
+    fn drop_with(mut self, ctx: &mut C) {
+        drop(self.read.take());
+        Value::Ref(self.id).drop_with(ctx);
+    }
 }
 
 /// A typed read handle for a Python object stored in a specific heap entry.
@@ -683,6 +751,15 @@ impl<'a> HeapPtr<'a> {
             }
         }
 
+        macro_rules! heap_read_value {
+            (inline $id:expr, $base:expr, $value:expr, $readers:expr) => {
+                heap_read($id, $base, $value, $readers)
+            };
+            (boxed $id:expr, $base:expr, $value:expr, $readers:expr) => {
+                heap_read_boxed($id, $base, $value, $readers)
+            };
+        }
+
         let entry = self.entry(reader);
         // Increment the reader count for this entry. The corresponding decrement
         // happens in `HeapRead::drop`.
@@ -690,80 +767,29 @@ impl<'a> HeapPtr<'a> {
         let readers = NonNull::from(&entry.readers);
         // Get the raw pointer from the UnsafeCell — this has SharedReadWrite permission.
         let base: *mut HeapData = entry.data.0.get();
+
+        macro_rules! read_heap_payload {
+            ($(
+                $(#[$meta:meta])*
+                $variant:ident($storage:ident $payload:ty)
+            ),* $(,)?) => {
+                // SAFETY: `base` points to this live entry's `UnsafeHeapData`.
+                match unsafe { &*base } {
+                    $(
+                        HeapData::$variant(value) => HeapReadOutput::$variant(
+                            heap_read_value!($storage id, base, value, readers)
+                        ),
+                    )*
+                }
+            };
+        }
+
         // SAFETY: Match on a shared reference (`&*base`) to read the discriminant without
         // creating a Unique retag. The shared retag is compatible with existing
         // SharedReadWrite permissions from prior `read()` calls into the same UnsafeCell.
         // The `heap_read` helper then derives the NonNull from `base` (not from `&T`),
         // so the returned pointer retains full SharedReadWrite permission.
-        match unsafe { &*base } {
-            HeapData::Str(s) => HeapReadOutput::Str(heap_read(id, base, s, readers)),
-            HeapData::Bytes(bytes) => HeapReadOutput::Bytes(heap_read(id, base, bytes, readers)),
-            HeapData::List(list) => HeapReadOutput::List(heap_read(id, base, list, readers)),
-            HeapData::Deque(deque) => HeapReadOutput::Deque(heap_read(id, base, deque, readers)),
-            HeapData::Tuple(tuple) => HeapReadOutput::Tuple(heap_read(id, base, tuple, readers)),
-            HeapData::NamedTuple(named_tuple) => {
-                HeapReadOutput::NamedTuple(heap_read_boxed(id, base, named_tuple, readers))
-            }
-            HeapData::NamedTupleClass(class) => {
-                HeapReadOutput::NamedTupleClass(heap_read_boxed(id, base, class, readers))
-            }
-            HeapData::Dict(dict) => HeapReadOutput::Dict(heap_read(id, base, dict, readers)),
-            HeapData::DictItemsView(v) => HeapReadOutput::DictItemsView(heap_read(id, base, v, readers)),
-            HeapData::DictKeysView(v) => HeapReadOutput::DictKeysView(heap_read(id, base, v, readers)),
-            HeapData::DictValuesView(v) => HeapReadOutput::DictValuesView(heap_read(id, base, v, readers)),
-            HeapData::Set(set) => HeapReadOutput::Set(heap_read(id, base, set, readers)),
-            HeapData::FrozenSet(frozen_set) => HeapReadOutput::FrozenSet(heap_read(id, base, frozen_set, readers)),
-            HeapData::Closure(closure) => HeapReadOutput::Closure(heap_read(id, base, closure, readers)),
-            HeapData::FunctionDefaults(function_defaults) => {
-                HeapReadOutput::FunctionDefaults(heap_read(id, base, function_defaults, readers))
-            }
-            HeapData::ExtFunction(name) => HeapReadOutput::ExtFunction(heap_read(id, base, name, readers)),
-            HeapData::Cell(cell_value) => HeapReadOutput::Cell(heap_read(id, base, cell_value, readers)),
-            HeapData::Range(range) => HeapReadOutput::Range(heap_read(id, base, range, readers)),
-            HeapData::Slice(slice) => HeapReadOutput::Slice(heap_read(id, base, slice, readers)),
-            HeapData::Exception(simple_exception) => {
-                HeapReadOutput::Exception(heap_read(id, base, simple_exception, readers))
-            }
-            HeapData::Dataclass(dataclass) => HeapReadOutput::Dataclass(heap_read_boxed(id, base, dataclass, readers)),
-            HeapData::Class(class) => HeapReadOutput::Class(heap_read_boxed(id, base, class, readers)),
-            HeapData::Instance(instance) => HeapReadOutput::Instance(heap_read_boxed(id, base, instance, readers)),
-            HeapData::BoundMethod(bound_method) => {
-                HeapReadOutput::BoundMethod(heap_read(id, base, bound_method, readers))
-            }
-            HeapData::DataclassField(field) => HeapReadOutput::DataclassField(heap_read(id, base, field, readers)),
-            HeapData::DataclassParams(params) => HeapReadOutput::DataclassParams(heap_read(id, base, params, readers)),
-            HeapData::ListIterator(iter) => HeapReadOutput::ListIterator(heap_read(id, base, iter, readers)),
-            HeapData::DequeIterator(iter) => HeapReadOutput::DequeIterator(heap_read(id, base, iter, readers)),
-            HeapData::TupleIterator(iter) => HeapReadOutput::TupleIterator(heap_read(id, base, iter, readers)),
-            HeapData::StringIterator(iter) => HeapReadOutput::StringIterator(heap_read(id, base, iter, readers)),
-            HeapData::BytesIterator(iter) => HeapReadOutput::BytesIterator(heap_read(id, base, iter, readers)),
-            HeapData::RangeIterator(iter) => HeapReadOutput::RangeIterator(heap_read(id, base, iter, readers)),
-            HeapData::DictKeyIterator(iter) => HeapReadOutput::DictKeyIterator(heap_read(id, base, iter, readers)),
-            HeapData::DictItemIterator(iter) => HeapReadOutput::DictItemIterator(heap_read(id, base, iter, readers)),
-            HeapData::DictValueIterator(iter) => HeapReadOutput::DictValueIterator(heap_read(id, base, iter, readers)),
-            HeapData::SetIterator(iter) => HeapReadOutput::SetIterator(heap_read(id, base, iter, readers)),
-            HeapData::CallableIterator(c) => HeapReadOutput::CallableIterator(heap_read(id, base, c, readers)),
-            HeapData::Itertools(i) => HeapReadOutput::Itertools(heap_read(id, base, i, readers)),
-            HeapData::LongInt(l) => HeapReadOutput::LongInt(heap_read(id, base, l, readers)),
-            HeapData::Module(module) => HeapReadOutput::Module(heap_read_boxed(id, base, module, readers)),
-            HeapData::Coroutine(coroutine) => HeapReadOutput::Coroutine(heap_read(id, base, coroutine, readers)),
-            HeapData::GatherFuture(gather_future) => {
-                HeapReadOutput::GatherFuture(heap_read_boxed(id, base, gather_future, readers))
-            }
-            HeapData::ExternalFuture(external_future) => {
-                HeapReadOutput::ExternalFuture(heap_read_boxed(id, base, external_future, readers))
-            }
-            HeapData::Path(path) => HeapReadOutput::Path(heap_read(id, base, path, readers)),
-            HeapData::OpenFile(file) => HeapReadOutput::OpenFile(heap_read_boxed(id, base, file, readers)),
-            HeapData::RePattern(re_pattern) => {
-                HeapReadOutput::RePattern(heap_read_boxed(id, base, re_pattern, readers))
-            }
-            HeapData::ReMatch(re_match) => HeapReadOutput::ReMatch(heap_read_boxed(id, base, re_match, readers)),
-            HeapData::Date(d) => HeapReadOutput::Date(heap_read(id, base, d, readers)),
-            HeapData::DateTime(d) => HeapReadOutput::DateTime(heap_read(id, base, d, readers)),
-            HeapData::TimeDelta(d) => HeapReadOutput::TimeDelta(heap_read(id, base, d, readers)),
-            HeapData::TimeZone(d) => HeapReadOutput::TimeZone(heap_read(id, base, d, readers)),
-        }
+        crate::heap_data::heap_payloads!(read_heap_payload)
     }
 }
 
@@ -1029,19 +1055,22 @@ impl Heap {
     /// (strings, bytes, …) cannot participate in cycles and don't count
     /// against the GC interval.
     pub fn allocate(&self, data: HeapData) -> HeapId {
+        self.entries.allocate(self.new_entry(data))
+    }
+
+    /// Builds the initialized entry shared by typed and untyped allocation.
+    fn new_entry(&self, data: HeapData) -> HeapEntry {
         if data.is_gc_tracked() {
             self.allocations_since_gc
                 .set(self.allocations_since_gc.get().wrapping_add(1));
         }
 
-        let new_entry = HeapEntry {
+        HeapEntry {
             refcount: Cell::new(1),
             readers: Cell::new(0),
             data: UnsafeHeapData(UnsafeCell::new(data)),
             color: Cell::new(CcColor::Black),
-        };
-
-        self.entries.allocate(new_entry)
+        }
     }
 
     /// Returns the singleton empty tuple.

--- a/crates/monty/src/heap/stable_heap.rs
+++ b/crates/monty/src/heap/stable_heap.rs
@@ -148,6 +148,14 @@ impl<T> StableHeap<T> {
     ///   not the page contents. Any existing `&T` reference points into a
     ///   `Box`'s heap allocation, not into the `Vec`'s buffer.
     pub fn allocate(&self, value: T) -> HeapId {
+        self.allocate_with_slot(value).0
+    }
+
+    /// Allocates a value and also returns its stable arena slot.
+    ///
+    /// The slot lets the heap immediately project a newly allocated payload
+    /// without repeating the page and slot lookup.
+    pub fn allocate_with_slot(&self, value: T) -> (HeapId, &Option<T>) {
         // SAFETY: [DH]
         // - This is the only `&self` method which uses `pages.get()` to create a mutable reference to `pages`.
         // - This method is not re-entrant, and not `Sync`, so cannot have a global `StableHeap` where
@@ -180,9 +188,9 @@ impl<T> StableHeap<T> {
         // Write to the new slot. No need to worry about initializedness / the destructor - either the slot was
         // free (in which case the slot is `None` and has no meaningful destructor), or the slot is not
         // initialized yet.
-        slot.write(Some(value));
+        let slot = slot.write(Some(value));
 
-        id
+        (id, slot)
     }
 
     /// Iterates the live values
@@ -223,6 +231,10 @@ impl<T> StableHeap<T> {
 }
 
 /// Allocates a new page of uninitialized slots directly on the heap.
+#[expect(
+    clippy::unnecessary_box_returns,
+    reason = "each page must have a stable heap address independent of the page pointer vector"
+)]
 fn create_page<T>() -> Box<[Slot<T>; PAGE_SIZE]> {
     let raw = Box::into_raw(Box::<[Slot<T>]>::new_uninit_slice(PAGE_SIZE)).cast();
     // SAFETY: [DH] - allocation is known to be exactly PAGE_SIZE slots, so

--- a/crates/monty/src/heap/stable_heap.rs
+++ b/crates/monty/src/heap/stable_heap.rs
@@ -133,20 +133,6 @@ impl<T> StableHeap<T> {
     /// Takes `&self` instead of `&mut self`, enabling allocation while holding shared
     /// borrows to other heap entries. This is the core operation that makes
     /// `Heap::allocate(&self)` possible.
-    ///
-    /// # Safety contract (enforced by caller structure, not runtime checks)
-    ///
-    /// - No `&mut` reference to `pages` or `free_list` exists. Guaranteed because
-    ///   all `&mut self` methods on `HeapEntries` require exclusive access, and the
-    ///   borrow checker prevents calling this `&self` method while any `&mut self`
-    ///   method is active.
-    /// - **New slots** (at index `len`) have never been initialized — no existing
-    ///   reference can point to them, because `get()` requires `index < len`.
-    /// - **Reused slots** (from free list) were freed via `dec_ref` and have no
-    ///   active borrows — the slot was `.take()`n and its ID added to the free list.
-    /// - **Vec growth** (`pages.push(new_page)`) reallocates the page pointer array,
-    ///   not the page contents. Any existing `&T` reference points into a
-    ///   `Box`'s heap allocation, not into the `Vec`'s buffer.
     pub fn allocate(&self, value: T) -> HeapId {
         self.allocate_with_slot(value).0
     }
@@ -231,10 +217,6 @@ impl<T> StableHeap<T> {
 }
 
 /// Allocates a new page of uninitialized slots directly on the heap.
-#[expect(
-    clippy::unnecessary_box_returns,
-    reason = "each page must have a stable heap address independent of the page pointer vector"
-)]
 fn create_page<T>() -> Box<[Slot<T>; PAGE_SIZE]> {
     let raw = Box::into_raw(Box::<[Slot<T>]>::new_uninit_slice(PAGE_SIZE)).cast();
     // SAFETY: [DH] - allocation is known to be exactly PAGE_SIZE slots, so

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -17,187 +17,144 @@ use crate::{
     hash::{HashValue, identity_hash},
     heap::{DropWithContext, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,
-    modules::{
-        collections::defaultdict::defaultdict_missing,
-        dataclasses::{DataclassField, DataclassParams},
-    },
-    types::{
-        BoundMethod, Bytes, BytesIterator, Class, Dataclass, Deque, Dict, DictItemIterator, DictItemsView,
-        DictKeyIterator, DictKeysView, DictValueIterator, DictValuesView, ExtFunction, FrozenSet, Instance,
-        ItertoolsIter, LazyHeapSet, List, LongInt, Module, NamedTuple, NamedTupleClass, OpenFile, Path, PyTrait, Range,
-        RangeIterator, ReMatch, RePattern, Set, SetIterator, Slice, Str, StringIterator, Tuple, TupleIterator, Type,
-        callable_iterator::CallableIterator, date, datetime, deque::DequeIterator, list::ListIterator,
-        str::allocate_string, timedelta, timezone,
-    },
+    modules::collections::defaultdict::defaultdict_missing,
+    types::{LazyHeapSet, LongInt, PyTrait, Type, str::allocate_string},
     value::{EitherStr, Value},
 };
 
-/// HeapData captures every runtime value that must live in the arena.
-///
-/// The enum is moved by value on every heap allocate and free, so its inline
-/// size is a direct memcpy cost on those hot paths. Variants larger than
-/// [`Dict`] (the largest hot variant) are therefore `Box`ed — see the size
-/// assertion below the enum before adding or growing a variant.
-///
-/// Each variant wraps a type that implements `PyTrait`, providing
-/// Python-compatible operations. The trait is manually implemented to dispatch
-/// to the appropriate variant's implementation.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) enum HeapData {
-    Str(Str),
-    Bytes(Bytes),
-    List(List),
-    /// `collections.deque` — a double-ended queue with an optional `maxlen`.
-    Deque(Deque),
-    Tuple(Tuple),
-    NamedTuple(Box<NamedTuple>),
-    /// A `collections.namedtuple` class object (the callable that builds instances).
-    NamedTupleClass(Box<NamedTupleClass>),
-    Dict(Dict),
-    DictKeysView(DictKeysView),
-    DictItemsView(DictItemsView),
-    DictValuesView(DictValuesView),
-    Set(Set),
-    FrozenSet(FrozenSet),
-    Closure(Closure),
-    FunctionDefaults(FunctionDefaults),
-    /// A cell wrapping a single mutable value for closure support.
-    ///
-    /// Cells enable nonlocal variable access by providing a heap-allocated
-    /// container that can be shared between a function and its nested functions.
-    /// Both the outer function and inner function hold references to the same
-    /// cell, allowing modifications to propagate across scope boundaries.
-    Cell(CellValue),
-    /// A range object (e.g., `range(10)` or `range(1, 10, 2)`).
-    ///
-    /// Stored on the heap to keep `Value` enum small (16 bytes). Range objects
-    /// are immutable and hashable.
-    Range(Range),
-    /// A slice object (e.g., `slice(1, 10, 2)` or from `x[1:10:2]`).
-    ///
-    /// Stored on the heap to keep `Value` enum small. Slice objects represent
-    /// start:stop:step indices for sequence slicing operations.
-    Slice(Slice),
-    /// An exception instance (e.g., `ValueError('message')`).
-    ///
-    /// Stored on the heap to keep `Value` enum small (16 bytes). Exceptions
-    /// are created when exception types are called or when `raise` is executed.
-    Exception(SimpleException),
-    /// A dataclass instance with fields and method references.
-    ///
-    /// Contains a class name, a Dict of field name -> value mappings, and a set
-    /// of method names that trigger external function calls when invoked.
-    Dataclass(Box<Dataclass>),
-    /// A user-defined class object created by `class Foo: ...`.
-    ///
-    /// Holds the class name and a namespace of methods + class variables. Its own
-    /// `HeapId` is the type identity used by `type()`/`isinstance`.
-    Class(Box<Class>),
-    /// An instance of a user-defined class.
-    ///
-    /// Holds a reference to its `Class` and an `attrs` dict (the instance `__dict__`).
-    Instance(Box<Instance>),
-    /// A method bound to an instance, produced by `obj.method` without calling it.
-    BoundMethod(BoundMethod),
-    /// One `dataclasses.Field` of a `@dataclass`, held by the class's
-    /// `__dataclass_fields__` dict.
-    DataclassField(DataclassField),
-    /// `list_iterator` object.
-    ListIterator(ListIterator),
-    /// `_collections._deque_iterator` object.
-    DequeIterator(DequeIterator),
-    /// `tuple_iterator` object.
-    TupleIterator(TupleIterator),
-    /// `str_ascii_iterator` or `str_iterator` object.
-    StringIterator(StringIterator),
-    /// `bytes_iterator` object.
-    BytesIterator(BytesIterator),
-    /// `range_iterator` object.
-    RangeIterator(RangeIterator),
-    /// `dict_keyiterator` object.
-    DictKeyIterator(DictKeyIterator),
-    /// `dict_itemiterator` object.
-    DictItemIterator(DictItemIterator),
-    /// `dict_valueiterator` object.
-    DictValueIterator(DictValueIterator),
-    /// `set_iterator` object.
-    SetIterator(SetIterator),
-    /// `callable_iterator` object, from `iter(callable, sentinel)`
-    CallableIterator(CallableIterator),
-    /// An arbitrary precision integer (LongInt).
-    ///
-    /// Stored on the heap to keep `Value` enum at 16 bytes. Python has one `int` type,
-    /// so LongInt is an implementation detail - we use `Value::Int(i64)` for performance
-    /// when values fit, and promote to LongInt on overflow. When LongInt results fit back
-    /// in i64, they are demoted back to `Value::Int` for performance.
-    LongInt(LongInt),
-    /// A Python module (e.g., `sys`, `typing`).
-    ///
-    /// Modules have a name and a dictionary of attributes. They are created by
-    /// import statements and can have refs to other heap values in their attributes.
-    Module(Box<Module>),
-    /// A coroutine object from an async function call.
-    ///
-    /// Contains pre-bound arguments and captured cells, ready to be awaited.
-    /// When awaited, a new frame is pushed using the stored namespace.
-    Coroutine(Coroutine),
-    /// A gather() result tracking multiple coroutines/tasks.
-    ///
-    /// Created by asyncio.gather() and spawns tasks when awaited.
-    GatherFuture(Box<GatherFuture>),
-    /// An external future driven by the host.
-    ///
-    /// Created when the host returns `ExtFunctionResult::Future(call_id)`.
-    /// Holds its own state machine (`Pending`/`Resolved`/`Failed`) so
-    /// re-await yields cached results, matching CPython's Future semantics.
-    ExternalFuture(Box<ExternalFuture>),
-    /// A filesystem path from `pathlib.Path`.
-    ///
-    /// Stored on the heap to provide Python-compatible path operations.
-    /// Pure methods (name, parent, etc.) are handled directly by the VM.
-    /// I/O methods (exists, read_text, etc.) yield external function calls.
-    Path(Path),
-    /// A path-backed file object returned by the `open()` builtin.
-    ///
-    /// The object stores only virtual path and mode state.  Reads and writes are
-    /// full-file OS calls; no native file descriptor is kept while Monty runs.
-    OpenFile(Box<OpenFile>),
-    /// A compiled regex pattern from `re.compile()`.
-    ///
-    /// Contains the original pattern string, flags, and compiled regex engine.
-    /// Leaf type: no heap references, not GC-tracked.
-    RePattern(Box<RePattern>),
-    /// A regex match result from a successful regex operation.
-    ///
-    /// Contains the matched text, capture groups, positions, and input string.
-    /// Leaf type: no heap references, not GC-tracked.
-    ReMatch(Box<ReMatch>),
-    /// Reference to an external function supplied by the host or synthesized for a call.
-    ExtFunction(ExtFunction),
-    /// A `datetime.date` value stored with `chrono::NaiveDate`.
-    Date(date::Date),
-    /// A `datetime.datetime` value stored with chrono primitives.
-    DateTime(datetime::DateTime),
-    /// A `datetime.timedelta` duration value stored with `chrono::TimeDelta`.
-    TimeDelta(timedelta::TimeDelta),
-    /// A fixed-offset `datetime.timezone` value.
-    TimeZone(timezone::TimeZone),
-    // Append-only: this enum is dumped as part of the heap, so a mid-enum
-    // insertion makes every later variant decode as its neighbour.
-    /// Any `itertools` iterator (`count`, `repeat`, ...).
-    ///
-    /// One variant for the whole family — nothing outside `types::itertools`
-    /// dispatches on which adaptor it is.
-    Itertools(ItertoolsIter),
-    /// The `@dataclass(...)` options of a `@dataclass`, held by the class's
-    /// `__dataclass_params__` entry.
-    DataclassParams(DataclassParams),
+macro_rules! heap_storage_type {
+    (inline $payload:ty) => {
+        $payload
+    };
+    (boxed $payload:ty) => {
+        Box<$payload>
+    };
 }
 
-// `HeapData` is memcpy'd on every allocate and free, so its inline size is paid on
-// the hottest heap paths. `Dict` — far too hot to box — sets the 72-byte payload
-// ceiling (currently tag-free thanks to niche packing); if this assertion fails a
-// variant has outgrown it and should be boxed (or, for `Dict` itself, slimmed down).
+/// Invokes a consumer macro with every concrete payload stored by the heap.
+///
+/// This is the single payload registry. Its order is append-only because
+/// `HeapData`'s serde discriminants are snapshot data.
+macro_rules! heap_payloads {
+    ($consumer:ident) => {
+        $consumer! {
+            Str(inline $crate::types::Str),
+            Bytes(inline $crate::types::Bytes),
+            List(inline $crate::types::List),
+            /// `collections.deque` — a double-ended queue with an optional `maxlen`.
+            Deque(inline $crate::types::Deque),
+            Tuple(inline $crate::types::Tuple),
+            NamedTuple(boxed $crate::types::NamedTuple),
+            /// A `collections.namedtuple` class object (the callable that builds instances).
+            NamedTupleClass(boxed $crate::types::NamedTupleClass),
+            Dict(inline $crate::types::Dict),
+            DictKeysView(inline $crate::types::DictKeysView),
+            DictItemsView(inline $crate::types::DictItemsView),
+            DictValuesView(inline $crate::types::DictValuesView),
+            Set(inline $crate::types::Set),
+            FrozenSet(inline $crate::types::FrozenSet),
+            Closure(inline $crate::heap_data::Closure),
+            FunctionDefaults(inline $crate::heap_data::FunctionDefaults),
+            /// A cell wrapping a single mutable value for closure support.
+            Cell(inline $crate::heap_data::CellValue),
+            /// A range object such as `range(1, 10, 2)`.
+            Range(inline $crate::types::Range),
+            /// A slice object such as `slice(1, 10, 2)`.
+            Slice(inline $crate::types::Slice),
+            /// An exception instance such as `ValueError('message')`.
+            Exception(inline $crate::exception_private::SimpleException),
+            /// A dataclass instance with fields and method references.
+            Dataclass(boxed $crate::types::Dataclass),
+            /// A user-defined class object created by a `class` statement.
+            Class(boxed $crate::types::Class),
+            /// An instance of a user-defined class.
+            Instance(boxed $crate::types::Instance),
+            /// A method bound to an instance.
+            BoundMethod(inline $crate::types::BoundMethod),
+            /// One `dataclasses.Field` held by a class's `__dataclass_fields__` dictionary.
+            DataclassField(inline $crate::modules::dataclasses::DataclassField),
+            /// A `list_iterator` object.
+            ListIterator(inline $crate::types::list::ListIterator),
+            /// A `_collections._deque_iterator` object.
+            DequeIterator(inline $crate::types::deque::DequeIterator),
+            /// A `tuple_iterator` object.
+            TupleIterator(inline $crate::types::TupleIterator),
+            /// A `str_ascii_iterator` or `str_iterator` object.
+            StringIterator(inline $crate::types::StringIterator),
+            /// A `bytes_iterator` object.
+            BytesIterator(inline $crate::types::BytesIterator),
+            /// A `range_iterator` object.
+            RangeIterator(inline $crate::types::RangeIterator),
+            /// A `dict_keyiterator` object.
+            DictKeyIterator(inline $crate::types::DictKeyIterator),
+            /// A `dict_itemiterator` object.
+            DictItemIterator(inline $crate::types::DictItemIterator),
+            /// A `dict_valueiterator` object.
+            DictValueIterator(inline $crate::types::DictValueIterator),
+            /// A `set_iterator` object.
+            SetIterator(inline $crate::types::SetIterator),
+            /// A `callable_iterator` object from `iter(callable, sentinel)`.
+            CallableIterator(inline $crate::types::callable_iterator::CallableIterator),
+            /// An arbitrary-precision integer used when a Python `int` does not fit in `i64`.
+            LongInt(inline $crate::types::LongInt),
+            /// A Python module and its attributes.
+            Module(boxed $crate::types::Module),
+            /// A coroutine object from an async function call.
+            Coroutine(inline $crate::asyncio::Coroutine),
+            /// An `asyncio.gather()` result tracking multiple coroutines or tasks.
+            GatherFuture(boxed $crate::asyncio::GatherFuture),
+            /// An external future driven by the host.
+            ExternalFuture(boxed $crate::asyncio::ExternalFuture),
+            /// A filesystem path from `pathlib.Path`.
+            Path(inline $crate::types::Path),
+            /// A path-backed file object returned by `open()`.
+            OpenFile(boxed $crate::types::OpenFile),
+            /// A compiled regular-expression pattern.
+            RePattern(boxed $crate::types::RePattern),
+            /// A regular-expression match result.
+            ReMatch(boxed $crate::types::ReMatch),
+            /// A reference to an external function supplied by the host.
+            ExtFunction(inline $crate::types::ExtFunction),
+            /// A `datetime.date` value.
+            Date(inline $crate::types::date::Date),
+            /// A `datetime.datetime` value.
+            DateTime(inline $crate::types::datetime::DateTime),
+            /// A `datetime.timedelta` value.
+            TimeDelta(inline $crate::types::timedelta::TimeDelta),
+            /// A fixed-offset `datetime.timezone` value.
+            TimeZone(inline $crate::types::timezone::TimeZone),
+            // Append-only: a mid-list insertion changes serde's discriminants for all
+            // following variants and makes snapshots decode as the wrong payload type.
+            /// Any `itertools` iterator (`count`, `repeat`, and others).
+            Itertools(inline $crate::types::ItertoolsIter),
+            /// The options of a `@dataclass`, held in `__dataclass_params__`.
+            DataclassParams(inline $crate::modules::dataclasses::DataclassParams),
+        }
+    };
+}
+
+pub(crate) use heap_payloads;
+
+macro_rules! define_heap_data {
+    ($(
+        $(#[$meta:meta])*
+        $variant:ident($storage:ident $payload:ty)
+    ),* $(,)?) => {
+        /// Every runtime value that can be stored in the heap arena.
+        #[derive(Debug, serde::Serialize, serde::Deserialize)]
+        pub(crate) enum HeapData {
+            $(
+                $(#[$meta])*
+                $variant(heap_storage_type!($storage $payload)),
+            )*
+        }
+    };
+}
+
+heap_payloads!(define_heap_data);
+
+// `HeapData` is copied on every allocate and free. `Dict`, the largest hot
+// variant, sets the payload ceiling; larger variants should remain boxed.
 const _: () = assert!(mem::size_of::<HeapData>() <= 80);
 
 impl HeapData {

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -200,7 +200,7 @@ pub(crate) fn counter_update<'h>(
             };
             // Snapshot (key, delta) pairs first so `c.update(c)` is well-defined.
             let pairs: Vec<(Value, Value)> = {
-                let HeapReadOutput::Dict(src) = vm.heap.read(src_id) else {
+                let Some(src) = vm.heap.read_as::<Dict>(src_id) else {
                     unreachable!("mapping is a dict");
                 };
                 let src = src.get(vm.heap);
@@ -413,7 +413,7 @@ pub(crate) fn counter_most_common<'h>(
         let pair = allocate_tuple(smallvec![key, count], vm.heap);
         items.push(pair);
     }
-    Ok(Value::Ref(vm.heap.allocate(HeapData::List(List::new(items)))))
+    Ok(vm.heap.allocate_as(List::new(items)).into_value())
 }
 
 /// `Counter.elements()` — a list repeating each element by its count, skipping
@@ -462,7 +462,7 @@ pub(crate) fn counter_elements<'h>(
             items.push(key);
         }
     }
-    Ok(Value::Ref(vm.heap.allocate(HeapData::List(List::new(items)))))
+    Ok(vm.heap.allocate_as(List::new(items)).into_value())
 }
 
 /// The four binary `Counter` algebra operators.
@@ -488,39 +488,36 @@ pub(crate) fn counter_binary_op<'h>(
 ) -> RunResult<Value> {
     let mut result = Dict::new();
     result.make_counter();
-    let result_id = vm.heap.allocate(HeapData::Dict(result));
+    let result = vm.heap.allocate_as(result);
     // Guard the freshly allocated result dict: a catchable error below (e.g.
     // arithmetic or comparison on non-numeric counts raising `TypeError`) must
     // free it, which the bare `?` early-returns would otherwise leak.
-    let mut result_guard = DropGuard::new(Value::Ref(result_id), vm);
-    let vm = result_guard.ctx();
-    let HeapReadOutput::Dict(mut result) = vm.heap.read(result_id) else {
-        unreachable!("just allocated a Counter dict");
-    };
+    let mut result_guard = DropGuard::new(result, vm);
+    let (result, vm) = result_guard.as_parts_mut();
+    let result = result.read(vm.heap);
 
     // Each operand is snapshotted only when it is about to be consumed: taking
     // the right snapshot up front would leak it if folding the left one raised.
     match op {
         CounterOp::Add => {
             let l_pairs = lhs.clone_all_pairs(vm)?;
-            counter_bump_all(&mut result, l_pairs, false, vm)?;
+            counter_bump_all(result, l_pairs, false, vm)?;
             let r_pairs = rhs.clone_all_pairs(vm)?;
-            counter_bump_all(&mut result, r_pairs, false, vm)?;
+            counter_bump_all(result, r_pairs, false, vm)?;
         }
         CounterOp::Sub => {
             let l_pairs = lhs.clone_all_pairs(vm)?;
-            counter_bump_all(&mut result, l_pairs, false, vm)?;
+            counter_bump_all(result, l_pairs, false, vm)?;
             let r_pairs = rhs.clone_all_pairs(vm)?;
-            counter_bump_all(&mut result, r_pairs, true, vm)?;
+            counter_bump_all(result, r_pairs, true, vm)?;
         }
         // `|` keeps the larger count over the union of keys (see `counter_binary_extreme`).
-        CounterOp::Or => counter_binary_extreme(&mut result, lhs, rhs, ExtremeOp::Max, vm)?,
+        CounterOp::Or => counter_binary_extreme(result, lhs, rhs, ExtremeOp::Max, vm)?,
         // `&` keeps the smaller count over shared keys (see `counter_binary_extreme`).
-        CounterOp::And => counter_binary_extreme(&mut result, lhs, rhs, ExtremeOp::Min, vm)?,
+        CounterOp::And => counter_binary_extreme(result, lhs, rhs, ExtremeOp::Min, vm)?,
     }
-    counter_retain_positive(&mut result, vm)?;
-    drop(result);
-    Ok(result_guard.into_inner())
+    counter_retain_positive(result, vm)?;
+    Ok(result_guard.into_inner().into_value())
 }
 
 /// The extreme kept by the binary `&`/`|` algebra.
@@ -818,15 +815,13 @@ pub(crate) fn counter_unary_op<'h>(
 ) -> RunResult<Value> {
     let mut result = Dict::new();
     result.make_counter();
-    let result_id = vm.heap.allocate(HeapData::Dict(result));
+    let result = vm.heap.allocate_as(result);
     // Guard the freshly allocated result dict: a catchable error below (e.g.
     // comparing a non-numeric count) must free it, which the bare `?`
     // early-returns would otherwise leak.
-    let mut result_guard = DropGuard::new(Value::Ref(result_id), vm);
-    let vm = result_guard.ctx();
-    let HeapReadOutput::Dict(mut result) = vm.heap.read(result_id) else {
-        unreachable!("just allocated a Counter dict");
-    };
+    let mut result_guard = DropGuard::new(result, vm);
+    let (result, vm) = result_guard.as_parts_mut();
+    let result = result.read(vm.heap);
     // Scoped so the iterator guard releases its borrow of `result_guard` before
     // the result is handed back.
     {
@@ -860,9 +855,8 @@ pub(crate) fn counter_unary_op<'h>(
             }
         }
     }
-    counter_retain_positive(&mut result, vm)?;
-    drop(result);
-    Ok(result_guard.into_inner())
+    counter_retain_positive(result, vm)?;
+    Ok(result_guard.into_inner().into_value())
 }
 
 /// Folds a batch of `(key, delta)` pairs into `counter`, releasing any pairs

--- a/crates/monty/src/modules/dataclasses/mod.rs
+++ b/crates/monty/src/modules/dataclasses/mod.rs
@@ -70,7 +70,7 @@ pub fn create_module(vm: &mut VM<'_>) -> HeapId {
         Value::Builtin(Builtins::ExcType(ExcType::FrozenInstanceError)),
         vm,
     );
-    vm.heap.allocate(HeapData::Module(Box::new(module)))
+    vm.heap.allocate_as(module).into_id()
 }
 
 /// Dispatches a `dataclasses` module function call.
@@ -279,22 +279,20 @@ fn build_dataclass_fields<'h>(class: &HeapRead<'h, Class>, vm: &mut VM<'h>) -> R
 /// fields. The dict owns every `Field` from its first insertion, so a failure
 /// part-way releases them with it.
 fn allocate_fields_dict(vm: &mut VM<'_>, fields: Vec<DataclassField>) -> RunResult<Value> {
-    let dict_id = vm.heap.allocate(HeapData::Dict(Dict::with_capacity(fields.len())));
-    let mut guard = DropGuard::new(Value::Ref(dict_id), vm);
-    let vm = guard.ctx();
+    let dict = vm.heap.allocate_as(Dict::with_capacity(fields.len()));
+    let mut guard = DropGuard::new(dict, vm);
+    let (dict, vm) = guard.as_parts_mut();
+    let dict = dict.read(vm.heap);
     for field in fields {
         let name = field.name();
-        let field_id = vm.heap.allocate(HeapData::DataclassField(field));
-        let HeapReadOutput::Dict(mut dict) = vm.heap.read(dict_id) else {
-            unreachable!("the dict was just allocated")
-        };
+        let field = vm.heap.allocate_as(field).into_value();
         // Annotation keys are unique, so nothing is ever replaced — released
         // rather than asserted away so a future duplicate cannot leak. A dict
         // rejected by the memory limit releases the field it was handed.
-        let replaced = dict.set(Value::InternString(name), Value::Ref(field_id), vm)?;
+        let replaced = dict.set(Value::InternString(name), field, vm)?;
         replaced.drop_with(vm);
     }
-    Ok(guard.into_inner())
+    Ok(guard.into_inner().into_value())
 }
 
 /// Writes `__dataclass_fields__` into the class namespace, taking ownership of
@@ -317,10 +315,8 @@ fn store_dataclass_params<'h>(
     options: DataclassOptions,
     vm: &mut VM<'h>,
 ) -> RunResult<()> {
-    let params = vm
-        .heap
-        .allocate(HeapData::DataclassParams(DataclassParams::new(options)));
-    let replaced = class.set_attr(StaticStrings::DataclassParams.into(), Value::Ref(params), vm)?;
+    let params = vm.heap.allocate_as(DataclassParams::new(options)).into_value();
+    let replaced = class.set_attr(StaticStrings::DataclassParams.into(), params, vm)?;
     replaced.drop_with(vm);
     Ok(())
 }

--- a/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
@@ -11,6 +11,8 @@
 use super::*;
 #[cfg(heap_reader_compile_fail_test_smuggle_vm)]
 use crate::bytecode::VM;
+#[cfg(heap_reader_compile_fail_test_smuggle_heap_read)]
+use crate::types::List;
 #[cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)]
 use crate::types::str::allocate_string;
 

--- a/crates/monty/tests/heap_reader_compile_fail_cases/dec_ref_while_reading.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/dec_ref_while_reading.stderr
@@ -1,10 +1,10 @@
 error[E0502]: cannot borrow `*heap` as mutable because it is also borrowed as immutable
-  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:74:9
+  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:76:9
    |
-73 |         let list_ref = a.get(heap);
+75 |         let list_ref = a.get(heap);
    |                              ---- immutable borrow occurs here
-74 |         heap.heap_mut().dec_ref(list_id);
+76 |         heap.heap_mut().dec_ref(list_id);
    |         ^^^^^^^^^^^^^^^ mutable borrow occurs here
-75 |         let _ = list_ref.as_slice().len();
+77 |         let _ = list_ref.as_slice().len();
    |                 -------- immutable borrow later used here
 For more information about this error, try `rustc --explain E0502`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/double_get_mut.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/double_get_mut.stderr
@@ -1,10 +1,10 @@
 error[E0499]: cannot borrow `*heap` as mutable more than once at a time
-  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:55:31
+  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:57:31
    |
-54 |         let ref_a = a.get_mut(heap);
+56 |         let ref_a = a.get_mut(heap);
    |                               ---- first mutable borrow occurs here
-55 |         let ref_b = b.get_mut(heap);
+57 |         let ref_b = b.get_mut(heap);
    |                               ^^^^ second mutable borrow occurs here
-56 |         let _ = (ref_a, ref_b);
+58 |         let _ = (ref_a, ref_b);
    |                  ----- first borrow later used here
 For more information about this error, try `rustc --explain E0499`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/heap_mutation_while_reading.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/heap_mutation_while_reading.stderr
@@ -1,10 +1,10 @@
 error[E0502]: cannot borrow `*heap` as mutable because it is also borrowed as immutable
-  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:32:41
+  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:34:41
    |
-31 |         let slice = a.get(heap).as_slice();
+33 |         let slice = a.get(heap).as_slice();
    |                           ---- immutable borrow occurs here
-32 |         let _ = allocate_string("boom", heap.heap_mut());
+34 |         let _ = allocate_string("boom", heap.heap_mut());
    |                                         ^^^^^^^^^^^^^^^ mutable borrow occurs here
-33 |         let _ = slice.len();
+35 |         let _ = slice.len();
    |                 ----- immutable borrow later used here
 For more information about this error, try `rustc --explain E0502`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/mutation_in_map_closure.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/mutation_in_map_closure.stderr
@@ -1,13 +1,13 @@
 error[E0500]: closure requires unique access to `*heap` but it is already borrowed
-   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:116:18
+   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:118:18
     |
-113 |             .get(heap)
+115 |             .get(heap)
     |                  ---- borrow occurs here
 ...
-116 |             .map(|_v| {
+118 |             .map(|_v| {
     |              --- ^^^^ closure construction occurs here
     |              |
     |              first borrow later used by call
-117 |                 heap.heap_mut().dec_ref(other_id);
+119 |                 heap.heap_mut().dec_ref(other_id);
     |                 ---- second borrow occurs due to use of `*heap` in closure
 For more information about this error, try `rustc --explain E0500`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_and_swap_reader.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_and_swap_reader.stderr
@@ -1,12 +1,12 @@
 error[E0521]: borrowed data escapes outside of closure
-   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:183:13
+   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:185:13
     |
-179 |         HeapReader::with(heap_b, reader_a, |reader_b, smuggled| {
+181 |         HeapReader::with(heap_b, reader_a, |reader_b, smuggled| {
     |                                             --------  -------- `smuggled` declared here, outside of the closure body
     |                                             |
     |                                             `reader_b` is a reference that is only valid in the closure body
 ...
-183 |             std::mem::swap(reader_b, smuggled);
+185 |             std::mem::swap(reader_b, smuggled);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `reader_b` escapes the closure body here
     |
     = note: requirement occurs because of a mutable reference to `heap::HeapReader<'_>`

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_heap_read.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_heap_read.stderr
@@ -1,12 +1,12 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:93:9
+  --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:95:9
    |
-87 |     let mut smuggled: Option<HeapObjectRead<'_, List>> = None;
+89 |     let mut smuggled: Option<HeapObjectRead<'_, List>> = None;
    |         ------------ `smuggled` declared here, outside of the closure body
-88 |     HeapReader::with(heap, &mut (), |heap, ()| {
+90 |     HeapReader::with(heap, &mut (), |heap, ()| {
    |                                      ---- `heap` is a reference that is only valid in the closure body
 ...
-93 |         smuggled = Some(a);
+95 |         smuggled = Some(a);
    |         ^^^^^^^^ `heap` escapes the closure body here
    |
    = note: requirement occurs because of the type `heap::HeapObjectRead<'_, list::List>`, which makes the generic argument `'_` invariant

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
@@ -1,7 +1,7 @@
 error: lifetime may not live long enough
-   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:155:36
+   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:157:36
     |
-155 |         |reader, (interns, print)| VM::new(Vec::new(), code, reader, *interns, print.reborrow(), 120),
+157 |         |reader, (interns, print)| VM::new(Vec::new(), code, reader, *interns, print.reborrow(), 120),
     |          ------                  - ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
     |          |                       |
     |          |                       return type of closure is VM<'2>
@@ -11,15 +11,15 @@ error: lifetime may not live long enough
     = note: the struct `VM<'h>` is invariant over the parameter `'h`
     = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 error: lifetime may not live long enough
-   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:152:5
+   --> crates/monty/src/heap/../../tests/heap_reader_compile_fail_cases/cases.rs:154:5
     |
-151 |   fn smuggle_vm(heap: &mut Heap, interns: &crate::intern::Interns, code: &'static crate::bytecode::Code) -> VM<'static> {
+153 |   fn smuggle_vm(heap: &mut Heap, interns: &crate::intern::Interns, code: &'static crate::bytecode::Code) -> VM<'static> {
     |                                           - let's call the lifetime of this reference `'1`
-152 | /     HeapReader::with(
-153 | |         heap,
-154 | |         &mut (interns, monty_types::PrintWriter::Disabled),
-155 | |         |reader, (interns, print)| VM::new(Vec::new(), code, reader, *interns, print.reborrow(), 120),
-156 | |     )
+154 | /     HeapReader::with(
+155 | |         heap,
+156 | |         &mut (interns, monty_types::PrintWriter::Disabled),
+157 | |         |reader, (interns, print)| VM::new(Vec::new(), code, reader, *interns, print.reborrow(), 120),
+158 | |     )
     | |_____^ returning this value requires that `'1` must outlive `'static`
     |
     = note: requirement occurs because of the type `VM<'_>`, which makes the generic argument `'_` invariant


### PR DESCRIPTION
This is an attempt to make the code easier to read by adding `allocate_as` and `read_as` helpers to `HeapReader` which aim to reduce verbosity.

I also refactored the set of enums using the `HeapData` enum to use a macro to generate all the arms from a common list of types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed `allocate_as` and `read_as` helpers to `HeapReader` and generates the `HeapData`/`HeapReadOutput` enums from one central payload registry, cutting allocation and read boilerplate without changing behavior.

- `HeapReader::allocate_as` returns a typed `HeapAllocation` handle whose initial reference is transferred via `into_value`/`into_id` or released with `DropGuard`.
- `StableHeap::allocate_with_slot` exposes the freshly written slot so typed allocation skips the page lookup.
- `heap_payloads!` in `heap_data.rs` is now the single source of truth, generating the `HeapData` variants, `HeapReadOutput`, and `HeapPayload` impls.
- The registry is append-only; inserting a payload mid-list shifts serde discriminants and breaks snapshot decode.
- `Counter` and dataclasses call sites now use typed allocation in place of `HeapData` constructors.
- `DropGuard` gains an `as_parts_mut` to pair a guarded allocation with its VM reference.
- Heap reader compile-fail test expectations were refreshed after the source reordering.

<sup>Written for commit c22c6fc4017b6f4f1a17668f51bd404acdbad86d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

