### PR TITLE
recreate fix for 712 against `main`

### DIFF
--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -39,7 +39,7 @@ pub fn builtin_sorted(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     } else {
         ArgValues::Kwargs(kwargs)
     };
-    parse_and_sort(items, sort_args, vm)?;
+    parse_and_sort("sorted() key argument", items, sort_args, vm)?;
 
     let (items, vm) = items_guard.into_parts();
     let heap_id = vm.heap.allocate(HeapData::List(List::new(items)));

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -371,6 +371,8 @@ impl VM<'_> {
     /// User-defined functions run until their frame returns. An unresolved name raises
     /// `NameError`; external, OS, method, and future suspensions raise a variant-specific
     /// `NotImplementedError` because this context cannot preserve and resume its state.
+    /// These are raised at the suspension point inside the callee's frames, so the
+    /// callee can catch them with an ordinary `try`/`except` like any other exception.
     ///
     /// The nested `self.run()` below recurses on the native Rust stack, so
     /// re-entry is bounded via [`enter_run_reentry`](Self::enter_run_reentry)
@@ -391,30 +393,35 @@ impl VM<'_> {
         let mut guard = RunReentryGuard::new(self);
         let this = &mut *guard;
 
-        let exit = match this.call_function(callable, args)? {
-            CallResult::Value(v) => return Ok(v),
+        match this.call_function(callable, args)? {
+            CallResult::Value(v) => Ok(v),
             CallResult::FramePushed => {
                 // A new frame was pushed for a defined function call - we need to run it
                 // to completion.
                 let stack_depth = this.suspended_frames.len();
                 // Mark the frame as an exit point from the `run()` loop
                 this.current_frame_mut().should_return = true;
-                match this.run()? {
-                    FrameExit::Return(v) => return Ok(v),
-                    exit => {
-                        // Pop frames off the stack from this failed evaluation
-                        // (including the one just pushed)
-                        while this.suspended_frames.len() >= stack_depth {
-                            this.pop_frame();
+                loop {
+                    match this.run()? {
+                        FrameExit::Return(v) => return Ok(v),
+                        exit => {
+                            // Raise unsupported suspensions inside the callee so its
+                            // exception handlers can observe them.
+                            let error = this.unsupported_frame_exit(ctx, exit);
+                            if let Some(error) = this.handle_exception(error) {
+                                // Unwinding normally stops after popping the `should_return`
+                                // frame; cover any frames still above the evaluation boundary.
+                                while this.suspended_frames.len() >= stack_depth {
+                                    this.pop_frame();
+                                }
+                                return Err(error);
+                            }
                         }
-                        exit
                     }
                 }
             }
-            unsupported => return Err(this.unsupported_call_result(ctx, unsupported)),
-        };
-
-        Err(this.unsupported_frame_exit(ctx, exit))
+            unsupported => Err(this.unsupported_call_result(ctx, unsupported)),
+        }
     }
 
     /// Converts a direct call suspension into a specific synchronous-context error.

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -398,7 +398,6 @@ impl VM<'_> {
             CallResult::FramePushed => {
                 // A new frame was pushed for a defined function call - we need to run it
                 // to completion.
-                let stack_depth = this.suspended_frames.len();
                 // Mark the frame as an exit point from the `run()` loop
                 this.current_frame_mut().should_return = true;
                 loop {
@@ -408,12 +407,9 @@ impl VM<'_> {
                             // Raise unsupported suspensions inside the callee so its
                             // exception handlers can observe them.
                             let error = this.unsupported_frame_exit(ctx, exit);
+                            // The `should_return` frame stops unwinding before an
+                            // outer handler can consume this error.
                             if let Some(error) = this.handle_exception(error) {
-                                // Unwinding normally stops after popping the `should_return`
-                                // frame; cover any frames still above the evaluation boundary.
-                                while this.suspended_frames.len() >= stack_depth {
-                                    this.pop_frame();
-                                }
                                 return Err(error);
                             }
                         }

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -349,16 +349,20 @@ impl MontyRepl {
                     let old = mem::replace(&mut vm.globals[args_slot], args_tuple);
                     old.drop_with(vm);
 
-                    match vm.run_module() {
-                        Ok(FrameExit::Return(value)) => Ok(MontyObject::new(value, vm)),
-                        Ok(exit) => Err(vm
-                            .unsupported_frame_exit("MontyRepl::call_function", exit)
-                            .into_python_exception(&executor.interns, |fname| {
-                                self.sources.get(fname).map(String::as_str)
-                            })),
-                        Err(error) => Err(error.into_python_exception(&executor.interns, |fname| {
-                            self.sources.get(fname).map(String::as_str)
-                        })),
+                    let mut run_result = vm.run_module();
+                    loop {
+                        run_result = match run_result {
+                            Ok(FrameExit::Return(value)) => break Ok(MontyObject::new(value, vm)),
+                            Ok(exit) => {
+                                let error = vm.unsupported_frame_exit("MontyRepl::call_function", exit);
+                                vm.resume_with_exception(error)
+                            }
+                            Err(error) => {
+                                break Err(error.into_python_exception(&executor.interns, |fname| {
+                                    self.sources.get(fname).map(String::as_str)
+                                }));
+                            }
+                        };
                     }
                 }
                 Err(error) => Err(error),

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -39,7 +39,14 @@ struct ListSortArgs {
 /// builtin — sharing here is what makes unknown-kwarg errors uniformly
 /// read `sort() got an unexpected keyword argument 'X'` (matching
 /// CPython, whose `sorted` delegates to `list.sort` internally).
-pub fn parse_and_sort(items: &mut [Value], args: ArgValues, vm: &mut VM<'_>) -> RunResult<()> {
+///
+/// `key_context` names the calling builtin in rejected-suspension errors.
+pub fn parse_and_sort(
+    key_context: &'static str,
+    items: &mut [Value],
+    args: ArgValues,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
     let ListSortArgs { key, reverse } = ListSortArgs::from_args(args, vm)?;
     let key_fn = match key {
         Some(v) if matches!(v, Value::None) => {
@@ -49,11 +56,18 @@ pub fn parse_and_sort(items: &mut [Value], args: ArgValues, vm: &mut VM<'_>) -> 
         other => other,
     };
     defer_drop!(key_fn, vm);
-    sort_values(items, key_fn.as_ref(), reverse.bool(), vm)
+    sort_values(key_context, items, key_fn.as_ref(), reverse.bool(), vm)
 }
 
 /// Sorts a vector of values, with optional key function.
-pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
+/// `key_context` names the calling builtin — see [`parse_and_sort`].
+pub fn sort_values(
+    key_context: &'static str,
+    values: &mut [Value],
+    key_fn: Option<&Value>,
+    reverse: bool,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
     if let Some(f) = key_fn {
         // Sort by key function: compute all the keys, sort an index buffer, then
         // rearrange the original values in-place according to the sorted indices.
@@ -66,7 +80,7 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
         for (i, item) in values.iter().enumerate() {
             vm.heap.tracker.check_time_every(i)?;
             let item = item.clone_with_heap(vm);
-            keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
+            keys.push(vm.evaluate_function(key_context, f, ArgValues::One(item))?);
         }
 
         // 2. Sort indices by comparing key values (or values themselves if no key)

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -901,7 +901,7 @@ fn do_list_sort<'h>(list: &mut HeapRead<'h, List>, args: ArgValues, vm: &mut VM<
     let items = mem::take(&mut list.get_mut(vm.heap).items);
     defer_drop_mut!(items, vm);
 
-    let sort_result = parse_and_sort(items, args, vm);
+    let sort_result = parse_and_sort("sort() key argument", items, args, vm);
 
     // Swap our (sorted) buffer back into the list. Whatever the user placed
     // on the live empty list during the sort ends up in `items`; if

--- a/crates/monty/tests/file_error_paths.rs
+++ b/crates/monty/tests/file_error_paths.rs
@@ -190,6 +190,39 @@ f.read(5)
     assert_eq!(result, MontyObject::Bytes(Vec::new()));
 }
 
+#[test]
+fn rejected_read_suspension_catchable_inside_key_fn() {
+    let code = r"
+f = open('/x.txt')
+caught = []
+
+def key_fn(x):
+    try:
+        f.read(5)
+    except NotImplementedError as e:
+        caught.append(str(e))
+    return x
+
+sorted([1], key=key_fn)
+caught[0]
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let open_call = progress.into_os_call().expect("expected Open OsCall");
+    let progress = open_call
+        .resume(MontyObject::FileHandle(file_handle("/x.txt", "r")), PrintWriter::Stdout)
+        .unwrap();
+    let result = progress.into_complete().expect("expected Complete");
+    assert_eq!(
+        result,
+        MontyObject::String(
+            "sorted() key argument: OS function 'Path.read_text' is not yet supported in this context".to_owned()
+        )
+    );
+}
+
 // ---------------------------------------------------------------------------
 // apply_write_position: a host that returns a non-int (or negative) byte
 // count must surface as a clean Python error rather than panic. The

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -216,6 +216,47 @@ sorted([1, 2, 3], key=key_fn)
     );
 }
 
+/// An uncaught key-function error returns to the sorting call before an outer
+/// handler runs, preserving the synchronous evaluation boundary.
+#[test]
+fn not_implemented_in_sort_key_catchable_outside_key_fn() {
+    let code = "
+seen = []
+
+def key_fn(x):
+    seen.append(x)
+    ext_fn()
+
+try:
+    sorted([1, 2], key=key_fn)
+except NotImplementedError:
+    seen.append('caught')
+seen.append('after')
+seen
+";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let result = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap();
+    assert_eq!(
+        result,
+        MontyObject::List(vec![
+            MontyObject::Int(1),
+            MontyObject::String("caught".to_owned()),
+            MontyObject::String("after".to_owned()),
+        ])
+    );
+}
+
 /// Rejected-suspension errors identify `list.sort()` rather than `sorted()`.
 #[test]
 fn not_implemented_in_list_sort_key_names_sort() {

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -157,9 +157,10 @@ fn external_function_in_reduce_raises_not_implemented() {
 
 /// A user `__next__` calling an external function cannot suspend: like
 /// `__repr__`/`__str__` it runs synchronously via `evaluate_function`, so the
-/// call raises `NotImplementedError` (see `limitations/classes.md`). Rust-side
-/// for the same reason as `external_function_as_init_raises_not_implemented`:
-/// on CPython the external is a real function and the loop would succeed.
+/// call raises `NotImplementedError` at the `ext_fn()` call site inside
+/// `__next__` (see `limitations/classes.md`). Rust-side for the same reason as
+/// `external_function_as_init_raises_not_implemented`: on CPython the external
+/// is a real function and the loop would succeed.
 #[test]
 fn external_function_in_next_raises_not_implemented() {
     let code = "class Foo:\n    def __iter__(self):\n        return self\n\n    def __next__(self):\n        return ext_fn()\n\nfor _x in Foo():\n    pass";
@@ -178,7 +179,63 @@ fn external_function_in_next_raises_not_implemented() {
         .unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Traceback (most recent call last):\n  File \"test.py\", line 8, in <module>\n    for _x in Foo():\n              ~~~~~\nNotImplementedError: __next__: external function 'ext_fn' is not yet supported in this context"
+        "Traceback (most recent call last):\n  File \"test.py\", line 6, in __next__\n    return ext_fn()\n           ~~~~~~~~\nNotImplementedError: __next__: external function 'ext_fn' is not yet supported in this context"
+    );
+}
+
+/// Rejected suspensions are raised inside the key function's frame, where an
+/// ordinary `try`/`except` can catch them and let the sort complete.
+#[test]
+fn not_implemented_in_sort_key_catchable_inside_key_fn() {
+    let code = "
+def key_fn(x):
+    try:
+        ext_fn()
+    except NotImplementedError:
+        return -x
+    return 0
+
+sorted([1, 2, 3], key=key_fn)
+";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let result = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap();
+    assert_eq!(
+        result,
+        MontyObject::List(vec![MontyObject::Int(3), MontyObject::Int(2), MontyObject::Int(1)])
+    );
+}
+
+/// Rejected-suspension errors identify `list.sort()` rather than `sorted()`.
+#[test]
+fn not_implemented_in_list_sort_key_names_sort() {
+    let code = "[1, 2].sort(key=lambda x: ext_fn())";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let err = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Traceback (most recent call last):\n  File \"test.py\", line 1, in <lambda>\n    [1, 2].sort(key=lambda x: ext_fn())\n                              ~~~~~~~~\nNotImplementedError: sort() key argument: external function 'ext_fn' is not yet supported in this context"
     );
 }
 

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -1168,7 +1168,24 @@ fn call_function_that_calls_undefined_name_fails() {
     let err = s
         .call_function("call_missing", vec![], PrintWriter::Stdout)
         .unwrap_err();
-    assert_snapshot!(err, @"NotImplementedError: MontyRepl::call_function: external function 'unknown_func' is not yet supported in this context");
+    assert_snapshot!(err, @r#"
+    Traceback (most recent call last):
+      File "<python-input-1>", line 1, in <module>
+        call_missing()
+        ~~~~~~~~~~~~~~
+      File "<python-input-0>", line 1, in call_missing
+        def call_missing(): return unknown_func()
+                                   ~~~~~~~~~~~~~~
+    NotImplementedError: MontyRepl::call_function: external function 'unknown_func' is not yet supported in this context
+    "#);
+}
+
+#[test]
+fn call_function_catches_unsupported_os_call() {
+    let mut s =
+        repl_with_code("def try_open():\n    try:\n        open('/x.txt')\n    except:\n        return 'caught'");
+    let result = s.call_function("try_open", vec![], PrintWriter::Stdout).unwrap();
+    assert_eq!(result, MontyObject::String("caught".to_owned()));
 }
 
 #[test]

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -226,8 +226,10 @@ first, e.g. return a `dict` of the fields.
   does.
 - `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
   `__repr__`/`__str__` they run synchronously, so one that calls an external or
-  OS function cannot suspend and raises `NotImplementedError`. Two related
-  protocols are still not dispatched, so a class relying on either is not
+  OS function cannot suspend and raises `NotImplementedError`. The error is
+  raised at the offending call inside the callee, so a `try`/`except` there
+  catches it like any other exception. Two related protocols are still not
+  dispatched, so a class relying on either is not
   iterable:
   - the legacy `__getitem__`-only fallback: CPython iterates a class defining
     `__getitem__` but not `__iter__` from index 0 until `IndexError`, while


### PR DESCRIPTION
Reimplements #726 on top of main.

Fixes #712 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-implements the fix for issue #712 on top of `main`: rejected suspensions (`NotImplementedError` from OS/external calls in synchronous contexts) are now raised at the offending call site inside the callee, so an ordinary `try`/`except` in the callee can catch them. Sort-key errors now identify the actual calling builtin, so `list.sort()` reports `sort() key argument: ...` instead of always saying `sorted()`.

**Bug Fixes**
- `VM::call_function` and `MontyRepl::call_function` unwind through the callee's frames when a suspension is unsupported, letting the callee's exception handlers observe the error.
- Tracebacks for rejected suspensions now point to the call inside the callee rather than the caller.
- Updated `limitations/classes.md` to document that synchronous protocol methods can catch these errors.

<sup>Written for commit 04df8c1a78b6709f7bba735b8b7514418813e52f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



