### PR TITLE
Vendor `_typeshed/_type_checker_internals.pyi` so TypedDict attribute access is rejected

### DIFF
--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -378,6 +378,39 @@ fn deeply_nested_parentheses_do_not_stack_overflow() {
     );
 }
 
+/// Regression test for issue #799: attribute access on a `TypedDict` value must
+/// be rejected (only subscript access works at runtime). ty synthesizes
+/// TypedDict members from `_typeshed._type_checker_internals.TypedDictFallback`;
+/// if the vendored typeshed drops that file, attribute access silently resolves
+/// to `Unknown` and this test fails with no diagnostics at all.
+#[test]
+fn typed_dict_attribute_access_is_rejected() {
+    let stubs = "\
+from typing import TypedDict
+
+class Change(TypedDict):
+    field_diffs: dict[str, object]
+
+def get_change() -> Change: ...
+";
+    let code = "\
+change = get_change()
+ok = change['field_diffs']
+bad = change.field_diffs
+";
+    let mut checker = TypeChecker::default();
+    let diagnostics = checker
+        .run(
+            &SourceFile::new(code, "main.py"),
+            Some(&SourceFile::new(stubs, "type_stubs.pyi")),
+            concise(),
+        )
+        .unwrap()
+        .expect("attribute access on a TypedDict must be a type error")
+        .to_string();
+    assert_snapshot!(diagnostics, @"main.py:3:7: error[unresolved-attribute] Object of type `Change` has no attribute `field_diffs`");
+}
+
 /// The narrowed `collections` stub must expose exactly what Monty implements at
 /// runtime — importing the four implemented names type-checks clean.
 #[test]

--- a/crates/monty-typeshed/update.py
+++ b/crates/monty-typeshed/update.py
@@ -184,7 +184,9 @@ def clone_or_update_typeshed() -> None:
     """Clone or update the typeshed repository to be at COMMIT.
 
     If the repository already exists at TYPESHED_REPO_DIR, fetches the target
-    commit. Otherwise, clones the repository. In both cases, checks out COMMIT.
+    commit. Otherwise, clones the repository. In both cases, checks out COMMIT
+    and then refuses to continue if the working tree is dirty — local edits
+    would otherwise be vendored while source_commit.txt still claims COMMIT.
     """
     if TYPESHED_REPO_DIR.exists():
         # Check if already at the right commit
@@ -197,14 +199,21 @@ def clone_or_update_typeshed() -> None:
         )
         if result.stdout.strip() == COMMIT:
             print(f'{TYPESHED_REPO_DIR} already at {COMMIT}')
-            return
-        print(f'{TYPESHED_REPO_DIR} exists, fetching {COMMIT}...')
-        subprocess.run(
-            ['git', 'fetch', 'origin', COMMIT],
-            cwd=TYPESHED_REPO_DIR,
-            check=True,
-            capture_output=True,
-        )
+        else:
+            print(f'{TYPESHED_REPO_DIR} exists, fetching {COMMIT}...')
+            subprocess.run(
+                ['git', 'fetch', 'origin', COMMIT],
+                cwd=TYPESHED_REPO_DIR,
+                check=True,
+                capture_output=True,
+            )
+            print(f'Checking out {COMMIT}...')
+            subprocess.run(
+                ['git', 'checkout', COMMIT],
+                cwd=TYPESHED_REPO_DIR,
+                check=True,
+                capture_output=True,
+            )
     else:
         print(f'Cloning typeshed to {TYPESHED_REPO_DIR}...')
         subprocess.run(
@@ -212,14 +221,26 @@ def clone_or_update_typeshed() -> None:
             check=True,
             capture_output=True,
         )
+        print(f'Checking out {COMMIT}...')
+        subprocess.run(
+            ['git', 'checkout', COMMIT],
+            cwd=TYPESHED_REPO_DIR,
+            check=True,
+            capture_output=True,
+        )
 
-    print(f'Checking out {COMMIT}...')
-    subprocess.run(
-        ['git', 'checkout', COMMIT],
+    status = subprocess.run(
+        ['git', 'status', '--porcelain'],
         cwd=TYPESHED_REPO_DIR,
         check=True,
         capture_output=True,
+        text=True,
     )
+    if status.stdout.strip():
+        raise ValueError(
+            f'{TYPESHED_REPO_DIR} has local modifications that would leak into the vendored stubs;'
+            f' discard them (or delete the directory to re-clone) and re-run:\n{status.stdout}'
+        )
 
 
 def filter_statements(nodes: list[ast.stmt]) -> list[ast.stmt]:
@@ -304,14 +325,15 @@ def filter_builtins(source: str) -> str:
 
 def main() -> int:
     """Main entry point."""
+    # Clone or update typeshed first: it validates the checkout, and failing
+    # there must leave the existing vendor directory untouched
+    clone_or_update_typeshed()
+    print(f'At python/typeshed commit {COMMIT}')
+
     # Clean up any stale files from previous runs
     if VENDOR_DIR.exists():
         print(f'Removing existing {VENDOR_DIR}...')
         shutil.rmtree(VENDOR_DIR)
-
-    # Clone or update typeshed
-    clone_or_update_typeshed()
-    print(f'At python/typeshed commit {COMMIT}')
 
     # Read source file
     src_stdlib = TYPESHED_REPO_DIR / 'stdlib'

--- a/crates/monty-typeshed/update.py
+++ b/crates/monty-typeshed/update.py
@@ -118,8 +118,12 @@ COPY_FILES = [
     'collections/__init__.pyi',
     'collections/abc.pyi',
     # ==============================
-    # Take only `__init__.pyi` from _typeshed dir
+    # From the _typeshed dir take `__init__.pyi` plus
+    # `_type_checker_internals.pyi`: ty synthesizes TypedDict members from its
+    # `TypedDictFallback`; without it attribute access on a TypedDict silently
+    # resolves to `Unknown` instead of `unresolved-attribute` (issue #799)
     '_typeshed/__init__.pyi',
+    '_typeshed/_type_checker_internals.pyi',
     # ==============================
     # all of pathlib dir
     'pathlib/__init__.pyi',

--- a/crates/monty-typeshed/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/monty-typeshed/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -1,0 +1,90 @@
+# Internals used by some type checkers.
+#
+# Don't use this module directly. It is only for type checkers to use.
+
+import sys
+from _collections_abc import dict_items, dict_keys, dict_values
+from abc import ABCMeta
+from collections.abc import Awaitable, Generator, Iterable, Mapping
+from typing import Any, ClassVar, Generic, TypeVar, overload
+
+import typing_extensions
+from typing_extensions import Never
+
+_T = TypeVar('_T')
+
+# Used for an undocumented mypy feature. Does not exist at runtime.
+promote = object()
+
+# Fallback type providing methods and attributes that appear on all `TypedDict` types.
+# N.B. Keep this mostly in sync with typing_extensions._TypedDict/mypy_extensions._TypedDict
+class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
+    __total__: ClassVar[bool]
+    __required_keys__: ClassVar[frozenset[str]]
+    __optional_keys__: ClassVar[frozenset[str]]
+    # __orig_bases__ sometimes exists on <3.12, but not consistently,
+    # so we only add it to the stub on 3.12+
+    if sys.version_info >= (3, 12):
+        __orig_bases__: ClassVar[tuple[Any, ...]]
+    if sys.version_info >= (3, 13):
+        __readonly_keys__: ClassVar[frozenset[str]]
+        __mutable_keys__: ClassVar[frozenset[str]]
+
+    def copy(self) -> typing_extensions.Self: ...
+    # Using Never so that only calls using mypy plugin hook that specialize the signature
+    # can go through.
+    def setdefault(self, k: Never, default: object) -> object: ...
+    # Mypy plugin hook for 'pop' expects that 'default' has a type variable type.
+    def pop(self, k: Never, default: _T = ...) -> object: ...  # pyright: ignore[reportInvalidTypeVarUse]
+    def update(self, m: typing_extensions.Self, /) -> None: ...
+    def __delitem__(self, k: Never) -> None: ...
+    def items(self) -> dict_items[str, object]: ...
+    def keys(self) -> dict_keys[str, object]: ...
+    def values(self) -> dict_values[str, object]: ...
+    @overload
+    def __or__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...
+    @overload
+    def __or__(self, value: dict[str, Any], /) -> dict[str, object]: ...
+    @overload
+    def __ror__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...
+    @overload
+    def __ror__(self, value: dict[str, Any], /) -> dict[str, object]: ...
+    # supposedly incompatible definitions of __or__ and __ior__
+    def __ior__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...  # type: ignore[misc]
+
+# Fallback type providing methods and attributes that appear on all `NamedTuple` types.
+class NamedTupleFallback(tuple[Any, ...]):
+    _field_defaults: ClassVar[dict[str, Any]]
+    _fields: ClassVar[tuple[str, ...]]
+    # __orig_bases__ sometimes exists on <3.12, but not consistently
+    # So we only add it to the stub on 3.12+.
+    if sys.version_info >= (3, 12):
+        __orig_bases__: ClassVar[tuple[Any, ...]]
+
+    @overload
+    def __init__(self, typename: str, fields: Iterable[tuple[str, Any]], /) -> None: ...
+    @overload
+    @typing_extensions.deprecated(
+        'Creating a typing.NamedTuple using keyword arguments is deprecated and support will be removed in Python 3.15'
+    )
+    def __init__(self, typename: str, fields: None = None, /, **kwargs: Any) -> None: ...
+    @classmethod
+    def _make(cls, iterable: Iterable[Any]) -> typing_extensions.Self: ...
+    def _asdict(self) -> dict[str, Any]: ...
+    def _replace(self, **kwargs: Any) -> typing_extensions.Self: ...
+    if sys.version_info >= (3, 13):
+        def __replace__(self, **kwargs: Any) -> typing_extensions.Self: ...
+
+# Non-default variations to accommodate couroutines, and `AwaitableGenerator` having a 4th type parameter.
+_S = TypeVar('_S')
+_YieldT_co = TypeVar('_YieldT_co', covariant=True)
+_SendT_nd_contra = TypeVar('_SendT_nd_contra', contravariant=True)
+_ReturnT_nd_co = TypeVar('_ReturnT_nd_co', covariant=True)
+
+# The parameters correspond to Generator, but the 4th is the original type.
+class AwaitableGenerator(
+    Awaitable[_ReturnT_nd_co],
+    Generator[_YieldT_co, _SendT_nd_contra, _ReturnT_nd_co],
+    Generic[_YieldT_co, _SendT_nd_contra, _ReturnT_nd_co, _S],
+    metaclass=ABCMeta,
+): ...

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "monty-workspace",


### PR DESCRIPTION
Fixes #799

## Problem

The type checker accepted attribute access on TypedDict values (`change.field_diffs`), which then failed at runtime with `AttributeError` — only subscript access works.

This turned out not to be a ty bug: standalone ty (tested 0.0.55 through 0.0.76) correctly reports `unresolved-attribute` for the same code. But latest ty run with `--typeshed crates/monty-typeshed/vendor/typeshed` reproduces the false negative exactly.

## Root cause

The typeshed trim in `update.py` kept only `_typeshed/__init__.pyi`, dropping `_typeshed/_type_checker_internals.pyi`. That file defines `TypedDictFallback`, which ty uses to synthesize TypedDict members. Without it, ty's TypedDict machinery degrades silently: attribute access resolves to `Unknown` with no diagnostic, while subscript access and ordinary class/dict checks keep working — matching all the symptoms in the issue, including arbitrary/missing attribute names passing and TypedDicts declared in source being equally affected.

## Fix

- `update.py` now includes `_typeshed/_type_checker_internals.pyi` in `COPY_FILES`, with a comment explaining why it must stay.
- Re-vendored (only change: the new file).
- Regression test `typed_dict_attribute_access_is_rejected` in `crates/monty-type-checking/tests/main.rs` using the issue's stub-based repro; it fails with no diagnostics at all if the file is ever dropped again.

Existing type-checking snapshots (`good_types` / `bad_types` / `reveal_types`), monty-runtime subprocess tests, monty-pool tests, and the pytest type-check suite are all unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfVPLN7qfAC6qNaofhhhZT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors `_typeshed/_type_checker_internals.pyi` so attribute access on `TypedDict` values is rejected with `error[unresolved-attribute]` instead of silently resolving to `Unknown` and failing at runtime (issue #799).

**Bug Fixes**
- `update.py` now copies the file, explains why it must stay, and refuses to vendor from a dirty typeshed checkout so local edits can't leak into the stubs.
- Adds a regression test that fails with no diagnostics if the file is dropped again.
- Re-vendored the file and regenerated `uv.lock`.

<sup>Written for commit 2dcb81464d491b2e3613050961691a1f37d1932a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

