### PR TITLE
add id to default object repr to match CPython

### DIFF
--- a/crates/monty/src/heap/mod.rs
+++ b/crates/monty/src/heap/mod.rs
@@ -269,6 +269,15 @@ macro_rules! define_heap_read_support {
             )*
         }
 
+        impl HeapReadOutput<'_> {
+            /// Returns the heap entry containing the complete dynamically read object.
+            pub fn id(&self) -> HeapId {
+                match self {
+                    $(Self::$variant(value) => value.id(),)*
+                }
+            }
+        }
+
         $(
             impl HeapPayload for $payload {
                 #[inline]

--- a/crates/monty/src/identity.rs
+++ b/crates/monty/src/identity.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::{
     builtins::Builtins,
-    heap::Heap,
+    heap::{Heap, HeapId},
     modules::ModuleFunctions,
     types::{LongInt, Property},
     value::{Marker, Value},
@@ -84,11 +84,14 @@ impl Identity {
         }
     }
 
-    /// Encodes this key as a nonnegative Python integer.
-    ///
-    /// Returns an immediate integer when possible, otherwise allocating a `LongInt`.
-    pub(crate) fn into_value(self, heap: &Heap) -> Value {
-        let payload = match &self {
+    /// Builds the identity of an arena-allocated object.
+    pub(crate) fn from_heap_id(id: HeapId) -> Self {
+        Self::Heap(id.index())
+    }
+
+    /// Encodes this key as the nonnegative integer exposed by Python's `id()`.
+    pub(crate) fn encoded(&self) -> u128 {
+        let payload = match self {
             Self::Undefined | Self::Ellipsis | Self::NotImplemented | Self::None => 0,
             Self::Bool(value) => u128::from(*value),
             Self::Int(value) => u128::from(zigzag_i64(*value)),
@@ -103,8 +106,14 @@ impl Identity {
             Self::Marker(value) => fixed_serde_payload(value),
             Self::Property(value) => fixed_serde_payload(value),
         };
-        let encoded = (payload << TAG_BITS) | u128::from(self.tag());
-        LongInt::value_from_u128(encoded, heap)
+        (payload << TAG_BITS) | u128::from(self.tag())
+    }
+
+    /// Encodes this key as a Python integer.
+    ///
+    /// Returns an immediate integer when possible, otherwise allocating a `LongInt`.
+    pub(crate) fn into_value(self, heap: &Heap) -> Value {
+        LongInt::value_from_u128(self.encoded(), heap)
     }
 
     /// Returns the stable low-bit category tag for this identity variant.

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -12,10 +12,8 @@ use crate::{
         BorrowedHeapReadMut, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead,
         HeapReadOutput, heap_read_ref_as_field_mut,
     },
-    identity::Identity,
     intern::Interns,
     modules::dataclasses::{self, DataclassHash},
-    types::allocate_string,
     value::{EitherStr, Value},
 };
 
@@ -205,9 +203,25 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
     }
 
     /// Dispatches to a user or synthesized `__repr__`, falling back to the
-    /// identity-bearing default representation.
+    /// identity-bearing default representation. The dataclass form registers
+    /// the instance in `heap_ids`, so a field pointing back renders `...`.
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        instance_repr_fmt(self.id(), f, vm, heap_ids)
+        let self_id = self.id();
+        if let Some(s) = instance_call_str_dunder(self_id, "__repr__", vm)? {
+            defer_drop!(s, vm);
+            Ok(f.write_str(s.to_str(vm)?)?)
+        } else {
+            let class_id = instance_class(self_id, vm);
+            match dataclasses::dataclass_fields(class_id, vm) {
+                Some(field_names) => {
+                    heap_ids.insert(self_id);
+                    let result = dataclasses::dataclass_repr_fmt(self_id, &field_names, f, vm, heap_ids);
+                    heap_ids.remove(&self_id);
+                    result
+                }
+                None => self.py_default_repr_fmt(f, vm),
+            }
+        }
     }
 
     fn py_call_attr(&mut self, vm: &mut VM<'h>, attr: &EitherStr, args: ArgValues) -> RunResult<CallResult> {
@@ -485,38 +499,10 @@ pub(crate) fn instance_attr(self_id: HeapId, attr: &str, vm: &mut VM<'_>) -> Opt
 /// Produces `repr(instance)`, dispatching to a user `__repr__` if the class
 /// defines one, otherwise the default `<ClassName object at 0x..>`.
 pub(crate) fn instance_repr(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value> {
-    // Top of a repr, so the cycle set starts empty.
-    let mut s = String::new();
-    let mut heap_ids = LazyHeapSet::default();
-    instance_repr_fmt(self_id, &mut s, vm, &mut heap_ids)?;
-    Ok(allocate_string(s, vm.heap))
-}
-
-/// Writes an instance's `repr` into `f`: a user `__repr__` wins, then the
-/// synthesized dataclass form, then the `<Foo object at 0x..>` default.
-///
-/// The dataclass form registers the instance in the *caller's* `heap_ids` for
-/// its duration, so a field pointing back renders `...` rather than nesting.
-pub(crate) fn instance_repr_fmt(
-    self_id: HeapId,
-    f: &mut impl Write,
-    vm: &mut VM<'_>,
-    heap_ids: &mut LazyHeapSet,
-) -> RunResult<()> {
-    if let Some(s) = instance_call_str_dunder(self_id, "__repr__", vm)? {
-        defer_drop!(s, vm);
-        return Ok(f.write_str(s.to_str(vm)?)?);
-    }
-    let class_id = instance_class(self_id, vm);
-    match dataclasses::dataclass_fields(class_id, vm) {
-        Some(field_names) => {
-            heap_ids.insert(self_id);
-            let result = dataclasses::dataclass_repr_fmt(self_id, &field_names, f, vm, heap_ids);
-            heap_ids.remove(&self_id);
-            result
-        }
-        None => Ok(f.write_str(&default_repr(self_id, vm))?),
-    }
+    let HeapReadOutput::Instance(instance) = vm.heap.read(self_id) else {
+        unreachable!("instance_repr called on non-instance heap value")
+    };
+    instance.py_repr(vm)
 }
 
 /// Produces `str(instance)`, dispatching to a user `__str__` if defined, else
@@ -641,16 +627,6 @@ pub(crate) fn class_dunder<'v>(class_id: HeapId, dunder: &str, vm: &'v VM<'_>) -
         HeapData::Class(class) => class.namespace().get_by_str(dunder, vm.heap, vm.interns),
         _ => None,
     }
-}
-
-/// The default `repr` for an instance with no user `__repr__`.
-fn default_repr(self_id: HeapId, vm: &mut VM<'_>) -> String {
-    let class_id = instance_class(self_id, vm);
-    format!(
-        "<{} object at 0x{:x}>",
-        class_name(class_id, vm.heap, vm.interns),
-        Identity::from_heap_id(self_id).encoded()
-    )
 }
 
 /// Returns the `HeapId` of `self_id`'s class object.

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -12,6 +12,7 @@ use crate::{
         BorrowedHeapReadMut, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead,
         HeapReadOutput, heap_read_ref_as_field_mut,
     },
+    identity::Identity,
     intern::Interns,
     modules::dataclasses::{self, DataclassHash},
     types::allocate_string,
@@ -203,15 +204,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
         }
     }
 
-    /// The best-effort `<ClassName object>` default, never the real `repr`.
-    ///
-    /// Every form that distinguishes instances needs the `HeapId` to pass `self`,
-    /// so all of it lives in [`instance_repr_fmt`], which `Value::py_repr_fmt`
-    /// routes every instance through; this is only the floor under a heap-level
-    /// `repr` reached without a `Value`.
-    fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        let class_id = self.get(vm.heap).class();
-        Ok(write!(f, "<{} object>", class_name(class_id, vm.heap, vm.interns))?)
+    /// Dispatches to a user or synthesized `__repr__`, falling back to the
+    /// identity-bearing default representation.
+    fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
+        instance_repr_fmt(self.id(), f, vm, heap_ids)
     }
 
     fn py_call_attr(&mut self, vm: &mut VM<'h>, attr: &EitherStr, args: ArgValues) -> RunResult<CallResult> {
@@ -653,7 +649,7 @@ fn default_repr(self_id: HeapId, vm: &mut VM<'_>) -> String {
     format!(
         "<{} object at 0x{:x}>",
         class_name(class_id, vm.heap, vm.interns),
-        self_id.index()
+        Identity::from_heap_id(self_id).encoded()
     )
 }
 

--- a/crates/monty/src/types/itertools/mod.rs
+++ b/crates/monty/src/types/itertools/mod.rs
@@ -275,8 +275,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ItertoolsIter> {
     }
 
     /// Only `count` and `repeat` carry a custom `repr`; every other adaptor
-    /// uses CPython's default `<itertools.name object>` form, which is what the
-    /// `PyTrait` default writes.
+    /// uses Python's identity-bearing default object representation.
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
         match self.get(vm.heap).kind() {
             Kind::Count => count::repr_fmt(self, f, vm, heap_ids),
@@ -289,10 +288,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ItertoolsIter> {
             | Kind::TakeWhile
             | Kind::DropWhile
             | Kind::FilterFalse
-            | Kind::StarMap => {
-                let type_name = self.py_type(vm).name(vm.heap, vm.interns);
-                Ok(write!(f, "<{type_name} object>")?)
-            }
+            | Kind::StarMap => self.py_default_repr_fmt(f, vm),
         }
     }
 }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -21,7 +21,8 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     expressions::CmpOperator,
     hash::HashValue,
-    heap::{DropWithContext, HeapId},
+    heap::{DropWithContext, HeapId, HeapObjectRead, HeapReadOutput},
+    identity::Identity,
     intern::StringId,
     value::{EitherStr, Value},
 };
@@ -121,22 +122,45 @@ impl CmpOrder {
     }
 }
 
+/// Supplies the Python identity shared by `PyTrait`'s dynamic and concrete receivers.
+///
+/// Complete heap reads carry their arena identity directly, while `Value` also
+/// covers immediate identities. Keeping this as a supertrait lets default Python
+/// operations use identity without adding it to each method's arguments.
+pub(crate) trait PyObjectIdentity {
+    /// Returns the structural key exposed by Python's `is` and `id()` operations.
+    fn py_identity(&self) -> Identity;
+}
+
+impl<T: ?Sized> PyObjectIdentity for HeapObjectRead<'_, T> {
+    fn py_identity(&self) -> Identity {
+        Identity::from_heap_id(self.id())
+    }
+}
+
+impl PyObjectIdentity for HeapReadOutput<'_> {
+    fn py_identity(&self) -> Identity {
+        Identity::from_heap_id(self.id())
+    }
+}
+
+impl PyObjectIdentity for Value {
+    fn py_identity(&self) -> Identity {
+        Identity::new(self)
+    }
+}
+
 /// Common operations for Python values.
 ///
 /// Implementers should provide Python-compatible semantics for all operations.
-/// Most methods take a `&VM` or `&mut VM` reference to access the heap and interned
-/// strings for nested lookups in containers holding `Value::Ref` values.
-///
-/// This trait is used with `enum_dispatch` on `HeapData` to enable efficient
-/// virtual dispatch without boxing overhead.
+/// Dynamic heap calls are forwarded exhaustively through [`HeapReadOutput`]
+/// without boxing.
 ///
 /// Methods take the concrete [`VM`]/`Heap` types, which own the resource
-/// tracker enforcing time/memory/recursion limits.
-///
-/// The lifetime `'h` connects [`crate::heap::HeapObjectRead`] implementations
-/// to the VM's heap reference; immediate [`Value`] implementations use it only
-/// through the VM argument.
-pub(crate) trait PyTrait<'h> {
+/// tracker enforcing time/memory/recursion limits. The lifetime `'h` connects
+/// [`HeapObjectRead`] implementations to the VM's heap reference; immediate
+/// [`Value`] implementations use it only through the VM argument.
+pub(crate) trait PyTrait<'h>: PyObjectIdentity {
     /// Returns the Python type name for this value (e.g., "list", "str").
     ///
     /// Used for error messages and the `type()` builtin.
@@ -230,6 +254,19 @@ pub(crate) trait PyTrait<'h> {
         Ok(self.py_len(vm) != Some(0))
     }
 
+    /// Writes Python's identity-bearing default object representation.
+    ///
+    /// Custom `repr` implementations that apply only to some values can call
+    /// this for their remaining variants.
+    fn py_default_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>) -> RunResult<()> {
+        let type_name = self.py_type(vm).name(vm.heap, vm.interns);
+        Ok(write!(
+            f,
+            "<{type_name} object at 0x{:x}>",
+            self.py_identity().encoded()
+        )?)
+    }
+
     /// Writes the Python `repr()` string for this value to a formatter.
     ///
     /// This method enables cycle detection for self-referential structures by tracking
@@ -243,9 +280,7 @@ pub(crate) trait PyTrait<'h> {
     /// * `vm` - The VM for resolving value references and looking up interned strings
     /// * `heap_ids` - Set of heap IDs currently being repr'd (for cycle detection)
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        let type_name = self.py_type(vm).name(vm.heap, vm.interns);
-        write!(f, "<{type_name} object>")?;
-        Ok(())
+        self.py_default_repr_fmt(f, vm)
     }
 
     /// Returns the Python `repr()` string for this value as a heap `str` `Value`.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -26,7 +26,7 @@ use crate::{
     types::{
         Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
+        instance::{instance_dataclass_eq, instance_getattr, instance_str, instance_user_eq},
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
@@ -504,12 +504,10 @@ impl<'h> PyTrait<'h> for Value {
                         _ => Ok(f.write_str("...")?),
                     }
                 } else if matches!(vm.heap.get(*id), HeapData::Instance(_)) {
-                    // Handled here, not at the heap level, because dispatch needs
-                    // the heap id for `self`. A user `__repr__` recurses on the
-                    // *Rust* stack (see limitations/classes.md); the synthesized
-                    // dataclass form carries `heap_ids`, so a cycle in one hits
-                    // the branch above.
-                    instance_repr_fmt(*id, f, vm, heap_ids)
+                    // Instances manage their own recursion state: synthesized
+                    // dataclass reprs use `heap_ids`, while a user `__repr__`
+                    // recurses until the VM's re-entry guard raises RecursionError.
+                    vm.heap.read(*id).py_repr_fmt(f, vm, heap_ids)
                 } else {
                     heap_ids.insert(*id);
                     let result = vm.heap.read(*id).py_repr_fmt(f, vm, heap_ids);

--- a/crates/monty/test_cases/class__repr.py
+++ b/crates/monty/test_cases/class__repr.py
@@ -73,6 +73,7 @@ class Plain:
 
 pl = Plain()
 assert repr(pl).startswith('<Plain object at 0x')
+assert repr(pl).endswith(f' object at {hex(id(pl))}>')
 assert str(pl) == repr(pl)
 assert type(pl).__name__ == 'Plain'
 

--- a/crates/monty/test_cases/class__repr.py
+++ b/crates/monty/test_cases/class__repr.py
@@ -73,7 +73,7 @@ class Plain:
 
 pl = Plain()
 assert repr(pl).startswith('<Plain object at 0x')
-assert repr(pl).endswith(f' object at {hex(id(pl))}>')
+assert int(repr(pl).rsplit(' at ', 1)[1][:-1], 16) == id(pl)
 assert str(pl) == repr(pl)
 assert type(pl).__name__ == 'Plain'
 

--- a/crates/monty/test_cases/iter__for.py
+++ b/crates/monty/test_cases/iter__for.py
@@ -19,6 +19,9 @@ assert type(iter({}.values())).__name__ == 'dict_valueiterator'
 assert type(iter(set())).__name__ == 'set_iterator'
 assert type(iter(frozenset())).__name__ == 'set_iterator'
 
+list_iterator = iter([])
+assert repr(list_iterator) == f'<list_iterator object at {hex(id(list_iterator))}>'
+
 # list with mixed types
 result = []
 for x in [1, 'a', True]:

--- a/crates/monty/test_cases/iter__for.py
+++ b/crates/monty/test_cases/iter__for.py
@@ -20,7 +20,9 @@ assert type(iter(set())).__name__ == 'set_iterator'
 assert type(iter(frozenset())).__name__ == 'set_iterator'
 
 list_iterator = iter([])
-assert repr(list_iterator) == f'<list_iterator object at {hex(id(list_iterator))}>'
+list_iterator_repr = repr(list_iterator)
+assert list_iterator_repr.startswith('<list_iterator object at 0x')
+assert int(list_iterator_repr.rsplit(' at ', 1)[1][:-1], 16) == id(list_iterator)
 
 # list with mixed types
 result = []

--- a/crates/monty/test_cases/itertools__adaptors.py
+++ b/crates/monty/test_cases/itertools__adaptors.py
@@ -37,7 +37,9 @@ assert iter(p) is p
 # for every dotted `tp_name` (see limitations/itertools.md).
 assert str(type(itertools.pairwise([]))) == "<class 'itertools.pairwise'>"
 pairwise_repr = itertools.pairwise([])
-assert repr(pairwise_repr) == f'<itertools.pairwise object at {hex(id(pairwise_repr))}>'
+pairwise_repr_text = repr(pairwise_repr)
+assert pairwise_repr_text.startswith('<itertools.pairwise object at 0x')
+assert int(pairwise_repr_text.rsplit(' at ', 1)[1][:-1], 16) == id(pairwise_repr)
 
 # === pairwise errors ===
 try:

--- a/crates/monty/test_cases/itertools__adaptors.py
+++ b/crates/monty/test_cases/itertools__adaptors.py
@@ -36,6 +36,8 @@ assert iter(p) is p
 # `str(type(...))` matches CPython; `__name__` is the dotted form Monty uses
 # for every dotted `tp_name` (see limitations/itertools.md).
 assert str(type(itertools.pairwise([]))) == "<class 'itertools.pairwise'>"
+pairwise_repr = itertools.pairwise([])
+assert repr(pairwise_repr) == f'<itertools.pairwise object at {hex(id(pairwise_repr))}>'
 
 # === pairwise errors ===
 try:

--- a/limitations/iter.md
+++ b/limitations/iter.md
@@ -6,6 +6,5 @@
 - A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see ./classes.md).
 - The vendored type stub is upstream typeshed's verbatim, so `-t` accepts `iter(obj)` for an object with only `__getitem__`; Monty has no `__getitem__` iteration fallback and raises `TypeError` at runtime.
 - `-t` accepts `for x in obj` (though not `a, b = obj`) for a class that opts out of iteration with `__iter__ = None`, which raises `TypeError` at runtime as it does in CPython.
-- Iterator `repr()` values omit CPython's process-local memory address: `<list_iterator object>` rather than `<list_iterator object at 0x...>`.
 - Built-in iterators do not expose their dunders as attributes: `hasattr(iter([1]), '__iter__')` is `False`, where CPython reports `True`. Iteration itself works; only attribute lookup of the dunder differs. This covers every built-in iterator, including the `itertools` adaptors.
 - Iterator-specific attributes such as `__length_hint__` are not exposed.

--- a/limitations/itertools.md
+++ b/limitations/itertools.md
@@ -51,10 +51,6 @@ raise `AttributeError` at runtime.
   reaches back to the `repeat` holding it, Monty prints `repeat([...])` where
   CPython prints `repeat([repeat([...])])`. This is Monty's general cycle
   detection in `repr()`, not specific to `itertools`.
-- **Adaptors without a custom `repr()` omit the address.** `repr(pairwise([]))`
-  is `<itertools.pairwise object>`, where CPython appends ` at 0x...`. This is
-  Monty's general iterator treatment (see ./iter.md), not specific
-  to `itertools`.
 - **A callable that suspends is rejected, not paused.** `takewhile`,
   `dropwhile`, `filterfalse` and `starmap` apply their callable through the
   synchronous `evaluate_function` path, which runs a frame to completion and


### PR DESCRIPTION
Addresses an existing divergence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the CPython-style memory address to default object reprs, so objects without a custom `__repr__` now show `<Class object at 0x...>` instead of `<Class object>`.

**Behavior**
- Instances, built-in iterators, and `itertools` adaptors without a custom `repr` now include the address.
- Removed the corresponding documented limitations for iterators and `itertools`.
- `repr()` now matches `id()` for these objects.

**Refactor**
- Extracts identity encoding into `Identity::encoded` so `id()` and default `repr` share one value.
- Adds `PyObjectIdentity` trait so heap objects and immediates provide identity consistently.

<sup>Written for commit 17b4bfaa6c5536bc76ceee0feef5092b808e7841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

