### PR TITLE
Commit gathers with an explicit stack instead of capping nesting

### DIFF
--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -473,6 +473,55 @@ fn async_accumulation_reaches_the_soft_limit() {
     child.shutdown();
 }
 
+/// Gathers nested as *items* of one another (`g = asyncio.gather(g)`) cost no
+/// Python frames, so nothing but `max_memory` bounds how deep a nest gets built.
+/// Building one too large for the limit must end the run with a `MemoryError`,
+/// and the worker must survive it.
+#[test]
+fn building_a_deep_gather_nest_reaches_the_soft_limit() {
+    let mut child = ChildProc::spawn();
+    child.create_repl_with(configure_with_max_memory(1024 * 1024));
+    // Built inside a function so unwinding releases the partial nest — a nest
+    // left bound at module level keeps the session over its limit.
+    let code = "import asyncio\nasync def leaf():\n    return 1\ndef build():\n    g = leaf()\n    for _ in range(50_000):\n        g = asyncio.gather(g)\n    return g\nbuild()";
+    let (_, event) = child.feed(code);
+    assert_eq!(expect_error(event).exc_type, "MemoryError");
+    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+    child.shutdown();
+}
+
+/// Committing a nest costs a walk frame per level on the way down and a result
+/// list per level on the way back up, none of it between bytecode instructions.
+/// So a nest that *fits* under `max_memory` can still exceed it when awaited,
+/// and that has to arrive as a `MemoryError` rather than as a dead worker: the
+/// walk polls the limit as it goes, and preflights its own reallocations.
+///
+/// Both depths build inside the limit. The small one crosses it during the walk;
+/// the large one is where a single `Vec` growth of the walk's stack used to jump
+/// clear over the allocator's hard ceiling in one allocation.
+#[test]
+fn committing_a_deep_gather_nest_reaches_the_soft_limit() {
+    for (limit, depth) in [(1024 * 1024, 3_500), (32 * 1024 * 1024, 100_000)] {
+        let mut child = ChildProc::spawn();
+        child.create_repl_with(configure_with_max_memory(limit));
+        let build = format!(
+            "import asyncio\nasync def leaf():\n    return 1\ng = leaf()\nfor _ in range({depth}):\n    g = asyncio.gather(g)\n1"
+        );
+        assert_eq!(child.feed_complete(&build), MontyObject::Int(1), "depth {depth}");
+
+        let (_, event) = child.feed("await g");
+        assert_eq!(expect_error(event).exc_type, "MemoryError", "depth {depth}");
+        // Dropping the nest brings the session back under its limit, which it
+        // could not do if the worker had died on the hard ceiling instead.
+        assert_eq!(
+            child.feed_complete("g = None\n1 + 1"),
+            MontyObject::Int(2),
+            "depth {depth}"
+        );
+        child.shutdown();
+    }
+}
+
 /// Known large results are rejected against allocator usage before they can
 /// jump from below the soft limit past the hard ceiling. The reported figure is
 /// what each result really costs, so it pins down that the refusal accounted for

--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -267,6 +267,14 @@ pub(crate) enum GatherState {
     Failed(RunError),
 }
 
+/// Children of a gather that are still in flight → the slots each fills in the
+/// gather's `results`.
+///
+/// Keyed by the child's own `HeapId` (coroutine, external future or nested
+/// gather), which is how every resolution site addresses its parent's slots.
+/// Duplicates from `gather(c, c)` share one entry with several indices.
+pub(crate) type PendingChildren = AHashMap<HeapId, SmallVec<[usize; 1]>>;
+
 /// Per-await bookkeeping for a [`GatherFuture`] in the `Awaited` phase.
 ///
 /// All fields are populated when the gather is first awaited (in
@@ -285,14 +293,11 @@ pub(crate) struct AwaitedGather {
     /// fans into the outer's slot). Single-waiter for now; the multi-waiter
     /// form is a planned follow-up.
     pub awaiter: Awaiter,
-    /// Children → slots they fill in `results`. Keyed by each child's own
-    /// `HeapId` (coroutine or external future). Duplicates from
-    /// `gather(c, c)` produce a single entry whose value is a `SmallVec` of
-    /// multiple indices.
+    /// Children → slots they fill in `results`, see [`PendingChildren`].
     ///
     /// Entries are removed as the corresponding child resolves. The gather
     /// is done when this map is empty.
-    pub pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>>,
+    pub pending_children: PendingChildren,
     /// Results from each gather item, in order. Indices align with
     /// `GatherFuture::items`. Filled as tasks complete and externals resolve.
     pub results: Vec<Option<Value>>,

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -6,22 +6,24 @@
 //! - Task completion and failure handling
 //! - External future resolution
 
-use std::{collections::hash_map::Entry, mem, task::Poll};
+use std::{mem, task::Poll};
 
-use ahash::AHashMap;
-use monty_types::MontyException;
+use monty_types::{MontyException, ResourceError, ResourceTracker};
 use smallvec::{SmallVec, smallvec};
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
     asyncio::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
-        GatherState, TaskId,
+        GatherState, PendingChildren, TaskId,
     },
     bytecode::vm::scheduler::{SerializedTaskFrame, TaskState},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapObjectRead, HeapRead, HeapReadOutput, HeapReader},
+    heap::{
+        ContainsHeap, DropGuard, DropWithContext, HeapData, HeapId, HeapObjectRead, HeapRead, HeapReadOutput,
+        HeapReader,
+    },
     intern::FunctionId,
     object_bridge::MontyObjectExt,
     run_progress::{ExtFunctionResult, ExtFunctionResultExt},
@@ -99,103 +101,132 @@ impl<'h> VM<'h> {
     }
 
     /// Awaits a gather future from the user's `await gather` site.
+    ///
+    /// A settled gather replays its cached result; a `Pending` one is handed to
+    /// [`Self::commit_gather_tree`], which commits it along with every gather
+    /// nested inside it.
     fn await_gather_future(
         &mut self,
-        mut gather: HeapObjectRead<'h, GatherFuture>,
+        gather: HeapObjectRead<'h, GatherFuture>,
         awaiter: Awaiter,
     ) -> Result<Poll<Value>, RunError> {
         let mut awaiter_guard = DropGuard::new(awaiter, self);
         let this = awaiter_guard.ctx();
-        match &gather.get(this.heap).state {
-            GatherState::Pending => {}
-            GatherState::Completed(value) => {
-                return Ok(Poll::Ready(value.clone_with_heap(this.heap)));
-            }
-            GatherState::Failed(err) => {
-                return Err(err.clone());
-            }
-            // TODO: support concurrent re-await (CPython does).
-            GatherState::Awaited(_) => {
-                return Err(SimpleException::new_msg(
-                    ExcType::RuntimeError,
-                    "cannot reuse gather that is currently being awaited",
-                )
-                .into());
-            }
+        if let Some(value) = poll_settled_gather(&gather, this.heap)? {
+            Ok(Poll::Ready(value))
+        } else {
+            // The walk re-reads each gather by id, so hand the handle back
+            // before it starts.
+            let gather_id = gather.id();
+            drop(gather);
+            let (awaiter, this) = awaiter_guard.into_parts();
+            this.commit_gather_tree(gather_id, awaiter)
         }
-
-        // Empty gather shortcut. Allocate the empty list, store it as the
-        // cached `Completed` result, and return an inc_ref'd reference.
-        let item_count = gather.get(this.heap).item_count();
-        if item_count == 0 {
-            let list_id = this.heap.allocate(HeapData::List(List::new(vec![])));
-            gather.cache_result(this.heap, list_id);
-            return Ok(Poll::Ready(Value::Ref(list_id)));
-        }
-
-        // Await all items, storing already resolved state and tracking the rest in `pending_children`.
-
-        let mut pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>> = AHashMap::new();
-        let results: Vec<Option<Value>> = (0..item_count).map(|_| None).collect();
-        let mut results_guard = DropGuard::new(results, this);
-        let (results, this) = results_guard.as_parts_mut();
-
-        // A later item failing during this commit pass leaves the ones already
-        // committed running, as CPython does. They keep pointing at this
-        // gather; `resolve_child` drops what they deliver to a `Failed` one.
-        if let Err(err) = this.commit_gather_items(&gather, &mut pending_children, results) {
-            gather.get_mut(this.heap).state = GatherState::Failed(err.clone());
-            return Err(err);
-        }
-
-        if pending_children.is_empty() {
-            // All items resolved synchronously — skip straight to Completed with the result list.
-            let (results, this) = results_guard.into_parts();
-            let results: Vec<Value> = results
-                .into_iter()
-                .map(|r| r.expect("all results filled for synchronous gather completion"))
-                .collect();
-            let list_id = this.heap.allocate(HeapData::List(List::new(results)));
-            gather.cache_result(this.heap, list_id);
-            return Ok(Poll::Ready(Value::Ref(list_id)));
-        }
-
-        let results = results_guard.into_inner();
-        let (awaiter, this) = awaiter_guard.into_parts();
-        gather.get_mut(this.heap).state = GatherState::Awaited(AwaitedGather {
-            awaiter,
-            pending_children,
-            results,
-        });
-
-        Ok(Poll::Pending)
     }
 
-    /// Commits `gather`'s items left-to-right into result slots or pending children.
+    /// Commits `root` and every gather nested inside it, reporting whether the
+    /// root settled synchronously.
     ///
-    /// Spawns coroutine children, installs awaiters on external futures, and
-    /// recursively awaits nested gathers. Any error leaves already-committed
-    /// entries in `pending_children` and their awaiters pointing at `gather`;
-    /// the caller settles it so their results are dropped on arrival.
-    fn commit_gather_items(
-        &mut self,
-        gather: &HeapObjectRead<'h, GatherFuture>,
-        pending_children: &mut AHashMap<HeapId, SmallVec<[usize; 1]>>,
-        results: &mut [Option<Value>],
-    ) -> Result<(), RunError> {
-        let gather_id = gather.id();
-        for (idx, result) in results.iter_mut().enumerate() {
-            let item_id = gather.get(self.heap).items[idx];
-            let vacant_entry = match pending_children.entry(item_id) {
-                Entry::Occupied(occ) => {
-                    // Dedup: We've already registered this item in this commit pass —
-                    // this is a duplicate item (e.g. `gather(coro, coro)`). Just
-                    // append the new slot index to the existing entry.
-                    occ.into_mut().push(idx);
-                    continue;
+    /// Nesting a gather costs no Python frames (`g = asyncio.gather(g)` in a
+    /// loop), so the recursion limit never saw the commit walk that descends
+    /// through it — a recursive walk turned heap-held nesting back into native
+    /// frames and aborted the process. The frames it needed now live in
+    /// `stack`, one [`GatherCommit`] per level, which makes nesting depth a
+    /// matter of memory rather than of native stack, as it is for CPython's
+    /// loop-driven futures.
+    fn commit_gather_tree(&mut self, root: HeapId, awaiter: Awaiter) -> Result<Poll<Value>, RunError> {
+        let mut stack = vec![self.open_gather_commit(root, awaiter, None)];
+        let mut steps = 0;
+        let outcome = loop {
+            // Each level costs a frame on the way down and a result list on the
+            // way back up, and the whole walk runs no bytecode, so
+            // `dispatch_checkpoint` never sees how far it has grown. Without
+            // this check a nest that fits under `max_memory` commits its way
+            // past the allocator's hard ceiling, taking the worker down instead
+            // of ending the run.
+            if let Err(err) = self.heap.tracker.check_memory_time_every(steps) {
+                break Err(err.into());
+            }
+            steps += 1;
+
+            let frame = stack.last_mut().expect("the commit stack is emptied only by returning");
+            match self.step_gather_commit(frame) {
+                // Descend: the nested gather's own items must be committed
+                // before the frame that owns its result slot can continue.
+                Ok(Some(nested)) => {
+                    if let Err(err) = check_commit_stack_growth(stack.len(), stack.capacity(), &self.heap.tracker) {
+                        nested.drop_with(self.heap);
+                        break Err(err.into());
+                    }
+                    stack.push(nested);
                 }
-                Entry::Vacant(vacant) => vacant,
-            };
+                Ok(None) => {
+                    let frame = stack.pop().expect("the frame just stepped is still on the stack");
+                    let (child_id, slot) = (frame.gather, frame.parent_slot);
+                    let poll = self.settle_gather_commit(frame);
+                    match stack.last_mut() {
+                        // The root settled: `poll` is what the `await` site sees.
+                        None => break Ok(poll),
+                        Some(parent) => {
+                            let slot = slot.expect("only the root commit frame has no parent slot");
+                            parent.resume_after_child(child_id, slot, poll);
+                        }
+                    }
+                }
+                Err(err) => break Err(err),
+            }
+        };
+
+        match outcome {
+            Ok(poll) => Ok(poll),
+            Err(err) => {
+                self.unwind_gather_commits(stack, &err);
+                Err(err)
+            }
+        }
+    }
+
+    /// Opens a commit frame for the `Pending` gather `gather`, sized to its items.
+    fn open_gather_commit(&mut self, gather: HeapId, awaiter: Awaiter, parent_slot: Option<usize>) -> GatherCommit {
+        let HeapReadOutput::GatherFuture(item_source) = self.heap.read(gather) else {
+            panic!("gather commit frame id is not a GatherFuture")
+        };
+        let item_count = item_source.get(self.heap).item_count();
+        GatherCommit {
+            gather,
+            awaiter,
+            parent_slot,
+            next: 0,
+            results: (0..item_count).map(|_| None).collect(),
+            pending_children: PendingChildren::new(),
+        }
+    }
+
+    /// Commits `frame`'s items left-to-right into result slots or pending
+    /// children, spawning coroutine children and installing awaiters on
+    /// external futures as it goes.
+    ///
+    /// Stops early at a `Pending` nested gather, returning the frame the caller
+    /// must commit before this one can continue; `Ok(None)` means every item is
+    /// committed. Any error leaves the items handled so far in `frame`, which
+    /// [`Self::unwind_gather_commits`] settles.
+    fn step_gather_commit(&mut self, frame: &mut GatherCommit) -> Result<Option<GatherCommit>, RunError> {
+        let HeapReadOutput::GatherFuture(gather) = self.heap.read(frame.gather) else {
+            panic!("gather commit frame id is not a GatherFuture")
+        };
+        let gather_id = frame.gather;
+
+        while frame.next < frame.results.len() {
+            let idx = frame.next;
+            let item_id = gather.get(self.heap).items[idx];
+            if let Some(slots) = frame.pending_children.get_mut(&item_id) {
+                // Dedup: We've already registered this item in this commit pass —
+                // this is a duplicate item (e.g. `gather(coro, coro)`). Just
+                // append the new slot index to the existing entry.
+                slots.push(idx);
+                frame.next += 1;
+                continue;
+            }
 
             let poll = match self.heap.read(item_id) {
                 HeapReadOutput::Coroutine(coro) => {
@@ -218,26 +249,85 @@ impl<'h> VM<'h> {
                     self.await_external_future(&mut fut, sub_awaiter)?
                 }
                 HeapReadOutput::GatherFuture(child_gather) => {
-                    self.heap.inc_ref(gather_id);
-                    let sub_awaiter = Awaiter::GatherSlot {
-                        gather: gather_id,
-                        source: item_id,
-                    };
-                    self.await_gather_future(child_gather, sub_awaiter)?
+                    if let Some(value) = poll_settled_gather(&child_gather, self.heap)? {
+                        Poll::Ready(value)
+                    } else {
+                        drop(child_gather);
+                        // Both the inc_ref and the awaiter that owns it are
+                        // handed to the nested frame, which releases them when
+                        // it settles; until then nothing is committed for this
+                        // slot, so an error above needs no cleanup here.
+                        self.heap.inc_ref(gather_id);
+                        let sub_awaiter = Awaiter::GatherSlot {
+                            gather: gather_id,
+                            source: item_id,
+                        };
+                        return Ok(Some(self.open_gather_commit(item_id, sub_awaiter, Some(idx))));
+                    }
                 }
                 _ => panic!("gather item is not a Coroutine, ExternalFuture, or GatherFuture"),
             };
 
             match poll {
-                Poll::Ready(value) => {
-                    *result = Some(value);
-                }
+                Poll::Ready(value) => frame.results[idx] = Some(value),
                 Poll::Pending => {
-                    vacant_entry.insert(smallvec![idx]);
+                    frame.pending_children.insert(item_id, smallvec![idx]);
                 }
             }
+            frame.next += 1;
         }
-        Ok(())
+
+        Ok(None)
+    }
+
+    /// Settles a fully-committed frame.
+    ///
+    /// With nothing left in flight the gather goes straight to `Completed` with
+    /// its result list (this covers the empty `gather()` too); otherwise it
+    /// parks in `Awaited`, taking over the frame's bookkeeping, and later
+    /// resolutions drive it from there.
+    fn settle_gather_commit(&mut self, frame: GatherCommit) -> Poll<Value> {
+        let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(frame.gather) else {
+            panic!("gather commit frame id is not a GatherFuture")
+        };
+
+        if frame.pending_children.is_empty() {
+            let results: Vec<Value> = frame
+                .results
+                .into_iter()
+                .map(|r| r.expect("all results filled for synchronous gather completion"))
+                .collect();
+            let list_id = self.heap.allocate(HeapData::List(List::new(results)));
+            gather.cache_result(self.heap, list_id);
+            frame.awaiter.drop_with(self.heap);
+            Poll::Ready(Value::Ref(list_id))
+        } else {
+            gather.get_mut(self.heap).state = GatherState::Awaited(AwaitedGather {
+                awaiter: frame.awaiter,
+                pending_children: frame.pending_children,
+                results: frame.results,
+            });
+            Poll::Pending
+        }
+    }
+
+    /// Fails every frame left on the commit stack with `err`, innermost first.
+    ///
+    /// This is the unwind the recursive walk got from `?`: each level caches the
+    /// error so re-awaits replay it, and drops the result slots and awaiter the
+    /// frame was holding. The children it had already committed keep running and
+    /// keep pointing at their now-`Failed` gather, as they do for a failure that
+    /// arrives after the commit pass (see [`HeapRead::fail`]).
+    fn unwind_gather_commits(&mut self, stack: Vec<GatherCommit>, err: &RunError) {
+        for frame in stack.into_iter().rev() {
+            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(frame.gather) else {
+                panic!("gather commit frame id is not a GatherFuture")
+            };
+            gather.get_mut(self.heap).state = GatherState::Failed(err.clone());
+            drop(gather);
+
+            frame.drop_with(self.heap);
+        }
     }
 
     /// Awaits an external future by inspecting its heap state.
@@ -935,6 +1025,93 @@ impl<'h> VM<'h> {
         } else {
             Ok(FrameExit::ResolveFutures(pending_call_ids))
         }
+    }
+}
+
+/// One gather part-way through being committed — a frame of the walk in
+/// [`VM::commit_gather_tree`], and the reason that walk needs no native stack.
+///
+/// Everything the recursive commit held in local variables lives here instead:
+/// the items handled so far, and where in `items` to resume once the nested
+/// gather this frame descended into has settled.
+struct GatherCommit {
+    /// The gather being committed. Borrowed — the reference is owned by the
+    /// parent gather's `items`, or for the root by the awaited value itself.
+    gather: HeapId,
+    /// Owned awaiter, installed on the gather when it parks in `Awaited` and
+    /// dropped when it settles synchronously. `Awaiter::GatherSlot` carries an
+    /// inc_ref on the parent gather (see [`Awaiter`]).
+    awaiter: Awaiter,
+    /// Slot in the parent frame's `results` that this gather fills; `None` for
+    /// the root, whose result goes to the `await` site instead.
+    parent_slot: Option<usize>,
+    /// Next index into the gather's `items` to commit.
+    next: usize,
+    /// Result slots, one per item, in `items` order. Owned values.
+    results: Vec<Option<Value>>,
+    /// Children committed but not yet settled → the slots they fill.
+    pending_children: PendingChildren,
+}
+
+impl GatherCommit {
+    /// Records the outcome of the nested gather this frame descended into and
+    /// resumes at the following item.
+    ///
+    /// A nested gather that settled synchronously fills its slot like any other
+    /// ready item; one that parked joins `pending_children`, so a later
+    /// resolution reaches this gather through [`HeapRead::resolve_child`].
+    fn resume_after_child(&mut self, child: HeapId, slot: usize, poll: Poll<Value>) {
+        match poll {
+            Poll::Ready(value) => self.results[slot] = Some(value),
+            Poll::Pending => {
+                self.pending_children.insert(child, smallvec![slot]);
+            }
+        }
+        self.next = slot + 1;
+    }
+}
+
+impl<C: ContainsHeap> DropWithContext<C> for GatherCommit {
+    fn drop_with(self, heap: &mut C) {
+        self.results.drop_with(heap);
+        self.awaiter.drop_with(heap);
+    }
+}
+
+/// Preflights the commit stack's next reallocation against `max_memory`.
+///
+/// A `Vec` grows by allocating the new buffer while the old one is still live,
+/// so one growth part-way through a deep walk can add several MiB at once —
+/// enough to clear the allocator's hard ceiling between two periodic checks,
+/// which kills the worker rather than ending the run.
+fn check_commit_stack_growth(len: usize, capacity: usize, tracker: &ResourceTracker) -> Result<(), ResourceError> {
+    if len == capacity {
+        tracker.check_allocation(2 * capacity * size_of::<GatherCommit>())
+    } else {
+        Ok(())
+    }
+}
+
+/// Polls a gather that may already have settled, returning `None` when it is
+/// still `Pending` and so needs committing.
+///
+/// Shared by the `await` site and the commit walk, which face the same four
+/// states: a cached result to replay, a cached error to re-raise, an in-flight
+/// gather someone else owns, or work to do.
+fn poll_settled_gather<'h>(
+    gather: &HeapRead<'h, GatherFuture>,
+    heap: &HeapReader<'h>,
+) -> Result<Option<Value>, RunError> {
+    match &gather.get(heap).state {
+        GatherState::Pending => Ok(None),
+        GatherState::Completed(value) => Ok(Some(value.clone_with_heap(heap))),
+        GatherState::Failed(err) => Err(err.clone()),
+        // TODO: support concurrent re-await (CPython does).
+        GatherState::Awaited(_) => Err(SimpleException::new_msg(
+            ExcType::RuntimeError,
+            "cannot reuse gather that is currently being awaited",
+        )
+        .into()),
     }
 }
 

--- a/crates/monty/test_cases/async__gather_all.py
+++ b/crates/monty/test_cases/async__gather_all.py
@@ -203,6 +203,17 @@ nested_2 = asyncio.gather(nested_1, nested_1)
 assert await nested_2 == [[1, 1], [1, 1]]  # pyright: ignore
 
 
+# === Nested gather that settles before its parent finishes its items ===
+# An empty gather has nothing to wait for, so it settles while the outer gather
+# is still working through its items; the result must land in the outer's slot
+# rather than leaving the outer waiting on it.
+assert await asyncio.gather(asyncio.gather()) == [[]]  # pyright: ignore
+assert await asyncio.gather(asyncio.gather(asyncio.gather())) == [[[]]]  # pyright: ignore
+
+settled = asyncio.gather()
+assert await asyncio.gather(settled, task1(), settled) == [[], 1, []]  # pyright: ignore
+
+
 # === Sibling failure while blocked on a gather of gathers ===
 # The failing sibling settles the gather that a task blocked on
 # `gather(gather(...))` was a child of, whose inner gather owns a task of its

--- a/crates/monty/test_cases/refcount__gather_nested_commit_unwind.py
+++ b/crates/monty/test_cases/refcount__gather_nested_commit_unwind.py
@@ -1,0 +1,25 @@
+# Test that unwinding a failed nested-gather commit releases every level. The
+# innermost gather fails on an already-awaited coroutine, so each gather above it
+# has to drop its result slots and its own awaiter as the commit stack unwinds.
+import asyncio
+
+
+async def leaf():
+    return 1
+
+
+async def slow():
+    return 2
+
+
+spent = leaf()
+await spent  # pyright: ignore
+
+inner = asyncio.gather(slow(), spent)
+outer = asyncio.gather(asyncio.gather(inner))
+try:
+    await outer  # pyright: ignore
+    assert False, 'expected the reused coroutine to raise'
+except RuntimeError as exc:
+    assert str(exc) == 'cannot reuse already awaited coroutine'
+# ref-counts={'asyncio': 1, 'spent': 2, 'outer': 1, 'inner': 2}

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -1042,21 +1042,128 @@ await main()
     assert_eq!(result, MontyObject::Int(333));
 }
 
+// === Test: Gathers nested directly inside one another commit without recursing ===
+
+/// Nesting a gather as an *item* of another costs no Python frames
+/// (`g = asyncio.gather(g)` in a loop), so the recursion limit never sees the
+/// commit walk that descends through it. Committing 5,000 levels must work.
+///
+/// Runs on a 2 MiB thread — a worker's budget, and where the abort was seen;
+/// libtest's 8 MiB would only move the depth at which it aborts.
+#[test]
+fn deeply_nested_gather_commit_does_not_overflow_the_stack() {
+    run_on_a_worker_stack(await_deeply_nested_gathers);
+}
+
+/// Wraps `leaf()` in 5,000 gathers, awaits the outermost, and unwraps the
+/// 5,000 single-item result lists back down to the leaf's `1`.
+///
+/// The leaf coroutine parks the whole chain (it is spawned as a task), so this
+/// covers both directions: the commit walk down, and the resolution walk back
+/// up through 5,000 `GatherSlot` links.
+fn await_deeply_nested_gathers() {
+    let code = r"
+import asyncio
+
+async def leaf():
+    return 1
+
+g = leaf()
+for _ in range(5000):
+    g = asyncio.gather(g)
+result = await g
+for _ in range(5000):
+    result = result[0]
+result
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let result = runner.run_no_limits(vec![]).expect("a deep gather nest should resolve");
+    assert_eq!(result, MontyObject::Int(1));
+}
+
+/// Companion to the parked chain: every level settles *during* the commit walk,
+/// which is the path that hands each nested result straight back to the frame
+/// holding its slot.
+#[test]
+fn deeply_nested_gather_settling_synchronously_does_not_overflow_the_stack() {
+    run_on_a_worker_stack(|| {
+        // An empty `gather()` completes on the spot, so all 5,000 levels settle
+        // as the walk unwinds rather than parking on a task.
+        let code = r"
+import asyncio
+
+g = asyncio.gather()
+for _ in range(5000):
+    g = asyncio.gather(g)
+result = await g
+for _ in range(5000):
+    result = result[0]
+result
+";
+        let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+        let result = runner
+            .run_no_limits(vec![])
+            .expect("a synchronously settling nest should resolve");
+        assert_eq!(result, MontyObject::List(vec![]));
+    });
+}
+
+/// The error path unwinds the same depth: the innermost gather holds an
+/// already-awaited coroutine, so the commit fails 5,000 levels down and every
+/// level above must be rolled back.
+#[test]
+fn deeply_nested_gather_commit_failure_does_not_overflow_the_stack() {
+    run_on_a_worker_stack(|| {
+        let code = r"
+import asyncio
+
+async def leaf():
+    return 1
+
+spent = leaf()
+await spent
+
+g = asyncio.gather(spent)
+for _ in range(5000):
+    g = asyncio.gather(g)
+
+caught = ''
+try:
+    await g
+except RuntimeError as exc:
+    caught = str(exc)
+caught
+";
+        let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+        let result = runner.run_no_limits(vec![]).expect("the reuse error should be caught");
+        assert_eq!(
+            result,
+            MontyObject::String("cannot reuse already awaited coroutine".to_owned())
+        );
+    });
+}
+
+/// Runs `body` on a 2 MiB thread, the stack a worker gets — libtest's own 8 MiB
+/// would hide an overflow that a real session hits.
+fn run_on_a_worker_stack(body: impl FnOnce() + Send + 'static) {
+    thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(body)
+        .expect("spawning the bounded-stack thread")
+        .join()
+        .expect("the bounded stack must be enough");
+}
+
 // === Test: Deep blocked task chains are torn down without recursing ===
 
 /// A chain of blocked tasks costs no native stack to *build*, so teardown must
 /// not turn that stored depth back into frames.
-///
-/// Runs on a 2 MiB thread — a worker's budget, and where the abort was seen;
-/// libtest's 8 MiB would need a far deeper, slower chain to prove the same.
 #[test]
 fn deep_blocked_task_chain_teardown_does_not_overflow_the_stack() {
-    thread::Builder::new()
-        .stack_size(2 * 1024 * 1024)
-        .spawn(fail_sibling_of_deep_task_chain)
-        .expect("spawning the bounded-stack thread")
-        .join()
-        .expect("tearing down a deep blocked chain must not overflow the stack");
+    run_on_a_worker_stack(fail_sibling_of_deep_task_chain);
 }
 
 /// Wraps `leaf()` in 20,000 nested gathers and awaits that chain alongside a

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -106,3 +106,13 @@ CPython prints `_GatheringFuture exception was never retrieved`, a `future:` lin
 gather holding an unretrieved exception is collected.
 In Monty that gather never ran, and no sandboxed code can write to stderr in any case — `print()` rejects its `file`
 argument.
+
+### Nesting `gather` inside `gather` is bounded by `max_memory`
+
+CPython nests gathers as deeply as memory allows, and the depth costs nothing beyond the futures themselves.
+Monty holds a walk frame per level while it commits the nest, so awaiting a deep nest costs memory on top of what the
+nest already occupies.
+A session with `max_memory` set can therefore build a nest it cannot await: the `await` ends the run with
+`MemoryError: memory limit exceeded`, which sandboxed code cannot catch (see ./resource_limits.md).
+The nesting is not charged against the recursion limit in either interpreter, and a session with no memory limit has
+no bound to hit.


### PR DESCRIPTION
Alternative to #727: nesting is bounded by memory rather than capped at 32, so there is no cap to document.

## Before / After

```python
import asyncio

async def leaf():
    return 1

g = leaf()
for _ in range(2000):
    g = asyncio.gather(g)

await g
```

**Before:** the process dies with `fatal runtime error: stack overflow, aborting`. Sandboxed code cannot catch it, a `try`/`except` makes no difference, and the session is lost. The CLI aborts at about 2,000 levels; a worker has a 2 MiB stack, so it aborts sooner.

**After:** the `await` returns the nested result. A nest too large for `max_memory` ends the run with `MemoryError` — uncatchable, as every soft-limit failure is — but the worker survives it, so the session is usable again once the nest is dropped.

**How:** `GatherCommit` moves the commit walk's per-level state onto an explicit stack, so `commit_gather_tree` pushes a frame to descend and pops one to unwind instead of recursing through `await_gather_future`.

The walk runs no bytecode, so `dispatch_checkpoint` cannot be what notices it growing, and a nest that *fits* under `max_memory` would otherwise commit its way past the allocator's hard ceiling — the same lost session by another route. The walk therefore polls the limit itself, in two places, because the growth has two shapes:

- **incremental** — a frame per level going down, a result list per level coming back up: an amortized `check_memory_time_every` per walk step.
- **bulk** — the walk stack's own `Vec` doubling, which at 200,000 levels adds ~14 MB in one allocation, clear over the 4 MiB headroom however often you poll: a `check_allocation` preflight before the push that would trigger it.

Both refusals unwind through `unwind_gather_commits`. Measured on a worker, awaiting a nest that built inside the limit:

| `max_memory` / depth | Without the checks | With them |
| --- | --- | --- |
| 8 MiB / 20,000 | worker dies, `OOM_EXIT_CODE` | `MemoryError`, session recovers |
| 32 MiB / 100,000 | worker dies, `OOM_EXIT_CODE` | `MemoryError`, session recovers |
| 64 MiB / 200,000 | worker dies, `OOM_EXIT_CODE` | `MemoryError`, session recovers |
| 512 MiB / 100,000 | resolves | resolves |

`limitations/asyncio.md` records the divergence this leaves: CPython nests as deeply as memory allows and charges nothing per level for the depth, so a session with `max_memory` set can build a nest it cannot await.

Rebased onto #786; #772 deleted the sibling teardown this branch de-recursed and #747 is upstream, so this is one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `asyncio.gather` nesting so committing deeply nested gathers no longer overflows the stack: the commit walk now uses an explicit stack of frames instead of native recursion. Nesting is bounded by memory rather than capped at 32 levels; awaiting a nest too large for `max_memory` raises `MemoryError`, which is uncatchable but leaves the worker running and the session usable.

**Resource limits**
- The commit walk polls `max_memory` itself because it runs no bytecode, so `dispatch_checkpoint` never sees its growth.
- A preflight check catches the walk stack's own `Vec` reallocation, which can jump past the hard ceiling in one allocation.
- `limitations/asyncio.md` documents that a session with `max_memory` set can build a nest it cannot await.

<sup>Written for commit 0edd88ad7a4774f6d0bbba3aab0ba8a3220a8477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

