### PR TITLE
Add a suspension limit to ResourceLimits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -959,8 +959,8 @@ where they are. Change one and you must change all of them:
 
 - **The importable stdlib module list** — `limitations/modules.md` (authoritative),
   `docs/python-subset.md`, `docs/index.md`, `README.md`.
-- **Default resource limits** (1000 recursion frames, 100 MB per-mount memory, 10 MiB
-  print collectors, 1s duration grace) — `limitations/resource_limits.md`,
+- **Default resource limits** (1000 recursion frames, 10,000 suspensions per run,
+  100 MB per-mount memory, 10 MiB print collectors, 1s duration grace) — `limitations/resource_limits.md`,
   `docs/resource-limits.md`, and the binding docstrings.
 - **Mount modes and their defaults** — `limitations/filesystem.md`, `docs/filesystem.md`,
   the `MountDir` docstrings in `_monty.pyi` and `crates/monty-js/ts/mount.ts`.

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -256,6 +256,14 @@ const limited = await pool.checkout({
 interpreter itself: the worker is killed and the session fails with
 `MontyCrashedError` (`timedOut: true`).
 
+`maxSuspensionsPerRun` (default 10,000) bounds how many times one run may
+suspend to the host — an external function call, a name lookup or an `os`
+callback. Each is a round trip the host retains state for, and none of it is
+visible to `maxMemory` or `maxDurationSecs`, so a loop that suspends and
+swallows the result is bounded by nothing else. `maxTotalSuspensions` is the
+optional cumulative cap across the session. Exceeding either ends the run with
+an uncatchable `RuntimeError` naming the limit.
+
 `maxDurationSecs` limits cumulative _execution_ time: the sandbox clock runs
 only while the interpreter executes, never while suspended waiting on an
 external function or between feeds. Sessions with the limit also get an

--- a/crates/monty-js/src/limits.rs
+++ b/crates/monty-js/src/limits.rs
@@ -25,6 +25,10 @@ pub struct JsResourceLimits {
     pub gc_interval: Option<f64>,
     /// Maximum function call stack depth (default: 1000).
     pub max_recursion_depth: Option<f64>,
+    /// Maximum host round trips in a single run (default: 10000).
+    pub max_suspensions_per_run: Option<f64>,
+    /// Maximum host round trips across the whole session.
+    pub max_total_suspensions: Option<f64>,
 }
 
 /// Extracts a Rust resource-limit configuration from a JS resource-limit object.
@@ -56,6 +60,12 @@ pub fn extract_limits(js_limits: JsResourceLimits) -> Result<ResourceLimits> {
     }
     if let Some(interval) = js_limits.gc_interval {
         limits = limits.gc_interval(js_number_to_usize(interval, "gcInterval")?);
+    }
+    if let Some(max) = js_limits.max_suspensions_per_run {
+        limits = limits.max_suspensions_per_run(js_number_to_usize(max, "maxSuspensionsPerRun")?);
+    }
+    if let Some(max) = js_limits.max_total_suspensions {
+        limits = limits.max_total_suspensions(js_number_to_usize(max, "maxTotalSuspensions")?);
     }
 
     Ok(limits)

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -80,14 +80,22 @@ export interface CheckoutOptions {
 
 /**
  * Sandbox resource limits. An omitted field means "unlimited", except
- * `maxRecursionDepth`, which falls back to its 1000-frame default and cannot
- * be disabled.
+ * `maxRecursionDepth` and `maxSuspensionsPerRun`, which fall back to their
+ * defaults (1000 frames, 10000 suspensions) and cannot be disabled.
  */
 export interface ResourceLimits {
   maxDurationSecs?: number
   maxMemory?: number
   gcInterval?: number
   maxRecursionDepth?: number
+  /**
+   * Host round trips allowed in one run — one `feedRun` and every resume that
+   * continues it. Each host function call, name lookup and `os` callback costs
+   * the host retained state no sandbox-side limit can see.
+   */
+  maxSuspensionsPerRun?: number
+  /** Host round trips allowed across the whole session. Unset by default. */
+  maxTotalSuspensions?: number
 }
 
 /**

--- a/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
+++ b/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
@@ -242,6 +242,8 @@ export interface ResourceLimits {
   maxMemoryBytes?: bigint
   gcInterval?: bigint
   maxRecursionDepth?: bigint
+  maxSuspensionsPerRun?: bigint
+  maxTotalSuspensions?: bigint
 }
 /**
  * # Variants

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -32,6 +32,8 @@ export interface ResourceLimits {
   maxMemory?: number
   gcInterval?: number
   maxRecursionDepth?: number
+  maxSuspensionsPerRun?: number
+  maxTotalSuspensions?: number
 }
 
 /** Session-creation options sent to the component worker. */
@@ -326,6 +328,8 @@ function encodeLimits(limits: ResourceLimits): ComponentResourceLimits {
     ...(limits.maxMemory === undefined ? {} : { maxMemoryBytes: BigInt(limits.maxMemory) }),
     ...(limits.gcInterval === undefined ? {} : { gcInterval: BigInt(limits.gcInterval) }),
     ...(limits.maxRecursionDepth === undefined ? {} : { maxRecursionDepth: BigInt(limits.maxRecursionDepth) }),
+    ...(limits.maxSuspensionsPerRun === undefined ? {} : { maxSuspensionsPerRun: BigInt(limits.maxSuspensionsPerRun) }),
+    ...(limits.maxTotalSuspensions === undefined ? {} : { maxTotalSuspensions: BigInt(limits.maxTotalSuspensions) }),
   }
 }
 

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -305,13 +305,15 @@ message StackFrame {
 // ============================================================================
 
 // Sandbox resource limits, enforced inside the child. Absent fields mean
-// "unlimited" except recursion depth, which defaults to monty's standard
-// limit (1000) when absent.
+// "unlimited" except recursion depth and per-run suspensions, which default
+// to monty's standard limits (1000 and 10,000) when absent.
 message ResourceLimits {
   optional uint64 max_duration_micros = 1;
   optional uint64 max_memory_bytes = 2;
   optional uint64 gc_interval = 3;
   optional uint64 max_recursion_depth = 4;
+  optional uint64 max_suspensions_per_run = 5;
+  optional uint64 max_total_suspensions = 6;
 }
 
 // ============================================================================

--- a/crates/monty-proto/src/convert/limits.rs
+++ b/crates/monty-proto/src/convert/limits.rs
@@ -2,12 +2,13 @@
 //!
 //! Wire fields are `u64`; the Rust struct uses `usize`, so proto → Rust
 //! saturates to `usize::MAX` on 32-bit hosts. Absent wire fields mean
-//! "unlimited", except recursion depth which falls back to monty's standard
-//! default — matching `ResourceLimits::default()` so an empty message is safe.
+//! "unlimited", except recursion depth and per-run suspensions, which fall
+//! back to monty's standard defaults — matching `ResourceLimits::default()`
+//! so an empty message is safe.
 
 use std::time::Duration;
 
-use monty_types::{DEFAULT_MAX_RECURSION_DEPTH, ResourceLimits};
+use monty_types::{DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_MAX_SUSPENSIONS_PER_RUN, ResourceLimits};
 
 use crate::pb;
 
@@ -20,6 +21,8 @@ impl From<&ResourceLimits> for pb::ResourceLimits {
             max_memory_bytes: limits.max_memory.map(|v| v as u64),
             gc_interval: limits.gc_interval.map(|v| v as u64),
             max_recursion_depth: Some(limits.max_recursion_depth as u64),
+            max_suspensions_per_run: Some(limits.max_suspensions_per_run as u64),
+            max_total_suspensions: limits.max_total_suspensions.map(|v| v as u64),
         }
     }
 }
@@ -31,6 +34,9 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             max_memory: usize_field(limits.max_memory_bytes),
             gc_interval: usize_field(limits.gc_interval),
             max_recursion_depth: usize_field(limits.max_recursion_depth).unwrap_or(DEFAULT_MAX_RECURSION_DEPTH),
+            max_suspensions_per_run: usize_field(limits.max_suspensions_per_run)
+                .unwrap_or(DEFAULT_MAX_SUSPENSIONS_PER_RUN),
+            max_total_suspensions: usize_field(limits.max_total_suspensions),
         }
     }
 }

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -303,8 +303,8 @@ pub struct StackFrame {
     pub hide_frame_name: bool,
 }
 /// Sandbox resource limits, enforced inside the child. Absent fields mean
-/// "unlimited" except recursion depth, which defaults to monty's standard
-/// limit (1000) when absent.
+/// "unlimited" except recursion depth and per-run suspensions, which default
+/// to monty's standard limits (1000 and 10,000) when absent.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]
@@ -315,6 +315,10 @@ pub struct ResourceLimits {
     pub gc_interval: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "4")]
     pub max_recursion_depth: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "5")]
+    pub max_suspensions_per_run: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "6")]
+    pub max_total_suspensions: ::core::option::Option<u64>,
 }
 /// Outcome of an external function / OS call, decided by the parent. Mirrors
 /// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -404,8 +404,8 @@ pub struct StackFrame {
     pub hide_frame_name: bool,
 }
 /// Sandbox resource limits, enforced inside the child. Absent fields mean
-/// "unlimited" except recursion depth, which defaults to monty's standard
-/// limit (1000) when absent.
+/// "unlimited" except recursion depth and per-run suspensions, which default
+/// to monty's standard limits (1000 and 10,000) when absent.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]
@@ -416,6 +416,10 @@ pub struct ResourceLimits {
     pub gc_interval: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "4")]
     pub max_recursion_depth: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "5")]
+    pub max_suspensions_per_run: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "6")]
+    pub max_total_suspensions: ::core::option::Option<u64>,
 }
 /// Outcome of an external function / OS call, decided by the parent. Mirrors
 /// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -522,24 +522,30 @@ fn resource_limits_round_trip() {
         max_memory: Some(64 * 1024 * 1024),
         gc_interval: Some(100),
         max_recursion_depth: 50,
+        max_suspensions_per_run: 25,
+        max_total_suspensions: Some(500),
     };
     let back = ResourceLimits::from(pb::ResourceLimits::from(&limits));
     assert_eq!(back.max_duration, limits.max_duration);
     assert_eq!(back.max_memory, limits.max_memory);
     assert_eq!(back.gc_interval, limits.gc_interval);
     assert_eq!(back.max_recursion_depth, limits.max_recursion_depth);
+    assert_eq!(back.max_suspensions_per_run, limits.max_suspensions_per_run);
+    assert_eq!(back.max_total_suspensions, limits.max_total_suspensions);
 }
 
 #[test]
-fn empty_resource_limits_default_recursion_depth() {
+fn empty_resource_limits_default_always_on_limits() {
     // an all-absent wire message must behave like ResourceLimits::default():
-    // unlimited everything except the standard recursion-depth default
+    // unlimited everything except the always-on recursion and suspension defaults
     let back = ResourceLimits::from(pb::ResourceLimits::default());
     let expected = ResourceLimits::default();
     assert_eq!(back.max_duration, expected.max_duration);
     assert_eq!(back.max_memory, expected.max_memory);
     assert_eq!(back.gc_interval, expected.gc_interval);
     assert_eq!(back.max_recursion_depth, expected.max_recursion_depth);
+    assert_eq!(back.max_suspensions_per_run, expected.max_suspensions_per_run);
+    assert_eq!(back.max_total_suspensions, expected.max_total_suspensions);
 }
 
 #[test]

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -104,8 +104,9 @@ class ResourceLimits(TypedDict, total=False):
     Configuration for resource limits during code execution.
 
     All limits are optional. Omit a key — or set it to `None` explicitly —
-    to disable that limit, with one exception: `max_recursion_depth` cannot
-    be disabled, and omitting it leaves the 1000-frame default in place.
+    to disable that limit, with two exceptions: `max_recursion_depth` and
+    `max_suspensions_per_run` cannot be disabled, and omitting them leaves
+    their defaults in place.
     """
 
     max_duration_secs: float | None
@@ -119,6 +120,23 @@ class ResourceLimits(TypedDict, total=False):
 
     max_recursion_depth: int | None
     """Maximum function call stack depth (default: 1000)."""
+
+    max_suspensions_per_run: int | None
+    """
+    Maximum host round trips in a single run (default: 10000).
+
+    Every host function call, name lookup and `os` callback suspends the
+    sandbox and costs the host retained state, which no sandbox-side limit
+    can see. A run is one `feed_run` and every resume that continues it.
+    """
+
+    max_total_suspensions: int | None
+    """
+    Maximum host round trips across the whole session.
+
+    Unset by default, so only each run is bounded. Set it to stop code
+    sidestepping `max_suspensions_per_run` by feeding repeatedly.
+    """
 
 
 class ExternalReturnValue(TypedDict):

--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -11,9 +11,12 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 /// - `max_memory`: Maximum heap memory in bytes (int)
 /// - `gc_interval`: Run garbage collection every N allocations (int)
 /// - `max_recursion_depth`: Maximum function call stack depth (int, default: 1000)
+/// - `max_suspensions_per_run`: Maximum host round trips in one run (int, default: 10000)
+/// - `max_total_suspensions`: Maximum host round trips for the whole session (int)
 ///
 /// If a key is missing or set to `None`, that limit is not applied
-/// (except `max_recursion_depth` which defaults to 1000).
+/// (except `max_recursion_depth` and `max_suspensions_per_run`, which fall
+/// back to their defaults).
 ///
 /// Raises `TypeError` if a value is present but has the wrong type.
 /// Raises `ValueError` if the dict contains an unknown key — limits are a
@@ -40,6 +43,8 @@ pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty_types::Resourc
             LimitKey::MaxMemory => limits.max_memory(value.extract()?),
             LimitKey::GcInterval => limits.gc_interval(value.extract()?),
             LimitKey::MaxRecursionDepth => limits.max_recursion_depth(value.extract()?),
+            LimitKey::MaxSuspensionsPerRun => limits.max_suspensions_per_run(value.extract()?),
+            LimitKey::MaxTotalSuspensions => limits.max_total_suspensions(value.extract()?),
         };
     }
     Ok(limits)
@@ -53,6 +58,8 @@ enum LimitKey {
     MaxMemory,
     GcInterval,
     MaxRecursionDepth,
+    MaxSuspensionsPerRun,
+    MaxTotalSuspensions,
 }
 
 impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
@@ -64,6 +71,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
             "max_memory" => Ok(Self::MaxMemory),
             "gc_interval" => Ok(Self::GcInterval),
             "max_recursion_depth" => Ok(Self::MaxRecursionDepth),
+            "max_suspensions_per_run" => Ok(Self::MaxSuspensionsPerRun),
+            "max_total_suspensions" => Ok(Self::MaxTotalSuspensions),
             _ => {
                 // `repr()` runs user `__repr__`, which may itself raise — fall
                 // back so the promised `ValueError` is raised for every unknown key.
@@ -72,7 +81,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
                     .map_or_else(|_| "<unprintable key>".to_owned(), |r| r.to_string());
                 Err(PyValueError::new_err(format!(
                     "unknown limits key {key_repr}; accepted keys are 'max_duration_secs', \
-                     'max_memory', 'gc_interval', 'max_recursion_depth'"
+                     'max_memory', 'gc_interval', 'max_recursion_depth', \
+                     'max_suspensions_per_run', 'max_total_suspensions'"
                 )))
             }
         }

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -17,11 +17,15 @@ def test_resource_limits_typed_dict():
         max_memory=1024,
         gc_interval=10,
         max_recursion_depth=500,
+        max_suspensions_per_run=50,
+        max_total_suspensions=200,
     )
     assert limits.get('max_duration_secs') == snapshot(5.0)
     assert limits.get('max_memory') == snapshot(1024)
     assert limits.get('gc_interval') == snapshot(10)
     assert limits.get('max_recursion_depth') == snapshot(500)
+    assert limits.get('max_suspensions_per_run') == snapshot(50)
+    assert limits.get('max_total_suspensions') == snapshot(200)
 
 
 def test_resource_limits_repr():
@@ -114,7 +118,7 @@ def test_limits_unknown_key_raises_error(pool: Monty):
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key 'max_memroy'; accepted keys are 'max_duration_secs', 'max_memory', "
-        "'gc_interval', 'max_recursion_depth'"
+        "'gc_interval', 'max_recursion_depth', 'max_suspensions_per_run', 'max_total_suspensions'"
     )
 
 
@@ -124,7 +128,7 @@ def test_limits_non_string_key_raises_error(pool: Monty):
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key 1; accepted keys are 'max_duration_secs', 'max_memory', "
-        "'gc_interval', 'max_recursion_depth'"
+        "'gc_interval', 'max_recursion_depth', 'max_suspensions_per_run', 'max_total_suspensions'"
     )
 
 
@@ -138,7 +142,7 @@ def test_limits_unprintable_key_still_raises_value_error(pool: Monty):
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key <unprintable key>; accepted keys are 'max_duration_secs', 'max_memory', "
-        "'gc_interval', 'max_recursion_depth'"
+        "'gc_interval', 'max_recursion_depth', 'max_suspensions_per_run', 'max_total_suspensions'"
     )
 
 
@@ -217,3 +221,38 @@ def test_timeout_enforced_in_builtin_loops(monty_run: RunMonty, code: str):
     assert isinstance(exc_info.value.exception(), TimeoutError)
     # Should terminate promptly - well under 2 seconds
     assert elapsed < 2.0
+
+
+def test_suspension_limit_stops_a_retry_loop(pool: Monty):
+    """A loop that swallows every refusal costs the host a round trip per turn and nothing else."""
+    code = """
+while True:
+    try:
+        open('/etc/passwd')
+    except Exception:
+        pass
+"""
+    with pool.checkout(limits={'max_suspensions_per_run': 5}) as session:
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.feed_run(code)
+    assert exc_info.value.display(format='type-msg') == snapshot(
+        'RuntimeError: suspension limit exceeded: 6 > 5 (max_suspensions_per_run)'
+    )
+
+
+def test_total_suspension_limit_spans_feeds(pool: Monty):
+    """The cumulative cap bites across feeds that each stay inside the per-run budget."""
+    code = """
+try:
+    open('/etc/passwd')
+except Exception:
+    pass
+"""
+    with pool.checkout(limits={'max_total_suspensions': 2}) as session:
+        session.feed_run(code)
+        session.feed_run(code)
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.feed_run(code)
+    assert exc_info.value.display(format='type-msg') == snapshot(
+        'RuntimeError: suspension limit exceeded: 3 > 2 (max_total_suspensions)'
+    )

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -39,7 +39,8 @@ monty --help
 - `-m` / `--mount /host/path::/virtual/path[::mode[::write_limit_bytes]]` —
   mount a host directory into the sandbox (`ro`, `rw`, or `overlay`)
 - `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
-  `--gc-interval` — sandbox resource limits
+  `--max-suspensions-per-run`, `--max-total-suspensions`, `--gc-interval` —
+  sandbox resource limits
 
 ## Worker mode
 

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -72,6 +72,14 @@ pub(crate) struct Cli {
     #[arg(long)]
     max_recursion_depth: Option<usize>,
 
+    /// Maximum host round trips in one run (defaults to 10000).
+    #[arg(long)]
+    max_suspensions_per_run: Option<usize>,
+
+    /// Maximum host round trips across the whole session (unlimited by default).
+    #[arg(long)]
+    max_total_suspensions: Option<usize>,
+
     #[command(subcommand)]
     subcommand: Option<Command>,
 }
@@ -118,12 +126,14 @@ impl Cli {
             || self.max_memory.is_some()
             || self.gc_interval.is_some()
             || self.max_recursion_depth.is_some()
+            || self.max_suspensions_per_run.is_some()
+            || self.max_total_suspensions.is_some()
     }
 
     /// Builds `ResourceLimits` from the parsed CLI arguments.
     ///
-    /// When no resource flags were provided, returns the default
-    /// recursion-only limits (`ResourceLimits::default()`).
+    /// When no resource flags were provided, returns the always-on defaults
+    /// (`ResourceLimits::default()`).
     /// Returns `Err` if a supplied flag cannot be converted into a valid limit.
     #[cfg(feature = "standalone")]
     fn resource_limits(&self) -> Result<monty_types::ResourceLimits, String> {
@@ -142,6 +152,12 @@ impl Cli {
         }
         if let Some(depth) = self.max_recursion_depth {
             limits = limits.max_recursion_depth(depth);
+        }
+        if let Some(max) = self.max_suspensions_per_run {
+            limits = limits.max_suspensions_per_run(max);
+        }
+        if let Some(max) = self.max_total_suspensions {
+            limits = limits.max_total_suspensions(max);
         }
         Ok(limits)
     }

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -510,6 +510,51 @@ fn child_enforces_time_limit() {
     child.shutdown();
 }
 
+/// The issue's shape: a loop that catches every refusal and retries costs the
+/// *parent* a round trip per iteration while allocating nothing in the sandbox
+/// and accruing no execution time. Only the suspension budget bounds it — and
+/// the refusal must arrive as a turn-ending error, not as one more OS call.
+#[test]
+fn child_enforces_suspension_limit() {
+    let mut child = ChildProc::spawn();
+    child.create_repl_with(pb::Configure {
+        script_name: "main.py".to_owned(),
+        limits: Some(pb::ResourceLimits {
+            max_suspensions_per_run: Some(3),
+            ..Default::default()
+        }),
+        type_check: false,
+        type_check_stubs: None,
+        monty_version: env!("CARGO_PKG_VERSION").to_owned(),
+        protocol_version: PROTOCOL_VERSION,
+        assert_message_annotations: None,
+        ..Default::default()
+    });
+    let code = "while True:\n    try:\n        open('/etc/passwd')\n    except Exception:\n        pass";
+    let mut event = child.feed(code).1;
+    for _ in 0..3 {
+        let pb::child_event::Kind::OsCall(call) = event else {
+            panic!("expected OsCall while the budget lasts, got {event:?}");
+        };
+        let exc = pb::RaisedException {
+            exc_type: "FileNotFoundError".to_owned(),
+            message: Some("No such file or directory: '/etc/passwd'".to_owned()),
+            traceback: vec![],
+            data: None,
+        };
+        event = child
+            .resume_call(call.call_id, pb::ext_function_result::Kind::Error(exc))
+            .1;
+    }
+    let error = expect_error(event);
+    assert_eq!(error.exc_type, "RuntimeError");
+    assert_eq!(
+        error.message.as_deref(),
+        Some("suspension limit exceeded: 4 > 3 (max_suspensions_per_run)")
+    );
+    child.shutdown();
+}
+
 /// A session's `max_memory` must not disturb work that stays inside it. This
 /// small budget includes the real allocations needed to compile and run a feed.
 #[test]

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -34,8 +34,8 @@ pub use crate::{
         RenameCallArgs, dir_stat, file_stat, stat_result, symlink_stat,
     },
     resource::{
-        BASELINE_MEMORY, DEFAULT_MAX_RECURSION_DEPTH, LARGE_RESULT_THRESHOLD, LIVE_MEMORY, OOM_EXIT_CODE,
-        ResourceError, ResourceLimits, ResourceTracker,
+        BASELINE_MEMORY, DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_MAX_SUSPENSIONS_PER_RUN, LARGE_RESULT_THRESHOLD,
+        LIVE_MEMORY, OOM_EXIT_CODE, ResourceError, ResourceLimits, ResourceTracker, SuspensionScope,
     },
     results::{ExtFunctionResult, NameLookupResult},
     run_options::{AssertMessageAnnotations, CompileOptions},

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -306,10 +306,11 @@ impl ResourceTracker {
 
     /// Starts a fresh run, zeroing the per-run suspension budget.
     ///
-    /// Called by the host-facing entry points that *begin* execution
-    /// (`MontyRepl::feed_start` / `feed_run` / `call_function`,
-    /// `MontyRun::start` / `run`) — never by a resume, which continues the
-    /// run it is resuming. The session total is deliberately untouched.
+    /// Called by the repl entry points that *begin* execution
+    /// (`MontyRepl::feed_start` / `feed_run` / `call_function`) — never by a
+    /// resume, which continues the run it is resuming. `MontyRun` needs no
+    /// call: it takes its tracker by value and runs once. The session total
+    /// is deliberately untouched.
     pub fn on_run_start(&self) {
         self.run_suspensions.set(0);
     }

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -54,6 +54,39 @@ pub enum ResourceError {
     Memory { limit: usize, used: usize },
     /// Maximum recursion depth exceeded.
     Recursion { limit: usize, depth: usize },
+    /// Maximum number of host suspensions exceeded.
+    ///
+    /// `scope` names which of the two budgets ran out, so the message can say
+    /// which limit the host should raise.
+    Suspensions {
+        limit: usize,
+        count: usize,
+        scope: SuspensionScope,
+    },
+}
+
+/// Which suspension budget a [`ResourceError::Suspensions`] refers to.
+///
+/// The two budgets are counted separately: one run's suspensions are also
+/// charged to the session total, so a session cap bites across feeds even
+/// when no single run comes near the per-run cap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuspensionScope {
+    /// The per-run budget, reset at the start of every feed/run.
+    Run,
+    /// The cumulative per-session budget, never reset.
+    Session,
+}
+
+impl SuspensionScope {
+    /// The limit's configuration name, quoted in the error message so a host
+    /// knows which field to raise.
+    fn limit_name(self) -> &'static str {
+        match self {
+            Self::Run => "max_suspensions_per_run",
+            Self::Session => "max_total_suspensions",
+        }
+    }
 }
 
 impl fmt::Display for ResourceError {
@@ -68,6 +101,13 @@ impl fmt::Display for ResourceError {
             Self::Recursion { .. } => {
                 write!(f, "maximum recursion depth exceeded")
             }
+            Self::Suspensions { limit, count, scope } => {
+                write!(
+                    f,
+                    "suspension limit exceeded: {count} > {limit} ({})",
+                    scope.limit_name()
+                )
+            }
         }
     }
 }
@@ -77,11 +117,13 @@ impl Error for ResourceError {}
 /// Configuration for resource limits.
 ///
 /// The time/memory/GC limits are optional — set to `None` to disable — but
-/// recursion depth is always bounded (default
-/// [`DEFAULT_MAX_RECURSION_DEPTH`]): unbounded recursion would let sandboxed
-/// code overflow the native stack and abort the process. Use
-/// `ResourceLimits::default()` for the recursion-only defaults, or build
-/// custom limits with the builder pattern.
+/// recursion depth and per-run suspensions are always bounded (defaults
+/// [`DEFAULT_MAX_RECURSION_DEPTH`] and
+/// [`DEFAULT_MAX_SUSPENSIONS_PER_RUN`]): unbounded recursion would let
+/// sandboxed code overflow the native stack and abort the process, and
+/// unbounded suspensions would let it grow the *host's* memory without ever
+/// allocating in the sandbox. Use `ResourceLimits::default()` for those
+/// always-on defaults, or build custom limits with the builder pattern.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResourceLimits {
     /// Maximum execution time.
@@ -94,12 +136,31 @@ pub struct ResourceLimits {
     pub gc_interval: Option<usize>,
     /// Maximum recursion depth (function call stack depth).
     pub max_recursion_depth: usize,
+    /// Maximum host suspensions in a single run (one feed and every resume
+    /// that continues it).
+    ///
+    /// Each suspension is a host round trip the host retains state for, so
+    /// this bounds host-side growth that no sandbox-side limit can see.
+    pub max_suspensions_per_run: usize,
+    /// Optional cumulative cap on host suspensions across the whole session.
+    ///
+    /// `None` (the default) bounds only each run. Set it to stop a caller
+    /// sidestepping `max_suspensions_per_run` by feeding repeatedly.
+    pub max_total_suspensions: Option<usize>,
 }
 
 /// Recommended maximum recursion depth if not otherwise specified.
 pub const DEFAULT_MAX_RECURSION_DEPTH: usize = 1000;
 
-/// Creates a new ResourceLimits with all limits disabled, except max recursion which is set to 1000.
+/// Suspensions a single run may make if not otherwise specified.
+///
+/// Sized well above what host-call-heavy code legitimately does (tens to
+/// hundreds per run) while still bounding the host-side state a refusal loop
+/// can accumulate.
+pub const DEFAULT_MAX_SUSPENSIONS_PER_RUN: usize = 10_000;
+
+/// Creates a new ResourceLimits with all limits disabled, except the two that
+/// are always on: recursion depth (1000) and per-run suspensions (10,000).
 impl Default for ResourceLimits {
     fn default() -> Self {
         Self {
@@ -107,6 +168,8 @@ impl Default for ResourceLimits {
             max_memory: None,
             gc_interval: None,
             max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
+            max_suspensions_per_run: DEFAULT_MAX_SUSPENSIONS_PER_RUN,
+            max_total_suspensions: None,
         }
     }
 }
@@ -140,6 +203,20 @@ impl ResourceLimits {
     #[must_use]
     pub fn max_recursion_depth(mut self, limit: usize) -> Self {
         self.max_recursion_depth = limit;
+        self
+    }
+
+    /// Sets the maximum host suspensions allowed in a single run.
+    #[must_use]
+    pub fn max_suspensions_per_run(mut self, limit: usize) -> Self {
+        self.max_suspensions_per_run = limit;
+        self
+    }
+
+    /// Sets a cumulative cap on host suspensions across the whole session.
+    #[must_use]
+    pub fn max_total_suspensions(mut self, limit: usize) -> Self {
+        self.max_total_suspensions = Some(limit);
         self
     }
 }
@@ -188,6 +265,17 @@ pub struct ResourceTracker {
     /// existed (`#[serde(default)]` gives back the `None` fallback case).
     #[serde(default)]
     recursion_limit_override: Cell<Option<usize>>,
+    /// Suspensions made by the run in progress, zeroed by
+    /// [`on_run_start`](Self::on_run_start).
+    ///
+    /// Serialized because a session can be dumped *while suspended*: skipping
+    /// it would hand a host that snapshots every suspension a free budget
+    /// reset.
+    #[serde(default)]
+    run_suspensions: Cell<usize>,
+    /// Suspensions made across the whole session, never reset.
+    #[serde(default)]
+    total_suspensions: Cell<usize>,
 }
 
 impl Default for ResourceTracker {
@@ -211,7 +299,61 @@ impl ResourceTracker {
             total_execution_time: Cell::new(Duration::ZERO),
             running_since: Cell::new(None),
             recursion_limit_override: Cell::new(None),
+            run_suspensions: Cell::new(0),
+            total_suspensions: Cell::new(0),
         }
+    }
+
+    /// Starts a fresh run, zeroing the per-run suspension budget.
+    ///
+    /// Called by the host-facing entry points that *begin* execution
+    /// (`MontyRepl::feed_start` / `feed_run` / `call_function`,
+    /// `MontyRun::start` / `run`) — never by a resume, which continues the
+    /// run it is resuming. The session total is deliberately untouched.
+    pub fn on_run_start(&self) {
+        self.run_suspensions.set(0);
+    }
+
+    /// Charges one host suspension against both budgets.
+    ///
+    /// Called once per suspension the VM is about to hand the host, so a
+    /// refused suspension never reaches the host at all — the host-side state
+    /// this bounds is allocated by the round trip, not by the sandbox.
+    pub fn record_suspension(&self) -> Result<(), ResourceError> {
+        let run = self.run_suspensions.get().saturating_add(1);
+        self.run_suspensions.set(run);
+        let total = self.total_suspensions.get().saturating_add(1);
+        self.total_suspensions.set(total);
+
+        let run_limit = self.limits.max_suspensions_per_run;
+        if run > run_limit {
+            Err(ResourceError::Suspensions {
+                limit: run_limit,
+                count: run,
+                scope: SuspensionScope::Run,
+            })
+        } else {
+            match self.limits.max_total_suspensions {
+                Some(limit) if total > limit => Err(ResourceError::Suspensions {
+                    limit,
+                    count: total,
+                    scope: SuspensionScope::Session,
+                }),
+                _ => Ok(()),
+            }
+        }
+    }
+
+    /// Suspensions made by the run in progress.
+    #[must_use]
+    pub fn run_suspensions(&self) -> usize {
+        self.run_suspensions.get()
+    }
+
+    /// Suspensions made across the whole session.
+    #[must_use]
+    pub fn total_suspensions(&self) -> usize {
+        self.total_suspensions.get()
     }
 
     /// Returns the live recursion ceiling: the override if one is in effect,

--- a/crates/monty-wasm-runtime/src/lib.rs
+++ b/crates/monty-wasm-runtime/src/lib.rs
@@ -293,6 +293,8 @@ fn configure_from_component(request: ConfigureRequest) -> pb::Configure {
             max_memory_bytes: limits.max_memory_bytes,
             gc_interval: limits.gc_interval,
             max_recursion_depth: limits.max_recursion_depth,
+            max_suspensions_per_run: limits.max_suspensions_per_run,
+            max_total_suspensions: limits.max_total_suspensions,
         }),
         type_check: request.type_check,
         type_check_stubs: request.type_check_stubs,

--- a/crates/monty-wasm-runtime/wit/runtime.wit
+++ b/crates/monty-wasm-runtime/wit/runtime.wit
@@ -168,6 +168,8 @@ interface worker {
         max-memory-bytes: option<u64>,
         gc-interval: option<u64>,
         max-recursion-depth: option<u64>,
+        max-suspensions-per-run: option<u64>,
+        max-total-suspensions: option<u64>,
     }
 
     /// Available renderings for type-check diagnostics.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -287,8 +287,8 @@ pub enum FrameExit {
 impl FrameExit {
     /// Whether this exit hands control to the host and waits to be resumed.
     ///
-    /// Every variant but `Return` is a host round trip, and each one is
-    /// charged against the session's suspension budget.
+    /// Every variant but `Return` suspends; `convert_frame_exit` charges each
+    /// one against the session's suspension budget.
     pub(crate) fn is_suspension(&self) -> bool {
         !matches!(self, Self::Return(_))
     }
@@ -971,30 +971,11 @@ impl<'h> VM<'h> {
     /// `run_external` call, and it must NEVER nest: VM-internal re-entry
     /// (task switches, `evaluate_function`) uses the raw private [`Self::run`]
     /// instead, whose time is already inside the enclosing window.
-    ///
-    /// This is also the single funnel every suspension leaves through, so it
-    /// is where the suspension budget is charged. Refusing here means the
-    /// over-budget suspension never reaches the host, and so never costs the
-    /// host the round trip the budget exists to bound.
     pub(crate) fn run_external(&mut self) -> Result<FrameExit, RunError> {
         self.heap.tracker.on_execution_start();
         let result = self.run();
         self.heap.tracker.on_execution_stop();
-        let exit = self.finish_host_turn(result)?;
-        let charged = if exit.is_suspension() {
-            self.heap.tracker.record_suspension()
-        } else {
-            Ok(())
-        };
-        match charged {
-            Ok(()) => Ok(exit),
-            Err(err) => {
-                // The exit owns heap references (call args, an armed OS
-                // effect); no host resume will consume them now.
-                exit.drop_with(self);
-                Err(err.into())
-            }
-        }
+        self.finish_host_turn(result)
     }
 
     /// Epilogue for every host-boundary execution window (here and

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -284,6 +284,16 @@ pub enum FrameExit {
     },
 }
 
+impl FrameExit {
+    /// Whether this exit hands control to the host and waits to be resumed.
+    ///
+    /// Every variant but `Return` is a host round trip, and each one is
+    /// charged against the session's suspension budget.
+    pub(crate) fn is_suspension(&self) -> bool {
+        !matches!(self, Self::Return(_))
+    }
+}
+
 impl<C: ContainsHeap> DropWithContext<C> for FrameExit {
     fn drop_with(self, heap: &mut C) {
         match self {
@@ -961,11 +971,30 @@ impl<'h> VM<'h> {
     /// `run_external` call, and it must NEVER nest: VM-internal re-entry
     /// (task switches, `evaluate_function`) uses the raw private [`Self::run`]
     /// instead, whose time is already inside the enclosing window.
+    ///
+    /// This is also the single funnel every suspension leaves through, so it
+    /// is where the suspension budget is charged. Refusing here means the
+    /// over-budget suspension never reaches the host, and so never costs the
+    /// host the round trip the budget exists to bound.
     pub(crate) fn run_external(&mut self) -> Result<FrameExit, RunError> {
         self.heap.tracker.on_execution_start();
         let result = self.run();
         self.heap.tracker.on_execution_stop();
-        self.finish_host_turn(result)
+        let exit = self.finish_host_turn(result)?;
+        let charged = if exit.is_suspension() {
+            self.heap.tracker.record_suspension()
+        } else {
+            Ok(())
+        };
+        match charged {
+            Ok(()) => Ok(exit),
+            Err(err) => {
+                // The exit owns heap references (call args, an armed OS
+                // effect); no host resume will consume them now.
+                exit.drop_with(self);
+                Err(err.into())
+            }
+        }
     }
 
     /// Epilogue for every host-boundary execution window (here and

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -26,7 +26,7 @@ const MAGIC: &[u8; 6] = b"MONTY\0";
 /// rejected instead of decoding as their neighbour. That covers the
 /// interpreter's own types *and* everything reachable from [`Dump`] — notably
 /// `TypeCheckingConfig` in `monty-types`.
-pub const DUMP_VERSION: u16 = 6;
+pub const DUMP_VERSION: u16 = 7;
 
 /// Number of bytes before the postcard payload.
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u16>();

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -151,6 +151,7 @@ impl MontyRepl {
         print: PrintWriter<'_>,
     ) -> Result<ReplProgress, Box<ReplStartError>> {
         let mut this = self;
+        this.heap.tracker.on_run_start();
         if code.is_empty() {
             return Ok(ReplProgress::Complete {
                 repl: this,
@@ -226,6 +227,7 @@ impl MontyRepl {
         inputs: Vec<(String, MontyObject)>,
         print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
+        self.heap.tracker.on_run_start();
         if code.is_empty() {
             return Ok(MontyObject::None);
         }
@@ -301,6 +303,7 @@ impl MontyRepl {
         args: Vec<MontyObject>,
         print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
+        self.heap.tracker.on_run_start();
         let Some(name_id) = self.interns.get_string_id_by_name(name) else {
             return Err(RunError::from(ExcType::name_error(name))
                 .into_python_exception(&self.interns, |fname| self.sources.get(fname).map(String::as_str)));

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -113,13 +113,15 @@ fn estimate_bits_to_bytes(bits: u64) -> usize {
 /// Converts a resource error to its host-visible Python exception.
 ///
 /// Recursion errors remain catchable for CPython compatibility; terminal
-/// memory and time errors cannot be suppressed by sandboxed code.
+/// memory, time and suspension errors cannot be suppressed by sandboxed code
+/// — a spent budget must end the run, not be swallowed by a bare `except`.
 impl From<ResourceError> for RunError {
     fn from(err: ResourceError) -> Self {
         let (exc_type, catchable) = match &err {
             ResourceError::Memory { .. } => (ExcType::MemoryError, false),
             ResourceError::Time { .. } => (ExcType::TimeoutError, false),
             ResourceError::Recursion { .. } => (ExcType::RecursionError, true),
+            ResourceError::Suspensions { .. } => (ExcType::RuntimeError, false),
         };
         let exc = SimpleException::new_msg(exc_type, err).into();
         if catchable {

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -152,6 +152,7 @@ impl MontyRun {
         print: PrintWriter<'_>,
     ) -> Result<RunProgress, MontyException> {
         let executor = self.executor;
+        resource_tracker.on_run_start();
 
         // Create heap and VM with empty globals, then populate inputs with VM alive
         let mut heap = Heap::new(executor.namespace_size(), resource_tracker);
@@ -415,6 +416,7 @@ impl Executor {
         resource_tracker: ResourceTracker,
         print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
+        resource_tracker.on_run_start();
         let heap_capacity = self.heap_capacity.load(Ordering::Relaxed);
         let mut heap = Heap::new(heap_capacity, resource_tracker);
         let globals = self.empty_globals();

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -152,7 +152,6 @@ impl MontyRun {
         print: PrintWriter<'_>,
     ) -> Result<RunProgress, MontyException> {
         let executor = self.executor;
-        resource_tracker.on_run_start();
 
         // Create heap and VM with empty globals, then populate inputs with VM alive
         let mut heap = Heap::new(executor.namespace_size(), resource_tracker);
@@ -416,7 +415,6 @@ impl Executor {
         resource_tracker: ResourceTracker,
         print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
-        resource_tracker.on_run_start();
         let heap_capacity = self.heap_capacity.load(Ordering::Relaxed);
         let mut heap = Heap::new(heap_capacity, resource_tracker);
         let globals = self.empty_globals();

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -15,6 +15,7 @@ use crate::{
     bytecode::{FrameExit, VM, VMSnapshot},
     exception_private::{ExcTypeExt, RunError, RunResult},
     heap::{Heap, HeapReader},
+    heap_traits::DropWithContext,
     object_bridge::MontyObjectExt,
     os_dispatch::release_pending_effect,
     run::Executor,
@@ -655,6 +656,10 @@ impl ConvertedExit {
 ///
 /// All `Value` → `MontyObject` and `StringId` → `String` conversions happen here,
 /// while the VM (and its heap/interns) are still accessible.
+///
+/// This is also the only path that turns a suspension into something the host
+/// is told about, so it is where the suspension budget is charged — a caller
+/// that resolves suspensions itself (`MontyRepl::call_function`) spends none.
 pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_>) -> ConvertedExit {
     // An effect still armed on arrival belongs to an OS call that was answered
     // without consuming it — a host may reply `ExtFunctionResult::Future`,
@@ -663,6 +668,20 @@ pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_>) 
     // (or leak its file pin when the next OS call overwrites the slot).
     // Arming for *this* exit happens below, after the slot is clear.
     release_pending_effect(vm.pending_os_effect.take(), vm.heap);
+    // Charged before the exit becomes an announcement, so an over-budget
+    // suspension never costs the host the round trip the budget bounds.
+    let result = match result {
+        Ok(exit) if exit.is_suspension() => match vm.heap.tracker.record_suspension() {
+            Ok(()) => Ok(exit),
+            Err(err) => {
+                // The exit owns heap references (call args, an OS effect not
+                // yet armed); no host resume will consume them now.
+                exit.drop_with(vm);
+                Err(err.into())
+            }
+        },
+        result => result,
+    };
     match result {
         Ok(FrameExit::Return(value)) => ConvertedExit::Complete(MontyObject::new(value, vm)),
         Ok(FrameExit::ExternalCall {

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use monty::{MontyRepl, MontyRun, RunProgress};
+use monty::{Dump, MontyRepl, MontyRun, ReplProgress, RunProgress, Session, SessionRef, dump};
 use monty_types::{
     CompileOptions, ExcType, MontyException, MontyObject, NameLookupResult, PrintWriter, ResourceLimits,
     ResourceTracker,
@@ -1267,4 +1267,147 @@ fn timeout_in_itertools_adaptor_loops() {
     for expr in ITERTOOLS_INFINITE_LOOPS {
         assert_timeout_in_builtin(&format!("import itertools\n{expr}"), expr);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Suspension limits
+// ---------------------------------------------------------------------------
+//
+// A suspension costs the *host* — a round trip and whatever state it retains
+// per call — while costing the sandbox nothing it allocates and no execution
+// time (the clock is paused while suspended). These tests pin the budget that
+// bounds it, since no other limit can see the growth.
+
+/// Drives a REPL feed to completion, answering suspensions the cheapest way:
+/// unresolved names become external functions, calls return `None`. Yields the
+/// recovered session, the feed's outcome, and how many suspensions the host
+/// was asked to answer.
+fn drive_feed(repl: MontyRepl, code: &str) -> (MontyRepl, Result<MontyObject, MontyException>, usize) {
+    let mut answered = 0;
+    let mut progress = match repl.feed_start(code, vec![], PrintWriter::Stdout) {
+        Ok(progress) => progress,
+        Err(err) => return (err.repl, Err(err.error), answered),
+    };
+    loop {
+        let resumed = match progress {
+            ReplProgress::Complete { repl, value } => return (repl, Ok(value), answered),
+            ReplProgress::NameLookup(lookup) => {
+                answered += 1;
+                let name = lookup.name.clone();
+                lookup.resume(
+                    NameLookupResult::Value(MontyObject::Function { name, docstring: None }),
+                    PrintWriter::Stdout,
+                )
+            }
+            ReplProgress::FunctionCall(call) => {
+                answered += 1;
+                call.resume(MontyObject::None, PrintWriter::Stdout)
+            }
+            other => panic!("unexpected suspension variant: {other:?}"),
+        };
+        progress = match resumed {
+            Ok(progress) => progress,
+            Err(err) => return (err.repl, Err(err.error), answered),
+        };
+    }
+}
+
+/// A loop that suspends forever is stopped by the per-run budget, and the
+/// refusal happens *before* the host is asked, so the host answers exactly the
+/// budgeted number of suspensions and no more.
+#[test]
+fn per_run_suspension_limit_stops_an_endless_host_call_loop() {
+    let limits = ResourceLimits::default().max_suspensions_per_run(8);
+    let repl = MontyRepl::new("test.py", ResourceTracker::new(limits), CompileOptions::default());
+    let (repl, result, answered) = drive_feed(repl, "while True:\n    interrupt()");
+    let exc = result.expect_err("the endless loop must exhaust the suspension budget");
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_eq!(
+        exc.message(),
+        Some("suspension limit exceeded: 9 > 8 (max_suspensions_per_run)")
+    );
+    assert_eq!(answered, 8);
+    assert_eq!(repl.tracker().run_suspensions(), 9);
+}
+
+/// The budget is per *run*, so a session that suspends heavily but finishes
+/// each feed keeps working — the counter is zeroed by the next feed.
+#[test]
+fn per_run_suspension_budget_resets_between_feeds() {
+    let limits = ResourceLimits::default().max_suspensions_per_run(3);
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::new(limits), CompileOptions::default());
+    // Each feed spends exactly the per-run budget, three times over.
+    let code = "interrupt()\ninterrupt()\ninterrupt()";
+    for _ in 0..3 {
+        let (next, result, answered) = drive_feed(repl, code);
+        result.expect("a feed within budget must complete");
+        assert_eq!(answered, 3);
+        repl = next;
+    }
+    assert_eq!(repl.tracker().total_suspensions(), 9);
+}
+
+/// `max_total_suspensions` is the opt-in cumulative cap: it bites across feeds
+/// that each stay under the per-run budget, which the per-run limit cannot.
+#[test]
+fn total_suspension_limit_spans_feeds() {
+    let limits = ResourceLimits::default().max_total_suspensions(3);
+    let repl = MontyRepl::new("test.py", ResourceTracker::new(limits), CompileOptions::default());
+    // Two calls per feed: each feed sits far inside the per-run default, but
+    // the pair crosses the cumulative cap the per-run budget cannot see.
+    let (repl, result, _) = drive_feed(repl, "interrupt()\ninterrupt()");
+    result.expect("first feed is within the cumulative cap");
+    let (repl, result, _) = drive_feed(repl, "interrupt()\ninterrupt()");
+    let exc = result.expect_err("the cumulative cap must fire on the second feed");
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_eq!(
+        exc.message(),
+        Some("suspension limit exceeded: 4 > 3 (max_total_suspensions)")
+    );
+    assert_eq!(repl.tracker().total_suspensions(), 4);
+}
+
+/// The refusal is uncatchable: the issue's shape wraps every call in
+/// `except Exception`, and a catchable error there would let the loop spin on.
+#[test]
+fn suspension_limit_is_not_catchable_by_sandboxed_code() {
+    let limits = ResourceLimits::default().max_suspensions_per_run(6);
+    let repl = MontyRepl::new("test.py", ResourceTracker::new(limits), CompileOptions::default());
+    let code = "while True:\n    try:\n        interrupt()\n    except Exception:\n        pass";
+    let (_, result, answered) = drive_feed(repl, code);
+    let exc = result.expect_err("a bare except must not swallow the budget refusal");
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_eq!(answered, 6);
+}
+
+/// A session can be dumped *while suspended*, so both counters travel in the
+/// dump. If they did not, a host that snapshots at every suspension would hand
+/// the sandbox a fresh budget on every resume — exactly the loop the limit
+/// exists to stop.
+#[test]
+fn suspension_counters_survive_a_dump_taken_while_suspended() {
+    let limits = ResourceLimits::default().max_suspensions_per_run(2);
+    let repl = MontyRepl::new("test.py", ResourceTracker::new(limits), CompileOptions::default());
+    let progress = repl
+        .feed_start("interrupt()\ninterrupt()\ninterrupt()", vec![], PrintWriter::Stdout)
+        .unwrap();
+    let call = progress.into_function_call().expect("first interrupt call");
+    let progress = call.resume(MontyObject::None, PrintWriter::Stdout).unwrap();
+
+    let bytes = dump("test.py", None, SessionRef::Suspended(&progress)).unwrap();
+    let Session::Suspended(loaded) = Dump::load(&bytes).unwrap().state else {
+        panic!("dumped a suspended session, loaded something else");
+    };
+
+    // Two suspensions are already spent, so resuming the second call must be
+    // refused rather than granted a third.
+    let call = loaded.into_function_call().expect("second interrupt call");
+    let err = call
+        .resume(MontyObject::None, PrintWriter::Stdout)
+        .expect_err("the restored session must resume with its budget already spent");
+    assert_eq!(err.error.exc_type(), ExcType::RuntimeError);
+    assert_eq!(
+        err.error.message(),
+        Some("suspension limit exceeded: 3 > 2 (max_suspensions_per_run)")
+    );
 }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1411,3 +1411,20 @@ fn suspension_counters_survive_a_dump_taken_while_suspended() {
         Some("suspension limit exceeded: 3 > 2 (max_suspensions_per_run)")
     );
 }
+
+/// `MontyRepl::call_function` resolves suspensions itself — it turns each one
+/// into an in-sandbox error rather than announcing it — so none of them cost
+/// the host a round trip and none may be charged to the budget.
+#[test]
+fn call_function_spends_no_suspension_budget() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("def attempt():\n    return missing()", vec![], PrintWriter::Stdout)
+        .unwrap();
+
+    let exc = repl
+        .call_function("attempt", vec![], PrintWriter::Stdout)
+        .expect_err("an unresolved name cannot be answered inside call_function");
+    assert_eq!(exc.exc_type(), ExcType::NotImplementedError);
+    assert_eq!(repl.tracker().run_suspensions(), 0);
+    assert_eq!(repl.tracker().total_suspensions(), 0);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,8 @@ hello world
 | `--max-duration` | Maximum execution time in seconds, e.g. `0.5` |
 | `--max-memory` | Maximum heap memory, e.g. `1024`, `512KB`, `10MB`, `1GB` |
 | `--max-recursion-depth` | Maximum call-stack depth; defaults to 1000 when any limit is set |
+| `--max-suspensions-per-run` | Maximum host round trips in one run; defaults to 10,000 |
+| `--max-total-suspensions` | Maximum host round trips for the whole session |
 | `--gc-interval` | Run garbage collection every N allocations |
 | `--version` | Print the version |
 

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -21,23 +21,26 @@ with Monty() as pool:
             #> MemoryError
 ```
 
-## The four settings
+## The six settings
 
 | Key | Meaning |
 | --- | --- |
 | `max_memory` | Maximum heap memory in bytes |
 | `max_duration_secs` | Maximum cumulative execution time in seconds |
 | `max_recursion_depth` | Maximum function call stack depth (default 1000) |
+| `max_suspensions_per_run` | Maximum host round trips in one run (default 10,000) |
+| `max_total_suspensions` | Maximum host round trips for the whole session |
 | `gc_interval` | Run garbage collection every N allocations |
 
 Every key is optional.
-Omit `max_memory` or `max_duration_secs`, or set them to `None`, to disable that limit.
-`max_recursion_depth` cannot be disabled: omitting it, or passing `None`, leaves the 1000-frame default.
+Omit `max_memory`, `max_duration_secs` or `max_total_suspensions`, or set them to `None`, to disable that limit.
+`max_recursion_depth` and `max_suspensions_per_run` cannot be disabled: omitting either, or passing `None`, leaves its
+default.
 `gc_interval` omitted or `None` uses the built-in schedule of every 100,000 allocations; collection cannot be turned
 off.
 
-In JavaScript the same fields are `maxMemory`, `maxDurationSecs`, `maxRecursionDepth` and `gcInterval`, passed as
-`limits` to `pool.checkout()`.
+In JavaScript the same fields are `maxMemory`, `maxDurationSecs`, `maxRecursionDepth`, `maxSuspensionsPerRun`,
+`maxTotalSuspensions` and `gcInterval`, passed as `limits` to `pool.checkout()`.
 In Rust they are the fields of `monty_types::ResourceLimits`, where the duration is a `Duration` named `max_duration`.
 
 ## Memory
@@ -87,6 +90,25 @@ Two host-side backstops cover that:
 
 Set `max_duration_secs` for untrusted code that may suspend repeatedly; `request_timeout` alone does not bound the
 overall call.
+
+## Suspensions
+
+Every host function call, unresolved name lookup and `os` callback suspends the sandbox and hands the host a round
+trip, which the host retains state for.
+That growth is invisible to the other limits: the sandbox allocates nothing, and the execution clock is paused while
+suspended, so a loop that suspends and swallows the result makes no progress the memory or time budgets can see.
+
+`max_suspensions_per_run` bounds it, defaulting to **10,000** per run — one `feed_run` and every resume that continues
+it.
+Exceeding it ends the run with an uncatchable `RuntimeError` naming the limit; the over-budget suspension is refused
+before the host is asked, so it never costs the round trip.
+
+`max_total_suspensions` is the optional cumulative cap across the whole session.
+It is unset by default, so only each run is bounded.
+Set it to stop code sidestepping the per-run budget by feeding repeatedly.
+
+Both counters are serialized into [snapshots](snapshots.md), so restoring a session suspended mid-run does not hand it
+a fresh budget.
 
 ## Recursion
 

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -110,6 +110,9 @@ Set it to stop code sidestepping the per-run budget by feeding repeatedly.
 Both counters are serialized into [snapshots](snapshots.md), so restoring a session suspended mid-run does not hand it
 a fresh budget.
 
+Exhausting the per-run budget does not end the session: the next `feed_run` starts a fresh one.
+Exhausting `max_total_suspensions` does, since nothing resets it.
+
 ## Recursion
 
 Python-level call depth defaults to **1000 frames**; the 1001st nested call raises `RecursionError`.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -1,9 +1,10 @@
 # Resource limits
 
-Monty enforces limits on memory, time, and recursion to keep untrusted code
-bounded. Memory limits surface to the host as `MemoryError`s and time limits as
-`TimeoutError`s; sandboxed code cannot catch either resource error.
-`RecursionError` is catchable, as in CPython.
+Monty enforces limits on memory, time, recursion, and host suspensions to keep
+untrusted code bounded. Memory limits surface to the host as `MemoryError`s,
+time limits as `TimeoutError`s, and suspension limits as `RuntimeError`s;
+sandboxed code cannot catch any of those three. `RecursionError` is catchable,
+as in CPython.
 
 ## Compilation
 
@@ -178,6 +179,25 @@ indistinguishable from a stack overflow.
   session resumes its budget where it left off rather than restarting
   from zero.
 - There is no in-sandbox way to observe the budget or remaining time.
+
+## Suspensions
+
+CPython has no equivalent: there is nothing to suspend to.
+
+- `max_suspensions_per_run` bounds how many times a run may suspend to the
+  host — external function calls, unresolved name lookups, and OS callbacks
+  all count. It defaults to 10,000 and cannot be disabled; a run is one feed
+  and every resume that continues it.
+- `max_total_suspensions` is an optional cumulative cap across the session,
+  unset by default.
+- Exhausting either raises an **uncatchable** `RuntimeError` reading
+  `suspension limit exceeded: {count} > {limit} ({limit name})`. Unlike
+  `RecursionError`, a bare `except Exception` cannot swallow it.
+- The over-budget suspension is refused before the host is told about it, so
+  the host answers exactly the budgeted number of suspensions.
+- Both counters are serialized into dumps, including dumps taken mid-run, so a
+  restored session does not resume with a fresh budget.
+- There is no in-sandbox way to observe either budget or what remains of it.
 
 ## JSON
 

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -216,3 +216,9 @@ can receive another feed, but execution is not transactional and no guarantees
 are made about heap state or reference counts. Hosts should discard the session;
 the worker itself remains reusable. A caught `RecursionError` may continue
 normally inside the sandbox.
+
+A suspension refusal lands at a turn boundary rather than mid-operation, so
+heap state and reference counts are sound and the session need not be
+discarded. `max_suspensions_per_run` is spent only for the run that hit it —
+the next feed starts a fresh budget — while `max_total_suspensions` stays
+exhausted for the life of the session.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -193,8 +193,13 @@ CPython has no equivalent: there is nothing to suspend to.
 - Exhausting either raises an **uncatchable** `RuntimeError` reading
   `suspension limit exceeded: {count} > {limit} ({limit name})`. Unlike
   `RecursionError`, a bare `except Exception` cannot swallow it.
+- Memory and time limits surface as `MemoryError` and `TimeoutError`, which a
+  host can branch on by type. Suspensions have no Python name to borrow, so
+  the message is the only thing that identifies them.
 - The over-budget suspension is refused before the host is told about it, so
-  the host answers exactly the budgeted number of suspensions.
+  the host answers exactly the budgeted number of suspensions. Suspensions a
+  caller resolves itself rather than announcing — `MontyRepl::call_function`
+  turns each into an in-sandbox error — cost nothing.
 - Both counters are serialized into dumps, including dumps taken mid-run, so a
   restored session does not resume with a fresh budget.
 - There is no in-sandbox way to observe either budget or what remains of it.


### PR DESCRIPTION
Closes #736 by adding a suspension budget to `ResourceLimits` — `max_suspensions_per_run` (always on, default 10,000) and the opt-in cumulative `max_total_suspensions` — charged in `convert_frame_exit` before an over-budget suspension is announced, so a sandbox loop that repeatedly suspends and swallows the result can no longer grow the host's retained state without bound.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a suspension budget to `ResourceLimits` so sandboxed code that repeatedly suspends to the host can no longer grow host-retained state without bound (fixes #736). `max_suspensions_per_run` is always on (default 10,000) and `max_total_suspensions` is an opt-in cumulative cap across the session.

**Behavior**
- Each suspension is charged in `convert_frame_exit` before the over-budget one is announced, so the host never pays for a refused round trip.
- Exceeding either limit ends the run with an uncatchable `RuntimeError` naming the limit.
- The per-run counter resets at each feed; the total counter never resets.
- Both counters are serialized into dumps so a restored session resumes with its budget spent.

<sup>Written for commit 0b240a326e80610e6a48f40740552c00b415a878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

