### PR TITLE
Name the class in builtin-type attribute errors

### DIFF
--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -480,7 +480,10 @@ impl Type {
             _ => {
                 let method_name = vm.interns.get_str(method_id);
                 args.drop_with(vm.heap);
-                Err(ExcType::attribute_error(self, method_name))
+                Err(ExcType::attribute_error_type(
+                    &self.name(vm.heap, vm.interns),
+                    method_name,
+                ))
             }
         }
     }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1755,6 +1755,12 @@ impl Value {
                         BuiltinsFunctions::ObjectSetattr,
                     ))));
                 }
+                // CPython names the class rather than the metaclass here:
+                // `type object 'list' has no attribute 'nonexistent'`.
+                return Err(ExcType::attribute_error_type(
+                    &t.name(vm.heap, vm.interns),
+                    attr.as_str(vm.interns),
+                ));
             }
             _ => {}
         }

--- a/crates/monty/test_cases/attr__class_object_errors.py
+++ b/crates/monty/test_cases/attr__class_object_errors.py
@@ -1,0 +1,44 @@
+# An unknown attribute on a builtin *type object* names the class, not the
+# metaclass: `type object 'list' has no attribute 'nonexistent'`, never
+# `'type' object has no attribute 'nonexistent'`.
+import datetime
+
+_classes = [
+    (int, 'int'),
+    (str, 'str'),
+    (list, 'list'),
+    (dict, 'dict'),
+    (tuple, 'tuple'),
+    (set, 'set'),
+    (frozenset, 'frozenset'),
+    (bytes, 'bytes'),
+    (range, 'range'),
+    (datetime.datetime, 'datetime.datetime'),
+]
+
+# === attribute access ===
+for _cls, _name in _classes:
+    try:
+        _cls.nonexistent
+        assert False, 'expected AttributeError'
+    except AttributeError as e:
+        assert str(e) == f"type object '{_name}' has no attribute 'nonexistent'"
+
+# === calling an unknown class method takes the same wording ===
+for _cls, _name in _classes:
+    try:
+        _cls.nonexistent()
+        assert False, 'expected AttributeError'
+    except AttributeError as e:
+        assert str(e) == f"type object '{_name}' has no attribute 'nonexistent'"
+
+# === instances still report the instance form ===
+try:
+    [1].nonexistent
+    assert False, 'expected AttributeError'
+except AttributeError as e:
+    assert str(e) == "'list' object has no attribute 'nonexistent'"
+
+# === a known class method is unaffected ===
+assert dict.fromkeys(['a'], 1) == {'a': 1}
+assert bytes.fromhex('ff') == b'\xff'

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -77,6 +77,15 @@ semantics (the finally body runs exactly once and a `return`/`break`/
 not emit CPython 3.14's PEP 765 `SyntaxWarning` for such statements, having
 no warnings machinery.
 
+## Attribute errors on type objects
+
+`list.nonexistent` raises `AttributeError: type object 'list' has no attribute
+'nonexistent'`, naming the class rather than the metaclass, and calling it
+(`list.nonexistent()`) reports the same message. Both use Monty's name for the
+class, which differs from CPython's for four of them: `date`, `timedelta`
+and `timezone` are reported without their `datetime.` prefix, and
+`pathlib.Path` reports `PosixPath` (see ./pathlib.md).
+
 ## Traceback behaviour
 
 Tracebacks are formatted to match CPython, including the


### PR DESCRIPTION
An unknown attribute on a builtin type object now names the class rather than the metaclass, so `list.nonexistent` raises `type object 'list' has no attribute 'nonexistent'` as CPython does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attribute errors on builtin type objects to name the class rather than the metaclass, so `list.nonexistent` and `list.nonexistent()` raise `type object 'list' has no attribute 'nonexistent'` as CPython does.

**Bug Fixes**
- Instance access (`[1].nonexistent`) keeps the old wording.
- Adds regression tests and documents that `pathlib.Path` still diverges (`PosixPath`).

<sup>Written for commit 84fa588947802cb7e4e106f714be801fbe3da2a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

