### PR TITLE
Match CPython on both halves of a type's name

### DIFF
--- a/crates/monty-js/__test__/types.spec.ts
+++ b/crates/monty-js/__test__/types.spec.ts
@@ -382,9 +382,7 @@ test('time input round-trips', async () => {
 
 test('time input is a real sandbox time', async () => {
   const time = { __monty_type__: 'Time', hour: 10, minute: 20, second: 0, microsecond: 0 }
-  // `__name__` is the qualified spelling, as it is for `datetime` — see
-  // limitations/datetime.md
-  t.is(await run('type(x).__name__', { inputs: { x: time } }), 'datetime.time')
+  t.is(await run('type(x).__name__', { inputs: { x: time } }), 'time')
   t.is(await run('x.hour * 60 + x.minute', { inputs: { x: time } }), 620)
   t.is(await run('x.isoformat()', { inputs: { x: time } }), '10:20:00')
 })

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -120,11 +120,11 @@ results
     }
     assert monty_run(code, external_lookup=fns) == snapshot(
         [
-            ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5)'),
-            ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)'),
-            ('datetime.date', 'datetime.date(2021, 1, 2)'),
-            ('datetime.timedelta', 'datetime.timedelta(days=1, seconds=2)'),
-            ('datetime.timezone', 'datetime.timezone(datetime.timedelta(seconds=18000))'),
+            ('datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5)'),
+            ('datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)'),
+            ('date', 'datetime.date(2021, 1, 2)'),
+            ('timedelta', 'datetime.timedelta(days=1, seconds=2)'),
+            ('timezone', 'datetime.timezone(datetime.timedelta(seconds=18000))'),
             ('PosixPath', "PosixPath('/a/b')"),
         ]
     )

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -122,9 +122,9 @@ results
         [
             ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5)'),
             ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)'),
-            ('date', 'datetime.date(2021, 1, 2)'),
-            ('timedelta', 'datetime.timedelta(days=1, seconds=2)'),
-            ('timezone', 'datetime.timezone(datetime.timedelta(seconds=18000))'),
+            ('datetime.date', 'datetime.date(2021, 1, 2)'),
+            ('datetime.timedelta', 'datetime.timedelta(days=1, seconds=2)'),
+            ('datetime.timezone', 'datetime.timezone(datetime.timedelta(seconds=18000))'),
             ('PosixPath', "PosixPath('/a/b')"),
         ]
     )

--- a/crates/monty-types/src/object.rs
+++ b/crates/monty-types/src/object.rs
@@ -799,10 +799,16 @@ pub enum MontyType {
     Float,
     Range,
     Slice,
+    /// The four `datetime` classes carry the qualified names the runtime
+    /// `Type` uses (`datetime.date`, ...) rather than bare `date`, so a type
+    /// object keeps one name either side of the boundary.
+    #[strum(serialize = "datetime.date")]
     Date,
     #[strum(serialize = "datetime.datetime")]
     DateTime,
+    #[strum(serialize = "datetime.timedelta")]
     TimeDelta,
+    #[strum(serialize = "datetime.timezone")]
     TimeZone,
     Str,
     Bytes,

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -215,12 +215,12 @@ mod tests {
 
         assert_eq!(
             variant_order_fingerprint(Type::VARIANTS),
-            0x1df7_cdc5_e099_9f0e,
+            0x8329_9d5d_712d_8aef,
             "Type variants changed for dump version {DUMP_VERSION}"
         );
         assert_eq!(
             variant_order_fingerprint(MontyType::VARIANTS),
-            0x3033_7e3c_d7aa_541f,
+            0x2d60_6c6b_5b58_dcf2,
             "MontyType variants changed for dump version {DUMP_VERSION}"
         );
     }

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -63,8 +63,8 @@ pub enum Type {
     Slice,
     /// The four `datetime` classes are qualified like `collections.deque`:
     /// this is the `tp_name` CPython gives these C types, so it is the
-    /// spelling its reprs and type-naming error messages use. Only `__name__`
-    /// diverges — see `limitations/datetime.md`.
+    /// spelling its reprs and type-naming error messages use. `__name__`
+    /// reports the bare name, see `dunder_name`.
     #[strum(serialize = "datetime.date")]
     Date,
     #[strum(serialize = "datetime.datetime")]
@@ -185,8 +185,8 @@ pub enum Type {
     #[strum(serialize = "Field")]
     DataclassField,
     /// `collections.deque` — qualified like `datetime.datetime`/`re.Pattern` so
-    /// the name matches CPython's `repr` and error messages; only `__name__`
-    /// diverges from CPython's bare `'deque'`. See `limitations/collections.md`.
+    /// the name matches CPython's `repr` and error messages; `__name__` reports
+    /// the bare `'deque'`, see `dunder_name`.
     #[strum(serialize = "collections.deque")]
     Deque,
     /// `iter(deque(...))` — CPython's `_collections._deque_iterator`.

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -61,10 +61,17 @@ pub enum Type {
     Float,
     Range,
     Slice,
+    /// The four `datetime` classes are qualified like `collections.deque`:
+    /// this is the `tp_name` CPython gives these C types, so it is the
+    /// spelling its reprs and type-naming error messages use. Only `__name__`
+    /// diverges — see `limitations/datetime.md`.
+    #[strum(serialize = "datetime.date")]
     Date,
     #[strum(serialize = "datetime.datetime")]
     DateTime,
+    #[strum(serialize = "datetime.timedelta")]
     TimeDelta,
+    #[strum(serialize = "datetime.timezone")]
     TimeZone,
     Str,
     Bytes,

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -268,6 +268,19 @@ impl Type {
         }
     }
 
+    /// The name CPython's `__name__` reports: [`name`](Self::name) with any
+    /// module qualifier stripped (`datetime.date` → `date`). CPython keeps one
+    /// dotted `tp_name` per C type and derives the bare `__name__` from it, so
+    /// reprs and error messages qualify where `__name__` does not. Sandbox
+    /// class names ([`Instance`](Self::Instance)) are identifiers, so
+    /// stripping is a no-op for them.
+    pub(crate) fn dunder_name<'i>(self, heap: &Heap, interns: &'i Interns) -> Cow<'i, str> {
+        match self.name(heap, interns) {
+            Cow::Borrowed(name) => Cow::Borrowed(name.rsplit_once('.').map_or(name, |(_, bare)| bare)),
+            owned @ Cow::Owned(_) => owned,
+        }
+    }
+
     /// [`name`](Self::name) as rendered by CPython's `_PyArg_BadArgument`
     /// ("argument N must be X, not Y") error formatter: identical except that
     /// `NoneType` renders as `"None"` — CPython special-cases

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1741,7 +1741,10 @@ impl Value {
                     |ss| ss == StaticStrings::DunderName,
                 );
                 if is_dunder_name {
-                    return Ok(CallResult::Value(allocate_string(t.name(vm.heap, vm.interns), vm.heap)));
+                    return Ok(CallResult::Value(allocate_string(
+                        t.dunder_name(vm.heap, vm.interns),
+                        vm.heap,
+                    )));
                 }
                 if *t == Type::TimeZone && attr.as_str(vm.interns) == "utc" {
                     return Ok(CallResult::Value(vm.heap.get_timezone_utc()));

--- a/crates/monty/test_cases/attr__class_object_errors.py
+++ b/crates/monty/test_cases/attr__class_object_errors.py
@@ -13,8 +13,11 @@ _classes = [
     (frozenset, 'frozenset'),
     (bytes, 'bytes'),
     (range, 'range'),
+    (datetime.date, 'datetime.date'),
     (datetime.datetime, 'datetime.datetime'),
     (datetime.time, 'datetime.time'),
+    (datetime.timedelta, 'datetime.timedelta'),
+    (datetime.timezone, 'datetime.timezone'),
 ]
 
 # === attribute access ===

--- a/crates/monty/test_cases/attr__class_object_errors.py
+++ b/crates/monty/test_cases/attr__class_object_errors.py
@@ -49,6 +49,12 @@ try:
 except AttributeError as e:
     assert str(e) == "'datetime.time' object has no attribute 'nonexistent'"
 
+# === the error names the dotted `tp_name`; `__name__` stays bare ===
+assert datetime.date.__name__ == 'date'
+assert datetime.time.__name__ == 'time'
+assert datetime.timedelta.__name__ == 'timedelta'
+assert int.__name__ == 'int'
+
 # === a known class method is unaffected ===
 assert dict.fromkeys(['a'], 1) == {'a': 1}
 assert bytes.fromhex('ff') == b'\xff'

--- a/crates/monty/test_cases/collections__deque.py
+++ b/crates/monty/test_cases/collections__deque.py
@@ -6,11 +6,14 @@
 # NOT tested here, and why:
 # - `del d[i]`: CPython supports it, but the `del` statement is unimplemented
 #   Monty-wide (a parse error), so including it would fail to parse the file.
-# - `type(d).__name__`: CPython gives the bare 'deque'; Monty gives the qualified
-#   'collections.deque' for all module-scoped types. Pre-existing repo-wide
-#   divergence, see limitations/collections.md.
 
 from collections import deque
+
+# === Type name ===
+# The dotted `tp_name` shows in reprs and error messages, the bare one in
+# `__name__`, as CPython does it.
+assert str(type(deque())) == "<class 'collections.deque'>"
+assert type(deque()).__name__ == 'deque'
 
 # === Construction ===
 assert list(deque()) == [], 'empty deque'

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -1242,6 +1242,29 @@ except TypeError as e:
     assert str(e) == "argument for function given by name ('month') and position (2)", f'dt dup month: {e}'
 
 
+# === type names carry the `datetime.` prefix, as CPython's tp_name does ===
+
+assert repr(datetime.date) == "<class 'datetime.date'>"
+assert repr(datetime.datetime) == "<class 'datetime.datetime'>"
+assert repr(datetime.time) == "<class 'datetime.time'>"
+assert repr(datetime.timedelta) == "<class 'datetime.timedelta'>"
+assert repr(datetime.timezone) == "<class 'datetime.timezone'>"
+
+_values = [
+    (datetime.date(2024, 1, 1), 'datetime.date'),
+    (datetime.datetime(2024, 1, 1), 'datetime.datetime'),
+    (datetime.time(1, 2), 'datetime.time'),
+    (datetime.timedelta(days=1), 'datetime.timedelta'),
+    (datetime.timezone.utc, 'datetime.timezone'),
+]
+for _value, _name in _values:
+    try:
+        _value + 1
+        assert False, 'expected TypeError'
+    except TypeError as e:
+        assert str(e) == f"unsupported operand type(s) for +: '{_name}' and 'int'", f'operand type name: {e}'
+
+
 # === GC must follow datetime.tzinfo_ref ===
 # Regression: aware datetimes retain the tzinfo as a private heap reference,
 # so the GC mark phase must follow it. Without that, a cycle-triggered

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -1242,13 +1242,19 @@ except TypeError as e:
     assert str(e) == "argument for function given by name ('month') and position (2)", f'dt dup month: {e}'
 
 
-# === type names carry the `datetime.` prefix, as CPython's tp_name does ===
+# === reprs and error messages carry the `datetime.` prefix, `__name__` does not ===
 
 assert repr(datetime.date) == "<class 'datetime.date'>"
 assert repr(datetime.datetime) == "<class 'datetime.datetime'>"
 assert repr(datetime.time) == "<class 'datetime.time'>"
 assert repr(datetime.timedelta) == "<class 'datetime.timedelta'>"
 assert repr(datetime.timezone) == "<class 'datetime.timezone'>"
+
+assert datetime.date.__name__ == 'date'
+assert datetime.datetime.__name__ == 'datetime'
+assert datetime.time.__name__ == 'time'
+assert datetime.timedelta.__name__ == 'timedelta'
+assert datetime.timezone.__name__ == 'timezone'
 
 _values = [
     (datetime.date(2024, 1, 1), 'datetime.date'),

--- a/crates/monty/test_cases/itertools__adaptors.py
+++ b/crates/monty/test_cases/itertools__adaptors.py
@@ -33,9 +33,10 @@ assert list(spent) == []
 p = itertools.pairwise([1, 2])
 assert iter(p) is p
 
-# `str(type(...))` matches CPython; `__name__` is the dotted form Monty uses
-# for every dotted `tp_name` (see limitations/itertools.md).
+# The dotted `tp_name` shows in `str(type(...))`, the bare one in `__name__`,
+# as CPython does it.
 assert str(type(itertools.pairwise([]))) == "<class 'itertools.pairwise'>"
+assert type(itertools.pairwise([])).__name__ == 'pairwise'
 pairwise_repr = itertools.pairwise([])
 pairwise_repr_text = repr(pairwise_repr)
 assert pairwise_repr_text.startswith('<itertools.pairwise object at 0x')

--- a/crates/monty/test_cases/open__fs.py
+++ b/crates/monty/test_cases/open__fs.py
@@ -231,11 +231,8 @@ try:
 except OSError as exc:
     assert str(exc) == 'not writable', f'unexpected not-writable message: {exc}'
     # Mode-violation errors must surface as io.UnsupportedOperation, not bare
-    # OSError. CPython exposes the class as `io.UnsupportedOperation` whose
-    # `__name__` is the bare `UnsupportedOperation`; Monty uses the qualified
-    # `io.UnsupportedOperation` as its single type identifier.
-    expected_name = 'io.UnsupportedOperation' if is_monty else 'UnsupportedOperation'
-    assert type(exc).__name__ == expected_name, f'expected {expected_name}, got {type(exc).__name__}'
+    # OSError.
+    assert type(exc).__name__ == 'UnsupportedOperation', f'unexpected type name: {type(exc).__name__}'
 
 try:
     open(root / 'hello.txt', 'rb').write(b'x')

--- a/limitations/base64.md
+++ b/limitations/base64.md
@@ -28,7 +28,3 @@ docs describe is always `bytes` here.
 `b2a_hex`/`a2b_hex` aliases), the base64 pair (`b2a_base64`/`a2b_base64`) and
 `crc32` are implemented. The uuencode and quoted-printable conversions
 (`a2b_uu`, `b2a_uu`, `a2b_qp`, `b2a_qp`) are absent and raise `AttributeError`.
-
-`type(exc).__name__` reports the qualified name `binascii.Error` where CPython
-reports the bare `Error` — Monty's general treatment of types whose CPython
-`tp_name` is dotted, described in [itertools.md](itertools.md).

--- a/limitations/collections.md
+++ b/limitations/collections.md
@@ -82,21 +82,13 @@ divergences. `repr(Point)` is `<class 'Point'>` where CPython gives
 
 ## Qualified vs bare type names
 
-Monty stores one name per type; CPython picks a qualified (`collections.deque`)
-or bare (`deque`) name *per surface*, depending on whether the type is written
-in C or in Python, so no single name matches everywhere. Each type takes the
-spelling CPython uses in the most places:
+`deque` and `defaultdict` are C types, so CPython qualifies them
+(`collections.deque`) in `repr(T)` and in every type-naming error message
+(`unsupported operand type(s)`, `object is not callable`, `object has no
+attribute`) while `__name__` stays bare (`'deque'`); Monty matches both
+surfaces.
 
-| type | Monty's name | what diverges |
-|---|---|---|
-| `deque` | `collections.deque` | only `__name__` (CPython: `'deque'`) |
-| `defaultdict` | `collections.defaultdict` | only `__name__` (CPython: `'defaultdict'`) |
-| `Counter` | `Counter` | only `repr(Counter)` and the `cannot use ...` clause of the unhashable message |
-
-`deque`/`defaultdict` are C types, so CPython qualifies them in `repr(T)` and in
-every type-naming error message (`unsupported operand type(s)`, `object is not
-callable`, `object has no attribute`); Monty matches all of those and pays only
-on `__name__`. `Counter` is a Python-level class, so those messages give the
-bare name, which Monty matches. Code that matches on a type name (parsing an
-error message or comparing `__name__`) may need to accept either spelling, as
-with `datetime.datetime`, `re.Pattern`, and `_io.TextIOWrapper`.
+`Counter` is a Python-level class, so CPython gives the bare name everywhere
+except `repr(Counter)`, which is `<class 'collections.Counter'>` where Monty
+writes `<class 'Counter'>`. Everywhere else — `__name__`, the `cannot use ...`
+unhashable clause, other type-naming errors — the bare name matches.

--- a/limitations/datetime.md
+++ b/limitations/datetime.md
@@ -108,14 +108,6 @@ a named zone against — CPython's own `t.utcoffset()` returns `None` there —
 so there is no offset to carry. An aware `datetime` is not affected: it has a
 date, and its zone resolves through `utcoffset(dt)`.
 
-## Type names
-
-`type(t).__name__` is `'datetime.time'`, where CPython gives `'time'`. Monty
-stores one name per type and uses the qualified spelling for `time`, so it
-matches CPython in `repr(datetime.time)` and in every type-naming error
-message and pays only on `__name__`. `datetime` diverges the same way
-(`'datetime.datetime'`); `date` and `timedelta` do not.
-
 ## `timedelta`
 
 Constructor: `timedelta(days=0, seconds=0, microseconds=0, *,
@@ -148,6 +140,19 @@ Monty, but the type error in CPython (`timezone() argument 1 must be
 datetime.timedelta, not str`). CPython's parser type-checks `offset` while
 binding, whereas Monty validates the `timedelta` in the constructor body
 after binding completes.
+
+## Type names
+
+All five classes are named with their `datetime.` prefix — `datetime.date`,
+`datetime.datetime`, `datetime.time`, `datetime.timedelta`,
+`datetime.timezone` — which is the `tp_name` CPython gives these C types and so
+the spelling its `repr(T)` and every type-naming error message use
+(`unsupported operand type(s)`, `object is not callable`, `type object ... has
+no attribute`). Monty matches all of those and pays only on `__name__`, where
+CPython reports the bare `'date'`, `'datetime'`, `'time'`, `'timedelta'`,
+`'timezone'`. This is the same trade `deque` and `defaultdict` make (see
+./collections.md); code that compares `__name__` or parses a type name out of
+an error message may need to accept either spelling.
 
 ## Formatting
 

--- a/limitations/datetime.md
+++ b/limitations/datetime.md
@@ -141,19 +141,6 @@ datetime.timedelta, not str`). CPython's parser type-checks `offset` while
 binding, whereas Monty validates the `timedelta` in the constructor body
 after binding completes.
 
-## Type names
-
-All five classes are named with their `datetime.` prefix — `datetime.date`,
-`datetime.datetime`, `datetime.time`, `datetime.timedelta`,
-`datetime.timezone` — which is the `tp_name` CPython gives these C types and so
-the spelling its `repr(T)` and every type-naming error message use
-(`unsupported operand type(s)`, `object is not callable`, `type object ... has
-no attribute`). Monty matches all of those and pays only on `__name__`, where
-CPython reports the bare `'date'`, `'datetime'`, `'time'`, `'timedelta'`,
-`'timezone'`. This is the same trade `deque` and `defaultdict` make (see
-./collections.md); code that compares `__name__` or parses a type name out of
-an error message may need to accept either spelling.
-
 ## Formatting
 
 `strftime` supports the directives that map onto Rust's `chrono`

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -82,9 +82,9 @@ no warnings machinery.
 `list.nonexistent` raises `AttributeError: type object 'list' has no attribute
 'nonexistent'`, naming the class rather than the metaclass, and calling it
 (`list.nonexistent()`) reports the same message. Both use Monty's name for the
-class, which differs from CPython's for four of them: `date`, `timedelta`
-and `timezone` are reported without their `datetime.` prefix, and
-`pathlib.Path` reports `PosixPath` (see ./pathlib.md).
+class, which differs from CPython's for one builtin: `pathlib.Path` reports
+`PosixPath`, because Monty has a single type where CPython has the `Path`
+class and its `PosixPath` instances (see ./pathlib.md).
 
 ## Traceback behaviour
 

--- a/limitations/itertools.md
+++ b/limitations/itertools.md
@@ -34,11 +34,6 @@ raise `AttributeError` at runtime.
   number of remaining yields through it (`repeat(9, 3).__length_hint__() == 3`).
   Monty uses the remaining count internally to size the target of `list()` /
   `tuple()`, but does not expose it as a Python-visible attribute.
-- **`type(...).__name__` is the dotted name.** `type(itertools.count()).__name__`
-  is `'itertools.count'`, where CPython reports the bare `'count'`. This is
-  Monty's general treatment of types whose CPython `tp_name` is dotted (`re.Pattern`
-  behaves the same way); `str(type(itertools.count()))` matches CPython's
-  `"<class 'itertools.count'>"`, as do error messages naming the type.
 - **`count` and `repeat` objects are unhashable.** `hash(itertools.count())`
   raises `TypeError: unhashable type: 'itertools.count'`, where CPython falls
   back to identity hashing. This applies to Monty's iterators generally, not

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -172,8 +172,7 @@ protocol (`__iter__`/`__next__`, including `for line in f:`).
 - `io.UnsupportedOperation` (raised by `read()` on `'w'` files, `write()`
   on `'r'` files, etc.) inherits from both `OSError` and `ValueError` for
   catch purposes, so `except OSError:` and `except ValueError:` both work as
-  in CPython. Monty's class name is the qualified `io.UnsupportedOperation`
-  whereas CPython's `__name__` is the bare `UnsupportedOperation`.
+  in CPython.
 - No host file descriptor is held between calls (see "Design note: no
   live host file descriptors" above). The user-visible consequence is
   that external processes can observe partial state between writes, and

--- a/limitations/pathlib.md
+++ b/limitations/pathlib.md
@@ -6,6 +6,12 @@ even when the host is Windows. `PurePath`, `PurePosixPath`, `PureWindowsPath`,
 `PosixPath`, `WindowsPath` are not separately exposed; the printed `repr`
 of a `Path` is `PosixPath(...)` for compatibility.
 
+Because the class object and its instances share one type, the class object
+answers to the instance name: `pathlib.Path.__name__` and `repr(pathlib.Path)`
+give `PosixPath` / `<class 'PosixPath'>`, and `pathlib.Path.nonexistent` raises
+`type object 'PosixPath' has no attribute 'nonexistent'`, where CPython names
+`Path` (the instance-level spellings, e.g. `Path('/a') / 1`, match CPython).
+
 ## Construction
 
 `Path(*segments)` works. Each segment may be a `str` or another `Path`.


### PR DESCRIPTION
Monty stored one name per type and so had to pick between the two spellings CPython uses; now both match, with reprs and error messages using the qualified name (`<class 'datetime.date'>`) and `__name__` staying bare (`'date'`).

## Now working

| | before | now (= CPython) |
|---|---|---|
| `repr(datetime.date)` | `<class 'date'>` | `<class 'datetime.date'>` |
| `date(2020, 1, 1) + 1` | `unsupported operand type(s) for +: 'date' and 'int'` | `unsupported operand type(s) for +: 'datetime.date' and 'int'` |
| `collections.deque.__name__` | `'collections.deque'` | `'deque'` |
| `type(itertools.count()).__name__` | `'itertools.count'` | `'count'` |

## Continues working

The two halves are set independently, so fixing either one does not disturb the other.

| | before and now (= CPython) |
|---|---|
| `datetime.date.__name__` | `'date'` |
| `repr(collections.deque)` | `<class 'collections.deque'>` |
| `str(type(itertools.count()))` | `<class 'itertools.count'>` |
| `deque().nonexistent` | `'collections.deque' object has no attribute 'nonexistent'` |
| `int.__name__`, `Foo.__name__` | `'int'`, `'Foo'` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MS2SKMv3kPuKfGNTKcZef4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Type objects now keep both halves of a type's name: the qualified name (`datetime.date`) for reprs and type-naming errors, and the bare name (`'date'`) for `__name__`, matching CPython.

- `date`, `timedelta`, and `timezone` gain the `datetime.` prefix in reprs, operand errors, and attribute errors; `datetime.datetime` and `datetime.time` were already qualified.
- `__name__` strips the module qualifier for all module-qualified types: `collections.deque`, `defaultdict`, the `itertools` adaptors, `re` and `_io` types, `binascii.Error`, `json.JSONDecodeError`, and the five `datetime` classes.
- Code comparing `__name__` or parsing type-naming error text may see the other spelling on the changed surfaces.
- `pathlib.Path` still reports `PosixPath` on its class-object surfaces, because one Monty type stands in for both `Path` and `PosixPath`.
- The dump encoding is unchanged — variant indices, not names — so existing dumps decode without a migration.

<sup>Written for commit df4c9b68e0db700ff7a8349842b75978c03ad59c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

