### PR TITLE
Charge existing file size on truncating writes against write_bytes_limit

### DIFF
--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -344,8 +344,7 @@ pub(super) fn host_iterdir(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudg
 /// `overlay::append_bytes` already applies when materializing a backing file.
 pub(super) fn existing_file_len(dir: &Dir, rel: &str) -> usize {
     dir.metadata(rel)
-        .map(|meta| usize::try_from(meta.len()).unwrap_or(usize::MAX))
-        .unwrap_or(0)
+        .map_or(0, |meta| usize::try_from(meta.len()).unwrap_or(usize::MAX))
 }
 
 /// Validates that writing `bytes` would not exceed the mount's quota.

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -338,6 +338,16 @@ pub(super) fn host_iterdir(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudg
     Ok(MontyObject::List(result))
 }
 
+/// Returns the size of the file a truncating write would discard, or `0` if
+/// no file exists there yet. New-file creation must stay free; only clobbering
+/// an existing file's content should be charged — mirrors the accounting
+/// `overlay::append_bytes` already applies when materializing a backing file.
+pub(super) fn existing_file_len(dir: &Dir, rel: &str) -> usize {
+    dir.metadata(rel)
+        .map(|meta| usize::try_from(meta.len()).unwrap_or(usize::MAX))
+        .unwrap_or(0)
+}
+
 /// Validates that writing `bytes` would not exceed the mount's quota.
 pub(super) fn check_write_limit(bytes: usize, ctx: &MountContext<'_>) -> Result<(), MountError> {
     if let Some(limit) = ctx.write_bytes_limit {

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -10,9 +10,9 @@ use monty_types::{FileMode, MontyObject};
 
 use super::{
     common::{
-        MemoryBudget, MountContext, check_write_limit, commit_write_bytes, host_append_bytes, host_append_text,
-        host_is_dir, host_is_file, host_iterdir, host_mkdir, host_read_bytes, host_read_text, host_rmdir, host_stat,
-        host_unlink, host_write_bytes, host_write_text, map_io, reject_non_regular,
+        MemoryBudget, MountContext, check_write_limit, commit_write_bytes, existing_file_len, host_append_bytes,
+        host_append_text, host_is_dir, host_is_file, host_iterdir, host_mkdir, host_read_bytes, host_read_text,
+        host_rmdir, host_stat, host_unlink, host_write_bytes, host_write_text, map_io, reject_non_regular,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
@@ -105,9 +105,10 @@ fn open(path: &str, mode: FileMode, ctx: &mut MountContext<'_>) -> Result<MontyO
             reject_non_regular(ctx.mount_dir, rel, path)?;
         }
         FileMode::Write(_) | FileMode::WriteUpdate(_) => {
-            check_write_limit(0, ctx)?;
+            let charged = existing_file_len(ctx.mount_dir, rel);
+            check_write_limit(charged, ctx)?;
             host_write_text(ctx.mount_dir, rel, "", path)?;
-            commit_write_bytes(0, ctx);
+            commit_write_bytes(charged, ctx);
         }
         FileMode::Append(_) | FileMode::AppendUpdate(_) => {
             host_append_bytes(ctx.mount_dir, rel, &[], path)?;
@@ -132,20 +133,28 @@ fn bool_query(
 }
 
 /// Writes text after validating quota.
+///
+/// A truncating write discards whatever the file previously held, so the
+/// charge is the destroyed bytes plus the new payload, not the payload alone
+/// (which would make `write_text('')` free even against a huge file).
 fn write_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
-    check_write_limit(data.len(), ctx)?;
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    let result = host_write_text(ctx.mount_dir, target.for_dir_op(), data, path)?;
-    commit_write_bytes(data.len(), ctx);
+    let rel = target.for_dir_op();
+    let charged = existing_file_len(ctx.mount_dir, rel).saturating_add(data.len());
+    check_write_limit(charged, ctx)?;
+    let result = host_write_text(ctx.mount_dir, rel, data, path)?;
+    commit_write_bytes(charged, ctx);
     Ok(result)
 }
 
-/// Writes bytes after validating quota.
+/// Writes bytes after validating quota. See `write_text` for the truncation-accounting rationale.
 fn write_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
-    check_write_limit(data.len(), ctx)?;
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    let result = host_write_bytes(ctx.mount_dir, target.for_dir_op(), data, path)?;
-    commit_write_bytes(data.len(), ctx);
+    let rel = target.for_dir_op();
+    let charged = existing_file_len(ctx.mount_dir, rel).saturating_add(data.len());
+    check_write_limit(charged, ctx)?;
+    let result = host_write_bytes(ctx.mount_dir, rel, data, path)?;
+    commit_write_bytes(charged, ctx);
     Ok(result)
 }
 

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -2053,6 +2053,27 @@ fn rw_write_text_exceeds_limit() {
 }
 
 #[test]
+fn rw_write_text_charges_existing_file_size_on_truncate() {
+    // https://github.com/pydantic/monty/issues/788
+    // A truncating write must be charged for the file content it destroys,
+    // not just the new (possibly empty) payload -- otherwise `write_text("")`
+    // against a large existing file is free.
+    let dir = create_test_dir();
+    // hello.txt is pre-populated with "hello world\n" (12 bytes).
+    let mut mt = mount_at_mnt_with_limit(&dir, MountMode::ReadWrite, 5);
+
+    let exc = call_err(&mut mt, &write_text("/mnt/hello.txt", ""));
+    assert_exc(&exc, ExcType::OSError, "disk write limit of 5 bytes exceeded");
+
+    // The file must be untouched -- the quota check must happen before the
+    // truncating open, not after.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/hello.txt".into())),
+        MontyObject::String("hello world\n".to_owned())
+    );
+}
+
+#[test]
 fn rw_write_bytes_exceeds_limit() {
     let dir = create_test_dir();
     let mut mt = mount_at_mnt_with_limit(&dir, MountMode::ReadWrite, 5);


### PR DESCRIPTION
﻿Fixes #788.

A truncating write (open(path, "w"), Path.write_text(""), or any write_text/write_bytes call) is implemented in crates/monty-fs/src/direct.rs as a host write that opens with .truncate(true). The quota check and commit only ever accounted for the new payload length, not the file content the truncate discards.

So open(path, "w").close() charges 0 bytes and destroys the file's entire prior content, and write_text("hello") on a 1 MiB file charges 5 bytes for the same thing. Since the check passes trivially, this holds even after a mount's write budget is fully spent by other, non-truncating writes.

The fix stats the file before it is opened and charges the bytes the truncate would discard (plus any new payload), rejecting the write before it happens if that would exceed the mount's write_bytes_limit. This mirrors the existing convention in overlay.rs's append_bytes, which already charges existing_len + data.len() when materializing a backing file for the same reason.

Three call sites in direct.rs needed this: the open(path, "w") arm, write_text, and write_bytes. append_text/append_bytes are untouched -- they do not truncate, so payload-only accounting was already correct there.

Added a regression test (rw_write_text_charges_existing_file_size_on_truncate in crates/monty-fs/tests/fs.rs) against a pre-populated file from the test fixture, asserting both that the write is now rejected and that the file survives the rejection intact (the quota check runs before the truncating open, so a rejected write cannot partially destroy the file).

Verified:
- cargo test -p monty-fs: all 219 existing tests plus the new one pass.
- cargo clippy -p monty-fs --all-targets: clean on the changed files.
- Negative control: reverting only common.rs/direct.rs (keeping the new test) reproduces the bug exactly -- the test fails with "panicked at ...: expected Err: Int(0)", i.e. the old code returns Ok(0) instead of rejecting the write.
