### PR TITLE
Fix flakey CI on set repr

### DIFF
--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -665,13 +665,17 @@ impl<'h> HeapRead<'h, SetStorage> {
         // copies to a list first, so a user `__repr__` mutating the set
         // mid-format changes nothing (and can't invalidate indices here).
         vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
-        let mut items = Vec::with_capacity(len);
+        let items = Vec::with_capacity(len);
+        defer_drop_mut!(items, vm);
         for i in 0..len {
+            // The whole snapshot runs before `repr_items_fmt` reaches its first
+            // checkpoint, so it polls the deadline itself — otherwise a big set
+            // overshoots the time limit by the entire copy.
+            vm.heap.tracker.check_time_every(i)?;
             // No user code runs during the snapshot, so `len` is still current.
             let value = self.get(vm.heap).value_at(i).expect("index in range");
             items.push(value.clone_with_heap(vm.heap));
         }
-        defer_drop!(items, vm);
 
         f.write_char('{')?;
         repr_items_fmt(items, f, vm, heap_ids)?;

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1118,12 +1118,14 @@ repr(p)
 
 /// Test that `repr(large_set)` respects the time limit.
 ///
-/// Uses a set of 100K unique strings so that repr formatting is slow enough
-/// to trigger the timeout.
+/// The elements are ints rather than strings so that the promptness bound
+/// measures the timeout and not the teardown: freeing 300K distinct heap
+/// strings after the truncated repr costs more than the whole time budget on
+/// a loaded CI machine.
 #[test]
 fn timeout_truncation_in_set_repr() {
     let code = r"
-x = {str(i) for i in range(100_000)}
+x = {i for i in range(300_000)}
 interrupt()
 repr(x)
 ";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Large set `repr` now checks the time limit while copying elements instead of waiting until the full snapshot is complete. This prevents repr from overshooting its deadline and makes the timeout test reliable on loaded CI machines.

- Partially built snapshots are cleaned up if the timeout interrupts copying.
- The test uses 300,000 integers to avoid heap-string teardown costs affecting the timing assertion.

<sup>Written for commit 9920c5bf8ee2a43662719618a7d6124c77701182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

