### PR TITLE
Argument and attribute handling on builtin methods

### DIFF
--- a/crates/monty/src/args/mod.rs
+++ b/crates/monty/src/args/mod.rs
@@ -46,10 +46,26 @@ impl ArgValues {
         match self {
             Self::Empty => Ok(()),
             other => {
+                // CPython checks keywords first and reports them separately, so a
+                // stray kwarg is never described as `(0 given)`.
+                let has_kwargs = other.has_kwargs();
                 let count = other.count();
                 other.drop_with(heap);
-                Err(ExcType::type_error_no_args(name, count))
+                if has_kwargs {
+                    Err(ExcType::type_error_no_kwargs(name))
+                } else {
+                    Err(ExcType::type_error_no_args(name, count))
+                }
             }
+        }
+    }
+
+    /// Whether any keyword argument was passed.
+    #[must_use]
+    fn has_kwargs(&self) -> bool {
+        match self {
+            Self::Empty | Self::One(_) | Self::Two(_, _) => false,
+            Self::Kwargs(kwargs) | Self::ArgsKargs { kwargs, .. } => !kwargs.is_empty(),
         }
     }
 

--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -38,7 +38,7 @@ pub fn builtin_getattr(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         too_many => return Err(ExcType::type_error_at_most("getattr", 3, too_many.len())),
     };
 
-    let Some(attr) = name.as_either_str(vm.heap) else {
+    let Some(attr) = name.as_either_str(vm.heap).map(|s| s.resolve_interned(vm.interns)) else {
         let ty = name.py_type_name(vm);
         return Err(
             SimpleException::new_msg(ExcType::TypeError, format!("attribute name must be string, not '{ty}'")).into(),

--- a/crates/monty/src/builtins/hasattr.rs
+++ b/crates/monty/src/builtins/hasattr.rs
@@ -36,7 +36,7 @@ pub fn builtin_hasattr(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         other => return Err(ExcType::type_error_arg_count("hasattr", 2, other.len())),
     };
 
-    let Some(name) = name.as_either_str(vm.heap) else {
+    let Some(name) = name.as_either_str(vm.heap).map(|s| s.resolve_interned(vm.interns)) else {
         return Err(SimpleException::new_msg(
             ExcType::TypeError,
             format!("attribute name must be string, not '{}'", name.py_type_name(vm)),

--- a/crates/monty/src/builtins/setattr.rs
+++ b/crates/monty/src/builtins/setattr.rs
@@ -29,7 +29,7 @@ pub fn builtin_setattr(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         other => return Err(ExcType::type_error_arg_count("setattr", 3, other.len())),
     };
 
-    let Some(name) = name.as_either_str(vm.heap) else {
+    let Some(name) = name.as_either_str(vm.heap).map(|s| s.resolve_interned(vm.interns)) else {
         return Err(SimpleException::new_msg(
             ExcType::TypeError,
             format!("attribute name must be string, not '{}'", name.py_type_name(vm)),

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -11,7 +11,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     fstring::{FormatError, ascii_escape},
-    heap::{HeapData, HeapRead},
+    heap::{DropWithContext, HeapData, HeapRead},
     intern::{Interns, StaticStrings, StringId},
     parse::CodeRange,
     source_map::{SourceMap, StackFrameExt},
@@ -53,6 +53,19 @@ pub(crate) trait ExcTypeExt: Sized {
             frame: None,
             hide_caret: true, // CPython doesn't show carets for attribute GET errors
         })
+    }
+
+    /// Creates an AttributeError for an unknown *method*, releasing the
+    /// arguments the call has already evaluated.
+    ///
+    /// Prefer this over [`attribute_error`](Self::attribute_error) anywhere the
+    /// arguments are already owned: that one releases nothing, so calling it from
+    /// a `py_call_attr` fall-through leaks a reference per call — something
+    /// sandboxed code can repeat in a loop.
+    #[must_use]
+    fn attribute_error_method(type_name: impl Display, attr: &EitherStr, args: ArgValues, vm: &mut VM<'_>) -> RunError {
+        args.drop_with(vm);
+        Self::attribute_error(type_name, attr.as_str(vm.interns))
     }
 
     /// Creates an AttributeError for a missing attribute on a class object.
@@ -1117,7 +1130,10 @@ pub(crate) trait ExcTypeExt: Sized {
 
     /// Creates a TypeError for functions that don't accept keyword arguments.
     ///
-    /// Matches CPython's format: `TypeError: {name}() takes no keyword arguments`
+    /// Matches CPython's `PyArg_NoKeywords` format: `TypeError: {name}() takes
+    /// no keyword arguments`. CPython checks keywords before the positional
+    /// count, so a no-argument method given only a kwarg reports this rather
+    /// than `(0 given)`.
     #[must_use]
     fn type_error_no_kwargs(name: &str) -> RunError {
         SimpleException::new_msg(ExcType::TypeError, format!("{name}() takes no keyword arguments")).into()

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -287,7 +287,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Date> {
                     date.0.weekday().number_from_monday(),
                 ))))
             }
-            _ => Err(ExcType::attribute_error(Type::Date, attr.as_str(vm.interns))),
+            _ => Err(ExcType::attribute_error_method(Type::Date, attr, args, vm)),
         }
     }
 

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -880,7 +880,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DateTime> {
                 let ts = compute_timestamp(&dt);
                 Ok(CallResult::Value(Value::Float(ts)))
             }
-            _ => Err(ExcType::attribute_error(Type::DateTime, attr.as_str(vm.interns))),
+            _ => Err(ExcType::attribute_error_method(Type::DateTime, attr, args, vm)),
         }
     }
 

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -253,7 +253,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictKeysView> {
                 defer_drop!(other, vm);
                 Ok(CallResult::Value(Value::Bool(self.isdisjoint_from_value(other, vm)?)))
             }
-            _ => Err(ExcType::attribute_error(Type::DictKeys, attr.as_str(vm.interns))),
+            _ => Err(ExcType::attribute_error_method(Type::DictKeys, attr, args, vm)),
         }
     }
 }
@@ -529,7 +529,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictItemsView> {
                 defer_drop!(other, vm);
                 Ok(CallResult::Value(Value::Bool(self.isdisjoint_from_value(other, vm)?)))
             }
-            _ => Err(ExcType::attribute_error(Type::DictItems, attr.as_str(vm.interns))),
+            _ => Err(ExcType::attribute_error_method(Type::DictItems, attr, args, vm)),
         }
     }
 }

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -374,9 +374,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ReMatch> {
                 let n = extract_optional_group_arg(args, "re.Match.span", 0, vm.heap)?;
                 self.get(vm.heap).get_span(n, vm)?
             }
-            _ => {
-                return Err(ExcType::attribute_error(Type::ReMatch, attr.as_str(vm.interns)));
-            }
+            _ => return Err(ExcType::attribute_error_method(Type::ReMatch, attr, args, vm)),
         };
         Ok(CallResult::Value(result))
     }

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -448,9 +448,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, RePattern> {
                 let text = arg.to_str(vm)?;
                 self.get(vm.heap).finditer(arg, text, vm.heap)
             }
-            _ => {
-                return Err(ExcType::attribute_error(Type::RePattern, attr.as_str(vm.interns)));
-            }
+            _ => return Err(ExcType::attribute_error_method(Type::RePattern, attr, args, vm)),
         }?;
         Ok(CallResult::Value(result))
     }

--- a/crates/monty/src/types/time.rs
+++ b/crates/monty/src/types/time.rs
@@ -26,7 +26,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
-    heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput, HeapReader},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput, HeapReader},
     intern::StaticStrings,
     types::{
         CmpOrder, LazyHeapSet, PyTrait, TimeZone, Type,
@@ -572,12 +572,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Time> {
                 // Only fixed-offset zones exist, and none of them observes DST.
                 Ok(CallResult::Value(Value::None))
             }
-            _ => {
-                // The arguments were already evaluated and are owned by us, so an
-                // unknown attribute must still release them.
-                args.drop_with(vm);
-                Err(ExcType::attribute_error(Type::Time, attr.as_str(vm.interns)))
-            }
+            _ => Err(ExcType::attribute_error_method(Type::Time, attr, args, vm)),
         }
     }
 

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -460,7 +460,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeDelta> {
             args.check_zero_args("timedelta.total_seconds", vm.heap)?;
             return Ok(CallResult::Value(Value::Float(total_seconds(&td))));
         }
-        Err(ExcType::attribute_error(Type::TimeDelta, attr.as_str(vm.interns)))
+        Err(ExcType::attribute_error_method(Type::TimeDelta, attr, args, vm))
     }
 
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h>) -> RunResult<Option<CallResult>> {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -2372,6 +2372,25 @@ impl EitherStr {
         }
     }
 
+    /// Re-resolves a heap string to its interned id when the interner already
+    /// knows the text.
+    ///
+    /// Builtin attribute dispatch matches on `StringId`, so a name computed at
+    /// runtime (`getattr(x, 'up' + 'per')`) arrives as [`Heap`](Self::Heap) and
+    /// misses every builtin attribute — while still resolving on instances and
+    /// modules, which compare by text. Interning is a lookup, never an insert,
+    /// so sandboxed code cannot grow the interner by guessing names.
+    #[must_use]
+    pub fn resolve_interned(self, interns: &Interns) -> Self {
+        match self {
+            Self::Heap(s) => match interns.get_string_id_by_name(&s) {
+                Some(id) => Self::Interned(id),
+                None => Self::Heap(s),
+            },
+            already @ Self::Interned(_) => already,
+        }
+    }
+
     /// Checks whether this keyword matches the given interned identifier.
     pub fn matches(&self, target: StringId, interns: &Interns) -> bool {
         match self {

--- a/crates/monty/test_cases/args__macro_errors.py
+++ b/crates/monty/test_cases/args__macro_errors.py
@@ -834,3 +834,24 @@ try:
     assert False, 'crc32() with a keyword should raise'
 except TypeError as e:
     assert str(e) == 'binascii.crc32() takes no keyword arguments'
+
+# === check_zero_args: keywords are reported before the positional count ===
+# CPython's `PyArg_NoKeywords` runs first, so a lone keyword never reports
+# `(0 given)`, and a keyword alongside positionals still wins.
+try:
+    datetime.date(2020, 1, 1).isoformat(timespec='minutes')
+    assert False, 'isoformat(timespec=) should raise'
+except TypeError as e:
+    assert str(e) == 'date.isoformat() takes no keyword arguments'
+
+try:
+    datetime.date(2020, 1, 1).isoformat(1, bogus=2)
+    assert False, 'isoformat(1, bogus=) should raise'
+except TypeError as e:
+    assert str(e) == 'date.isoformat() takes no keyword arguments'
+
+try:
+    datetime.date(2020, 1, 1).isoformat(1)
+    assert False, 'isoformat(1) should raise'
+except TypeError as e:
+    assert str(e) == 'date.isoformat() takes no arguments (1 given)'

--- a/crates/monty/test_cases/builtin__getattr.py
+++ b/crates/monty/test_cases/builtin__getattr.py
@@ -82,3 +82,15 @@ except TypeError as e:
     attr_name = 'ar' + 'gs'
     args = getattr(e, attr_name)
     assert args == ('dynamic test',)
+
+# === Dynamic names on builtin types ===
+# Builtin attributes dispatch on interned string ids, so a name built at
+# runtime has to be resolved back through the interner before dispatch.
+import datetime
+
+assert getattr(datetime.timezone, 'ut' + 'c') is datetime.timezone.utc
+assert getattr(datetime.time(12, 30), 'ho' + 'ur') == 12
+assert getattr(datetime.date(2024, 6, 15), 'mon' + 'th') == 6
+assert getattr(datetime.timedelta(hours=1), 'sec' + 'onds') == 3600
+# a name the interner has never seen still misses, rather than erroring oddly
+assert getattr(datetime.date(2024, 6, 15), 'no' + 'pe', 'MISSING') == 'MISSING'

--- a/crates/monty/test_cases/builtin__hasattr.py
+++ b/crates/monty/test_cases/builtin__hasattr.py
@@ -48,3 +48,11 @@ try:
     assert False, 'hasattr() with None name should raise TypeError'
 except TypeError as e:
     assert str(e) == "attribute name must be string, not 'NoneType'", str(e)
+
+# === Dynamic names on builtin types ===
+# Same interner round-trip as `getattr`: a runtime-built name must resolve.
+import datetime
+
+assert hasattr(datetime.timezone, 'ut' + 'c')
+assert hasattr(datetime.time(12, 30), 'ho' + 'ur')
+assert not hasattr(datetime.time(12, 30), 'no' + 'pe')

--- a/crates/monty/test_cases/refcount__unknown_method_args.py
+++ b/crates/monty/test_cases/refcount__unknown_method_args.py
@@ -1,14 +1,35 @@
 # Calling an unknown method still owns the arguments the call evaluated, so the
 # AttributeError path has to release them. Regression test: sandboxed code could
 # otherwise leak a reference per call in a loop.
-from datetime import time
+import re
+from datetime import date, datetime, time, timedelta
 
 lst = [1, 2, 3]
 
+
+def call_bogus():
+    # One object per `py_call_attr` implementation that can reach an unknown
+    # attribute; each must hand `lst` back before raising.
+    mapping = {'k': 'v'}
+    pattern = re.compile('a')
+    for obj in [
+        time(1),
+        datetime(2020, 1, 1),
+        date(2020, 1, 1),
+        timedelta(hours=1),
+        pattern,
+        pattern.match('a'),
+        mapping.keys(),
+        mapping.items(),
+    ]:
+        try:
+            obj.bogus(lst)
+            assert False, 'expected AttributeError'
+        except AttributeError:
+            pass
+    return len(lst)
+
+
 for _ in range(3):
-    try:
-        time(1).bogus(lst)
-        assert False, 'expected AttributeError'
-    except AttributeError:
-        pass
-# ref-counts={'lst': 1}
+    assert call_bogus() == 3
+# ref-counts={'lst': 1, 're': 1}


### PR DESCRIPTION
Three fixes to the shared path that dispatches an attribute or method on a builtin type. None is specific to `datetime` — those types appear here only as call sites.

### 1. Release call arguments on every unknown-method error

`py_call_attr` owns its `ArgValues`, but eight builtin types dropped them as a plain Rust value, leaking a reference per call. The drop moves into `ExcType::attribute_error_method`, where it cannot be forgotten.

### 2. Report keyword arguments to a no-argument method as such

`check_zero_args` counted only positionals, so `date.isoformat(timespec='x')` claimed `takes no arguments (0 given)`. CPython runs `PyArg_NoKeywords` first. This is the shared binder, so it covers every zero-argument builtin method.

### 3. Resolve runtime-built attribute names against the interner

`getattr(x, 'ut' + 'c')` arrives as a heap string, and builtin types match on interned ids, so every builtin attribute missed. `EitherStr::resolve_interned` re-resolves through `get_string_id_by_name` — a lookup, never an insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three bugs in the shared path that dispatches attributes and methods on builtin types. Unknown methods now release their evaluated arguments before raising AttributeError (previously leaked a reference per call), zero-argument methods report "takes no keyword arguments" when keywords are passed (previously reported "takes no arguments (0 given)"), and `getattr`/`hasattr`/`setattr` now resolve runtime-built attribute names through the interner so builtin attributes match (previously missed all builtin attributes).

<sup>Written for commit 82ad3d42bd2c0b7c8f94124058dd5a7752a86398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

