### PR TITLE
remove `EitherStr` hash

### DIFF
--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -189,7 +189,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dataclass> {
         let vm = &mut *guard;
         let mut hasher = DefaultHasher::new();
         // Hash the class name
-        self.get(vm.heap).name.hash(&mut hasher);
+        self.get(vm.heap).name.as_str(vm.interns).hash(&mut hasher);
         // Hash each declared field (name, value) pair in order
         let field_count = self.get(vm.heap).field_names.len();
         for i in 0..field_count {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -2332,7 +2332,7 @@ pub(crate) fn eq_bytes(b: &[u8], other: &Value, vm: &VM<'_>) -> Option<bool> {
 ///
 /// Used when a string value can come from either the intern table (for known
 /// static strings and keywords) or from a heap-allocated Python string object.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) enum EitherStr {
     /// Interned string identifier (cheap comparisons and no allocation).
     Interned(StringId),


### PR DESCRIPTION
It doesn't work the same way as rest of string hashing, seems like a possible footgun.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `Hash` implementation for `EitherStr` so it hashes consistently with other string types. The derived hash covered the enum variant rather than the actual string value, which is a footgun.

- Dataclass hashing now uses `as_str(vm.interns)` to get the string value before hashing.

<sup>Written for commit 46ec7f608dcdfe126474bc225cb887e81a9ae9a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

