### PR TITLE
docs: clarify Python subset implemented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -964,6 +964,12 @@ where they are. Change one and you must change all of them:
 - **Mount modes and their defaults** — `limitations/filesystem.md`, `docs/filesystem.md`,
   the `MountDir` docstrings in `_monty.pyi` and `crates/monty-js/ts/mount.ts`.
 
+### Reviewer Notes
+
+Remember that Monty is a limited subset of CPython, its behavior should match Python 3.14 except where documented in `limitations`.
+
+The list of stdlib modules in `docs/python-subset.md` must be updated if a new standard library module is implemented.
+
 ### Rules for `docs/`
 
 - `make test-docs` checks every Python snippet in `docs/`, `README.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -966,7 +966,8 @@ where they are. Change one and you must change all of them:
 
 ### Reviewer Notes
 
-Remember that Monty is a limited subset of CPython, its behavior should match Python 3.14 except where documented in `limitations`.
+Monty implements a limited subset of CPython.
+Its behaviour should match CPython 3.14 except where documented in `limitations`.
 
 The list of stdlib modules in `docs/python-subset.md` must be updated if a new standard library module is implemented.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **Experimental** - This project is still in development, and not ready for prime time.
 
-A minimal, secure Python interpreter written in Rust for use by AI.
+A minimal, secure Python 3.14 interpreter written in Rust for use by AI.
 
 Monty avoids the cost, latency, complexity and general faff of using a full container based sandbox for running LLM generated code.
 
@@ -39,7 +39,7 @@ What Monty **can** do:
 - Control resource usage - Monty can track memory usage, stack depth, and execution time and cancel execution if it exceeds preset limits
 - Collect stdout and stderr and return it to the caller
 - Run async or sync sandboxed code, calling async or sync functions on the host
-- Use a small subset of the standard library: `asyncio`, `collections`, `dataclasses`, `datetime`, `functools`, `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing`, `unicodedata`
+- Use a small subset of the standard library including `asyncio`, `base64`, `binascii`, `collections`, `dataclasses`, `datetime`, `functools`, `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing`, `unicodedata`
 
 What Monty **cannot** do:
 
@@ -63,7 +63,7 @@ For motivation on why you might want to do this, see:
 
 In very simple terms, the idea of all the above is that LLMs can work faster, cheaper and more reliably if they're asked to write Python (or Javascript) code, instead of relying on traditional tool calling. Monty makes that possible without the complexity of a sandbox or risk of running code directly on the host.
 
-**Note:** Monty will (soon) be used to implement `codemode` in [Pydantic AI](https://github.com/pydantic/pydantic-ai)
+**Note:** Monty powers [`Code Mode`](https://pydantic.dev/docs/ai/harness/code-mode/) in [Pydantic AI](https://github.com/pydantic/pydantic-ai)
 
 **Documentation:** [`docs/`](./docs) covers installation, quickstarts for each language binding, the security model, host functions, resource limits, snapshotting, type checking and the supported Python subset. [`limitations/`](./limitations) is the reference for how Monty diverges from CPython.
 

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -70,8 +70,8 @@ pub(crate) enum StandardLib {
     Functools,
     /// The `base64` module providing the base64/base32/base16 codecs.
     Base64,
-    /// The `binascii` module, exposing only the `Error` class that `base64`
-    /// raises.
+    /// The `binascii` module providing binary-to-ASCII conversions, CRC32,
+    /// and the `Error` class used by `base64`.
     Binascii,
     /// The `gc` module exposing a single `collect()` for tests. Only present
     /// under the `test-hooks` feature so production sandboxes never see it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Monty is that place, without a container or a sandboxing service in the loop.
 ## What Monty can do
 
 - **Run a useful subset of Python** — functions, closures, decorators, classes, dataclasses, comprehensions,
-  `try`/`except`, f-strings, `async`/`await`, and 13 stdlib modules.
+  `try`/`except`, f-strings, `async`/`await`, and the most commonly-used stdlib modules.
   See [the Python subset](python-subset.md).
 - **Block host access by default** — an unmounted sandbox cannot read a file, read an environment variable, open a
   socket or spawn a process.
@@ -58,9 +58,7 @@ Monty is that place, without a container or a sandboxing service in the loop.
 
 ## What Monty cannot do
 
-- **Most of the standard library.** Only `asyncio`, `collections`, `dataclasses`, `datetime`, `functools`,
-  `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing` and `unicodedata` are importable, and each
-  covers only part of its CPython surface.
+- **Most of the standard library.** only a [subset of standard library modules are available](python-subset.md) and each covers only part of its CPython surface.
 - **Third-party packages.** There is no `sys.path` and no site-packages inside the sandbox; supporting PyPI packages is
   not a goal.
 - **Class inheritance.** `class Foo(Bar):` is rejected at parse time, and so are method decorators like `@classmethod`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,8 @@ Monty is that place, without a container or a sandboxing service in the loop.
 
 ## What Monty cannot do
 
-- **Most of the standard library.** only a [subset of standard library modules are available](python-subset.md) and each covers only part of its CPython surface.
+- **Most of the standard library.** Only a [subset of standard library modules](python-subset.md) is available, and each
+  module covers only part of its CPython surface.
 - **Third-party packages.** There is no `sys.path` and no site-packages inside the sandbox; supporting PyPI packages is
   not a goal.
 - **Class inheritance.** `class Foo(Bar):` is rejected at parse time, and so are method decorators like `@classmethod`,
@@ -89,7 +90,8 @@ where each one wins.
 - QuickStart for [Python](quickstart/python.md), [JavaScript](quickstart/javascript.md) or [Rust](quickstart/rust.md).
 - [Security model](security.md) for what "secure" does and does not mean here.
 
-Monty will be used to implement code mode in [Pydantic AI](https://github.com/pydantic/pydantic-ai).
+Monty powers [Code Mode](https://pydantic.dev/docs/ai/harness/code-mode/) in
+[Pydantic AI](https://github.com/pydantic/pydantic-ai).
 
 ## Part of the Pydantic Stack
 

--- a/docs/python-subset.md
+++ b/docs/python-subset.md
@@ -58,12 +58,13 @@ the repository, and that directory — not this page — is the source of truth.
 
 ## Standard library
 
-Fourteen modules are importable.
-Anything else raises `ModuleNotFoundError`.
+The following modules are present:
 
 | Module | Divergences |
 | --- | --- |
 | `asyncio` | [asyncio.md](https://github.com/pydantic/monty/blob/main/limitations/asyncio.md) |
+| `base64` | [base64.md](https://github.com/pydantic/monty/blob/main/limitations/base64.md) |
+| `binascii` | [base64.md](https://github.com/pydantic/monty/blob/main/limitations/base64.md) |
 | `collections` | [collections.md](https://github.com/pydantic/monty/blob/main/limitations/collections.md) |
 | `dataclasses` | [dataclasses.md](https://github.com/pydantic/monty/blob/main/limitations/dataclasses.md) |
 | `datetime` | [datetime.md](https://github.com/pydantic/monty/blob/main/limitations/datetime.md) |
@@ -83,7 +84,7 @@ The absent names are missing from the module namespace rather than stubbed, so t
 raising `AttributeError` at runtime.
 
 Notably absent: `enum`, `contextlib`, `random`, `time`, `io`, `copy`, `string`, `struct`, `operator`,
-`inspect`, `logging`, `traceback`, `base64`, `hashlib`, `uuid`, `urllib`.
+`inspect`, `logging`, `traceback`, `hashlib`, `uuid`, `urllib`.
 Some of those are absent by design — `socket`, `subprocess`, `multiprocessing`, `threading` and `ctypes` would breach
 the sandbox — and others are simply not implemented yet.
 


### PR DESCRIPTION
Hopefully stops cubic suggesting fixes for irrelevant Python versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Python subset Monty implements so reviewers and contributors no longer suggest fixes for irrelevant Python versions.

- Specifies that Monty targets Python 3.14 behavior except where documented in `limitations/`.
- Adds `base64` and `binascii` to the stdlib module lists in `README.md`, `docs/index.md`, and `docs/python-subset.md`, removes them from the "notably absent" list, and updates the `binascii` module comment to reflect its actual scope.
- Adds reviewer notes to `CLAUDE.md` requiring the module list in `docs/python-subset.md` to stay in sync with newly implemented stdlib modules.
- Replaces the "will be used to implement codemode" Pydantic AI messaging with "powers Code Mode" and swaps the "13 stdlib modules" count in `docs/index.md` for a link to `python-subset.md`.

<sup>Written for commit 0136c696891150e4babd4dbffe52056d0dec38d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

