### PR TITLE
Build musl npm packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1070,14 +1070,14 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             triple: linux-x64-musl
-            musl: true
+            cross-compile: true
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             triple: linux-arm64-gnu
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             triple: linux-arm64-musl
-            musl: true
+            native-musl: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1090,14 +1090,19 @@ jobs:
           targets: ${{ matrix.settings.target }}
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        if: matrix.settings.musl
+        if: matrix.settings.cross-compile
         with:
           version: 0.15.2
+          use-cache: false
 
       - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
-        if: matrix.settings.musl
+        if: matrix.settings.cross-compile
         with:
           tool: cargo-zigbuild
+
+      - name: Install the native musl linker
+        if: matrix.settings.native-musl
+        run: sudo apt-get update && sudo apt-get install --yes musl-tools
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -1116,8 +1121,10 @@ jobs:
         working-directory: crates/monty-js
 
       - name: Build the napi shared library
-        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.musl && '--cross-compile' || '' }}
+        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.cross-compile && '--cross-compile' || '' }}
         working-directory: crates/monty-js
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.settings.native-musl && 'musl-gcc' || '' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1077,7 +1077,7 @@ jobs:
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             triple: linux-arm64-musl
-            use-cross: true
+            cross-compile: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1098,12 +1098,7 @@ jobs:
       - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
         if: matrix.settings.cross-compile
         with:
-          tool: cargo-zigbuild
-
-      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
-        if: matrix.settings.use-cross
-        with:
-          tool: cross
+          tool: cargo-zigbuild@0.23.3
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -1122,7 +1117,7 @@ jobs:
         working-directory: crates/monty-js
 
       - name: Build the napi shared library
-        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.cross-compile && '--cross-compile' || matrix.settings.use-cross && '--use-cross' || '' }}
+        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.cross-compile && '--cross-compile' || '' }}
         working-directory: crates/monty-js
 
       - name: Upload artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1125,6 +1125,7 @@ jobs:
         working-directory: crates/monty-js
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.settings.native-musl && 'musl-gcc' || '' }}
+          RUSTFLAGS: ${{ matrix.settings.native-musl && '-C link-arg=-static-libgcc' || '' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1077,7 +1077,7 @@ jobs:
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             triple: linux-arm64-musl
-            native-musl: true
+            use-cross: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1100,9 +1100,10 @@ jobs:
         with:
           tool: cargo-zigbuild
 
-      - name: Install the native musl linker
-        if: matrix.settings.native-musl
-        run: sudo apt-get update && sudo apt-get install --yes musl-tools
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
+        if: matrix.settings.use-cross
+        with:
+          tool: cross
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -1121,11 +1122,8 @@ jobs:
         working-directory: crates/monty-js
 
       - name: Build the napi shared library
-        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.cross-compile && '--cross-compile' || '' }}
+        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.cross-compile && '--cross-compile' || matrix.settings.use-cross && '--use-cross' || '' }}
         working-directory: crates/monty-js
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.settings.native-musl && 'musl-gcc' || '' }}
-          RUSTFLAGS: ${{ matrix.settings.native-musl && '-C link-arg=-static-libgcc' || '' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,9 +1067,17 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             triple: linux-x64-gnu
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            triple: linux-x64-musl
+            musl: true
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             triple: linux-arm64-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            triple: linux-arm64-musl
+            musl: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1080,6 +1088,16 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        if: matrix.settings.musl
+        with:
+          version: 0.15.2
+
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
+        if: matrix.settings.musl
+        with:
+          tool: cargo-zigbuild
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -1098,7 +1116,7 @@ jobs:
         working-directory: crates/monty-js
 
       - name: Build the napi shared library
-        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }}
+        run: npx napi build --platform --release --esm --target ${{ matrix.settings.target }} ${{ matrix.settings.musl && '--cross-compile' || '' }}
         working-directory: crates/monty-js
 
       - name: Upload artifact
@@ -1296,6 +1314,39 @@ jobs:
         run: node package-smoke.mjs
         working-directory: crates/monty-js/smoke-test
 
+  test-js-musl-packages:
+    name: test ${{ matrix.platform.triple }} JS package on node@${{ matrix.node }}
+    needs:
+      - assemble-js-packages
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '24']
+        platform:
+          - os: ubuntu-latest
+            triple: linux-x64-musl
+          - os: ubuntu-24.04-arm
+            triple: linux-arm64-musl
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download package tarballs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: js-package-tarballs
+          path: crates/monty-js/package-tarballs
+
+      - name: Install and run the Alpine package
+        run: |
+          docker run --rm \
+            --volume "${{ github.workspace }}:/workspace" \
+            --workdir /workspace/crates/monty-js/smoke-test \
+            node:${{ matrix.node }}-alpine \
+            sh -c 'npm install ../package-tarballs/monty-main.tgz ../package-tarballs/monty-${{ matrix.platform.triple }}.tgz --force --no-save --no-package-lock && node package-smoke.mjs'
+
   release-js:
     name: Release to NPM
     runs-on: ubuntu-latest
@@ -1303,6 +1354,7 @@ jobs:
       - check
       - test-js
       - test-js-packages
+      - test-js-musl-packages
       - test-browser
       - release-python
     if: success() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.run_release))

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -43,7 +43,9 @@
         "@pydantic/monty-darwin-arm64": "0.0.23",
         "@pydantic/monty-darwin-x64": "0.0.23",
         "@pydantic/monty-linux-arm64-gnu": "0.0.23",
+        "@pydantic/monty-linux-arm64-musl": "0.0.23",
         "@pydantic/monty-linux-x64-gnu": "0.0.23",
+        "@pydantic/monty-linux-x64-musl": "0.0.23",
         "@pydantic/monty-win32-x64-msvc": "0.0.23"
       }
     },

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -40,8 +40,10 @@
       "x86_64-pc-windows-msvc",
       "x86_64-apple-darwin",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
       "aarch64-apple-darwin",
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl"
     ],
     "dtsHeaderFile": "./index-header.d.ts"
   },
@@ -108,7 +110,9 @@
     "@pydantic/monty-darwin-x64": "0.0.23",
     "@pydantic/monty-darwin-arm64": "0.0.23",
     "@pydantic/monty-linux-x64-gnu": "0.0.23",
+    "@pydantic/monty-linux-x64-musl": "0.0.23",
     "@pydantic/monty-linux-arm64-gnu": "0.0.23",
+    "@pydantic/monty-linux-arm64-musl": "0.0.23",
     "@pydantic/monty-win32-x64-msvc": "0.0.23"
   }
 }

--- a/crates/monty-js/scripts/assemble-packages.mjs
+++ b/crates/monty-js/scripts/assemble-packages.mjs
@@ -10,7 +10,9 @@ const runtimeArtifacts = {
   'darwin-x64': 'pypi_files-runtime-macos-x86_64-manylinux',
   'darwin-arm64': 'pypi_files-runtime-macos-aarch64-manylinux',
   'linux-x64-gnu': 'pypi_files-runtime-linux-x86_64-manylinux',
+  'linux-x64-musl': 'pypi_files-runtime-linux-x86_64-musllinux_1_1',
   'linux-arm64-gnu': 'pypi_files-runtime-linux-aarch64-manylinux',
+  'linux-arm64-musl': 'pypi_files-runtime-linux-aarch64-musllinux_1_1',
   'win32-x64-msvc': 'pypi_files-runtime-windows-x86_64-manylinux',
 }
 const triples = Object.keys(runtimeArtifacts)

--- a/crates/monty-js/scripts/create-platform-packages.mjs
+++ b/crates/monty-js/scripts/create-platform-packages.mjs
@@ -21,7 +21,15 @@ const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
 
 /** Native triples that ship a binary (kept in lockstep with `napi.targets`). */
-const NATIVE_TRIPLES = ['darwin-x64', 'darwin-arm64', 'linux-x64-gnu', 'linux-arm64-gnu', 'win32-x64-msvc']
+const NATIVE_TRIPLES = [
+  'darwin-x64',
+  'darwin-arm64',
+  'linux-x64-gnu',
+  'linux-x64-musl',
+  'linux-arm64-gnu',
+  'linux-arm64-musl',
+  'win32-x64-msvc',
+]
 
 // The main package must depend on every platform package at the exact same
 // version, otherwise npm installs a stale binary or shared library.

--- a/crates/monty-js/ts/binary.ts
+++ b/crates/monty-js/ts/binary.ts
@@ -33,18 +33,20 @@ export function platformTriple(): string | null {
   return null
 }
 
-/** Detects the musl loader used by Alpine and other musl-based Linux systems. */
+let musl: boolean | undefined
+
+/** Detects and caches the libc used by Alpine and other musl-based Linux systems. */
 function isMusl(): boolean {
+  return (musl ??= detectMusl())
+}
+
+/** Detects musl from its `ldd` script, then from Node's diagnostic report. */
+function detectMusl(): boolean {
   try {
     return readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
   } catch {
-    const report = process.report?.getReport() as
-      | { header: { glibcVersionRuntime?: string }; sharedObjects?: string[] }
-      | undefined
-    if (report?.header.glibcVersionRuntime !== undefined) {
-      return false
-    }
-    return report?.sharedObjects?.some((file) => file.includes('libc.musl-') || file.includes('ld-musl-')) ?? false
+    const report = process.report?.getReport() as { header: { glibcVersionRuntime?: string } } | undefined
+    return report !== undefined && report.header.glibcVersionRuntime === undefined
   }
 }
 

--- a/crates/monty-js/ts/binary.ts
+++ b/crates/monty-js/ts/binary.ts
@@ -8,7 +8,7 @@
 // 4. `monty` on PATH,
 // 5. a cargo workspace `target/{debug,release}` build (development fallback).
 
-import { accessSync, constants, existsSync, statSync } from 'node:fs'
+import { accessSync, constants, existsSync, readFileSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { delimiter, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -25,12 +25,27 @@ export function platformTriple(): string | null {
     return `darwin-${arch}`
   }
   if (platform === 'linux' && (arch === 'x64' || arch === 'arm64')) {
-    return `linux-${arch}-gnu`
+    return `linux-${arch}-${isMusl() ? 'musl' : 'gnu'}`
   }
   if (platform === 'win32' && arch === 'x64') {
     return 'win32-x64-msvc'
   }
   return null
+}
+
+/** Detects the musl loader used by Alpine and other musl-based Linux systems. */
+function isMusl(): boolean {
+  try {
+    return readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
+  } catch {
+    const report = process.report?.getReport() as
+      | { header: { glibcVersionRuntime?: string }; sharedObjects?: string[] }
+      | undefined
+    if (report?.header.glibcVersionRuntime !== undefined) {
+      return false
+    }
+    return report?.sharedObjects?.some((file) => file.includes('libc.musl-') || file.includes('ld-musl-')) ?? false
+  }
 }
 
 /**


### PR DESCRIPTION
Adds x64 and arm64 musl N-API packages.

Builds and smoke-tests the packages in Alpine before release.

Resolves #800 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@pydantic/monty-linux-x64-musl` and `@pydantic/monty-linux-arm64-musl` npm packages so Alpine and other musl-based Linux systems can use `monty` without a glibc compatibility layer. Previously only glibc-based Linux packages were published; the main package now depends on the new platform packages, and the JS binary loader detects musl at runtime (cached, with a fallback to Node's diagnostic report on hosts without an `ldd` script) to select the matching package. CI builds the x64 musl package with `cargo-zigbuild` 0.23.3, builds the arm64 musl package with `cross` so the addon links statically, and smoke-tests both in Alpine before release. Resolves #800.

<sup>Written for commit 28e05289d91e2be24ff0e78109b5f8850b5f3145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



