### PR TITLE
Add `max_suspensions` to `ResourceLimits`, enforced by the host via `AbortFeed`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -961,7 +961,7 @@ where they are. Change one and you must change all of them:
 
 - **The importable stdlib module list** — `limitations/modules.md` (authoritative),
   `docs/python-subset.md`, `docs/index.md`, `README.md`.
-- **Default resource limits** (1000 recursion frames, 100 MB per-mount memory, 10 MiB
+- **Default resource limits** (1000 recursion frames, 1000 suspensions, 100 MB per-mount memory, 10 MiB
   print collectors, 1s duration grace) — `limitations/resource_limits.md`,
   `docs/resource-limits.md`, and the binding docstrings.
 - **Mount modes and their defaults** — `limitations/filesystem.md`, `docs/filesystem.md`,

--- a/crates/monty-bench/benches/decode.rs
+++ b/crates/monty-bench/benches/decode.rs
@@ -40,6 +40,7 @@ fn complete_frame(value: MontyObject) -> Vec<u8> {
     let event = pb::ChildEvent {
         total_execution_micros: 0,
         max_duration_micros: None,
+        max_suspensions: None,
         restored_script_name: None,
         kind: Some(pb::child_event::Kind::Complete(pb::Complete {
             value: Some(WireObject(Some(value))),

--- a/crates/monty-bench/benches/pool.rs
+++ b/crates/monty-bench/benches/pool.rs
@@ -23,10 +23,7 @@ use monty_pool::{Checkout, Pool, PoolConfig, PrintFuture, ReplConfig, ResumeValu
 use monty_types::{MontyObject, PrintStream};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
-use tokio::{
-    runtime::{Builder, Runtime},
-    sync::Mutex,
-};
+use tokio::runtime::{Builder, Runtime};
 
 /// Locates (building once if needed) the `monty` CLI binary the workers run.
 /// Mirrors the resolution used by `monty-pool`'s integration tests: honour
@@ -150,24 +147,23 @@ for i in range(1000):
 ";
 
 /// Wire-protocol throughput: 1,000 external-call round trips over the framed
-/// protobuf channel on a single warm session. Reuses the session across
-/// iterations so only the messaging cost is measured, not checkout.
+/// protobuf channel on a warm session. The suspension budget is per checkout,
+/// so each iteration checks out its own session; that handshake is a fixed
+/// cost `session_checkout_run` measures alone.
 fn ext_calls_1000(bench: &mut Bencher) {
     let runtime = runtime();
     let pool = runtime
         .block_on(Pool::new(PoolConfig::subprocess(monty_binary())))
         .unwrap();
-    let session = runtime.block_on(pool.checkout(&ReplConfig::default())).unwrap();
-    let session = Mutex::new(session);
     bench.to_async(&runtime).iter(|| async {
-        let mut session = session.lock().await;
+        let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
         let event = session
             .feed(EXT_CALL_LOOP, vec![], vec![], false, &mut no_print)
             .await
             .unwrap();
         black_box(drive_answering_calls(&mut session, event).await);
+        session.finish().await.unwrap();
     });
-    runtime.block_on(session.into_inner().finish()).unwrap();
 }
 
 /// Sums `amount * quantity` over every row of every external-call result —
@@ -223,11 +219,10 @@ fn ext_call_rows(bench: &mut Bencher) {
     let pool = runtime
         .block_on(Pool::new(PoolConfig::subprocess(monty_binary())))
         .unwrap();
-    let session = runtime.block_on(pool.checkout(&ReplConfig::default())).unwrap();
-    let session = Mutex::new(session);
 
+    // A fresh checkout per iteration, as in `ext_calls_1000`.
     bench.to_async(&runtime).iter(|| async {
-        let mut session = session.lock().await;
+        let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
         let mut event = session
             .feed(EXT_ROWS_LOOP, vec![], vec![], false, &mut no_print)
             .await
@@ -246,8 +241,8 @@ fn ext_call_rows(bench: &mut Bencher) {
         };
         assert_eq!(value, expected);
         black_box(value);
+        session.finish().await.unwrap();
     });
-    runtime.block_on(session.into_inner().finish()).unwrap();
 }
 
 /// Configures the pool benchmarks.

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -399,6 +399,11 @@ remaining budget expires, covering cases where the in-sandbox limit cannot
 fire (its check only runs at interpreter checkpoints). Set
 `durationLimitGrace: null` to disable it.
 
+`maxSuspensions` is enforced by the pool rather than the sandbox: it counts
+the host round trips (external functions, `os` callbacks, name lookups) it
+services per checkout, and the one past the budget ends the feed with an
+uncatchable `RuntimeError`.
+
 ## Assert message annotations
 
 Failed `assert` statements carry a pytest-style introspected message by

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -399,8 +399,9 @@ remaining budget expires, covering cases where the in-sandbox limit cannot
 fire (its check only runs at interpreter checkpoints). Set
 `durationLimitGrace: null` to disable it.
 
-`maxSuspensions` limits the host round trips the pool services per checkout.
-Exceeding it ends the feed with an uncatchable `RuntimeError`.
+`maxSuspensions` limits the host round trips the pool services per checkout
+(default 1000; it cannot be disabled). Exceeding it ends the feed with an
+uncatchable `RuntimeError`.
 
 ## Assert message annotations
 

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -399,10 +399,8 @@ remaining budget expires, covering cases where the in-sandbox limit cannot
 fire (its check only runs at interpreter checkpoints). Set
 `durationLimitGrace: null` to disable it.
 
-`maxSuspensions` is enforced by the pool rather than the sandbox: it counts
-the host round trips (external functions, `os` callbacks, name lookups) it
-services per checkout, and the one past the budget ends the feed with an
-uncatchable `RuntimeError`.
+`maxSuspensions` limits the host round trips the pool services per checkout.
+Exceeding it ends the feed with an uncatchable `RuntimeError`.
 
 ## Assert message annotations
 

--- a/crates/monty-js/__test__/limits.spec.ts
+++ b/crates/monty-js/__test__/limits.spec.ts
@@ -163,3 +163,19 @@ test('suspension limit leaves the session usable', async () => {
   t.is(error.display('msg'), 'suspension limit exceeded: 2 > 1')
   t.is(await session.feedRun('1 + 1'), 2)
 })
+
+test('restored session keeps its suspension limit with a fresh count', async () => {
+  const fetch = () => 'ok'
+  let state: Buffer
+  {
+    await using session = await pool().checkout({ limits: { maxSuspensions: 1 } })
+    t.is(await session.feedRun("fetch('x')", { externalLookup: { fetch } }), 'ok')
+    state = await session.dump()
+  }
+
+  await using restored = await pool().checkout()
+  await restored.loadSession(state)
+  t.is(await restored.feedRun("fetch('y')", { externalLookup: { fetch } }), 'ok')
+  const error = await t.throwsAsync(() => restored.feedRun("fetch('z')", { externalLookup: { fetch } }), isRuntimeError)
+  t.is(error.display('msg'), 'suspension limit exceeded: 2 > 1')
+})

--- a/crates/monty-js/__test__/limits.spec.ts
+++ b/crates/monty-js/__test__/limits.spec.ts
@@ -5,7 +5,7 @@ import { kind } from './env.js'
 import { MontyRuntimeError, type ResourceLimits } from '@pydantic/monty'
 import { setupPool } from './helpers.js'
 
-const { run } = setupPool()
+const { run, pool } = setupPool()
 
 const isRuntimeError = { instanceOf: MontyRuntimeError }
 
@@ -19,6 +19,7 @@ test('resource limits custom', async () => {
     maxMemory: 64 * 1024,
     gcInterval: 10,
     maxRecursionDepth: 500,
+    maxSuspensions: 20,
   }
   // Just verify the object is valid and can be passed
   t.is(await run('1 + 1', { limits }), 2)
@@ -126,4 +127,39 @@ test('time limit', async () => {
   t.is(error.exception.typeName, 'TimeoutError')
   // The reported elapsed time varies from run to run; the limit is fixed.
   t.regex(error.display('msg'), /^time limit exceeded: \d+(\.\d+)?ms > 100ms$/)
+})
+
+// =============================================================================
+// Suspension limit tests
+// =============================================================================
+
+test('suspension limit', async () => {
+  // `maxSuspensions` is enforced by the pool: the suspension past the budget
+  // ends the feed with an uncatchable RuntimeError, so the retry loop dies
+  const code = `
+n = 0
+while True:
+    try:
+        fetch('x')
+    except Exception:
+        n += 1
+`
+  const fetch = () => {
+    throw new Error('refused')
+  }
+  const error = await t.throwsAsync(
+    () => run(code, { limits: { maxSuspensions: 3 }, externalLookup: { fetch } }),
+    isRuntimeError,
+  )
+  t.is(error.exception.typeName, 'RuntimeError')
+  t.is(error.display('msg'), 'suspension limit exceeded: 4 > 3')
+})
+
+test('suspension limit leaves the session usable', async () => {
+  await using session = await pool().checkout({ limits: { maxSuspensions: 1 } })
+  const fetch = () => 'ok'
+  t.is(await session.feedRun("fetch('x')", { externalLookup: { fetch } }), 'ok')
+  const error = await t.throwsAsync(() => session.feedRun("fetch('y')", { externalLookup: { fetch } }), isRuntimeError)
+  t.is(error.display('msg'), 'suspension limit exceeded: 2 > 1')
+  t.is(await session.feedRun('1 + 1'), 2)
 })

--- a/crates/monty-js/__test__/limits.spec.ts
+++ b/crates/monty-js/__test__/limits.spec.ts
@@ -134,8 +134,7 @@ test('time limit', async () => {
 // =============================================================================
 
 test('suspension limit', async () => {
-  // `maxSuspensions` is enforced by the pool: the suspension past the budget
-  // ends the feed with an uncatchable RuntimeError, so the retry loop dies
+  // Pool enforcement keeps sandboxed exception handling from retrying forever.
   const code = `
 n = 0
 while True:

--- a/crates/monty-js/__test__/limits.spec.ts
+++ b/crates/monty-js/__test__/limits.spec.ts
@@ -3,6 +3,7 @@ import { assertMemoryError, t } from './assertions.js'
 import { kind } from './env.js'
 
 import { MontyRuntimeError, type ResourceLimits } from '@pydantic/monty'
+import { WorkerTransport } from '../ts/worker/transport.js'
 import { setupPool } from './helpers.js'
 
 const { run, pool } = setupPool()
@@ -171,6 +172,33 @@ test('suspension limit leaves the session usable', async () => {
   const error = await t.throwsAsync(() => session.feedRun("fetch('y')", { externalLookup: { fetch } }), isRuntimeError)
   t.is(error.display('msg'), 'suspension limit 1 exceeded')
   t.is(await session.feedRun('1 + 1'), 2)
+})
+
+test('a suspension answering abort-feed ends the wasm worker', async () => {
+  // A compromised component could answer the abort with another suspension;
+  // servicing it would let it call host functions past the budget.
+  const call = (callId: number) => ({
+    tag: 'function-call' as const,
+    val: { callId, functionName: 'fetch', args: [], kwargs: [] },
+  })
+  const requests: string[] = []
+  const transport = await WorkerTransport.create(async (request) => {
+    requests.push(request.tag)
+    return request.tag === 'configure'
+      ? { status: 'continue', events: [{ tag: 'ok' }], maxSuspensions: 1n }
+      : { status: 'continue', events: [call(requests.length)] }
+  })
+  let reusable: boolean | undefined
+  transport.onFinish = (value) => {
+    reusable = value
+  }
+  const first = await transport.feed('fetch()', null, [], true, () => {})
+  t.is(first.kind, 'functionCall')
+  const turn = await transport.resumeReturn(null, () => {})
+  t.deepEqual(turn, { kind: 'protocol', message: 'worker answered abort-feed with functionCall' })
+  t.deepEqual(requests, ['configure', 'feed', 'resume-call', 'abort-feed'])
+  await transport.finish()
+  t.is(reusable, false)
 })
 
 test('restored session keeps its suspension limit with a fresh count', async () => {

--- a/crates/monty-js/__test__/limits.spec.ts
+++ b/crates/monty-js/__test__/limits.spec.ts
@@ -151,7 +151,7 @@ while True:
     isRuntimeError,
   )
   t.is(error.exception.typeName, 'RuntimeError')
-  t.is(error.display('msg'), 'suspension limit exceeded: 4 > 3')
+  t.is(error.display('msg'), 'suspension limit 3 exceeded')
 })
 
 test('suspension limit defaults to 1000', async () => {
@@ -160,7 +160,7 @@ test('suspension limit defaults to 1000', async () => {
     () => session.feedRun('n = 0\nwhile True:\n    fetch()\n    n += 1', { externalLookup: { fetch: () => null } }),
     isRuntimeError,
   )
-  t.is(error.display('msg'), 'suspension limit exceeded: 1001 > 1000')
+  t.is(error.display('msg'), 'suspension limit 1000 exceeded')
   t.is(await session.feedRun('n'), 1000)
 })
 
@@ -169,7 +169,7 @@ test('suspension limit leaves the session usable', async () => {
   const fetch = () => 'ok'
   t.is(await session.feedRun("fetch('x')", { externalLookup: { fetch } }), 'ok')
   const error = await t.throwsAsync(() => session.feedRun("fetch('y')", { externalLookup: { fetch } }), isRuntimeError)
-  t.is(error.display('msg'), 'suspension limit exceeded: 2 > 1')
+  t.is(error.display('msg'), 'suspension limit 1 exceeded')
   t.is(await session.feedRun('1 + 1'), 2)
 })
 
@@ -186,5 +186,5 @@ test('restored session keeps its suspension limit with a fresh count', async () 
   await restored.loadSession(state)
   t.is(await restored.feedRun("fetch('y')", { externalLookup: { fetch } }), 'ok')
   const error = await t.throwsAsync(() => restored.feedRun("fetch('z')", { externalLookup: { fetch } }), isRuntimeError)
-  t.is(error.display('msg'), 'suspension limit exceeded: 2 > 1')
+  t.is(error.display('msg'), 'suspension limit 1 exceeded')
 })

--- a/crates/monty-js/__test__/limits.spec.ts
+++ b/crates/monty-js/__test__/limits.spec.ts
@@ -154,6 +154,16 @@ while True:
   t.is(error.display('msg'), 'suspension limit exceeded: 4 > 3')
 })
 
+test('suspension limit defaults to 1000', async () => {
+  await using session = await pool().checkout()
+  const error = await t.throwsAsync(
+    () => session.feedRun('n = 0\nwhile True:\n    fetch()\n    n += 1', { externalLookup: { fetch: () => null } }),
+    isRuntimeError,
+  )
+  t.is(error.display('msg'), 'suspension limit exceeded: 1001 > 1000')
+  t.is(await session.feedRun('n'), 1000)
+})
+
 test('suspension limit leaves the session usable', async () => {
   await using session = await pool().checkout({ limits: { maxSuspensions: 1 } })
   const fetch = () => 'ok'

--- a/crates/monty-js/src/limits.rs
+++ b/crates/monty-js/src/limits.rs
@@ -25,6 +25,8 @@ pub struct JsResourceLimits {
     pub gc_interval: Option<f64>,
     /// Maximum function call stack depth (default: 1000).
     pub max_recursion_depth: Option<f64>,
+    /// Maximum suspensions (host round trips) the pool will service.
+    pub max_suspensions: Option<f64>,
 }
 
 /// Extracts a Rust resource-limit configuration from a JS resource-limit object.
@@ -56,6 +58,9 @@ pub fn extract_limits(js_limits: JsResourceLimits) -> Result<ResourceLimits> {
     }
     if let Some(interval) = js_limits.gc_interval {
         limits = limits.gc_interval(js_number_to_usize(interval, "gcInterval")?);
+    }
+    if let Some(max) = js_limits.max_suspensions {
+        limits = limits.max_suspensions(js_number_to_usize(max, "maxSuspensions")?);
     }
 
     Ok(limits)

--- a/crates/monty-js/src/limits.rs
+++ b/crates/monty-js/src/limits.rs
@@ -11,7 +11,8 @@ use napi_derive::napi;
 
 /// Resource limits configuration from JavaScript.
 ///
-/// All limits are optional. Omit a key to disable that limit.
+/// All limits are optional. Omit a key to disable that limit, except
+/// `maxRecursionDepth` and `maxSuspensions`, which keep their 1000 defaults.
 /// Numeric limits are received as JS `number`s, so the boundary uses `f64`
 /// and validates them before converting into Rust `usize` values.
 #[napi(object, js_name = "ResourceLimits")]
@@ -25,7 +26,7 @@ pub struct JsResourceLimits {
     pub gc_interval: Option<f64>,
     /// Maximum function call stack depth (default: 1000).
     pub max_recursion_depth: Option<f64>,
-    /// Maximum suspensions (host round trips) the pool will service.
+    /// Maximum suspensions (host round trips) the pool will service (default: 1000).
     pub max_suspensions: Option<f64>,
 }
 

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -81,13 +81,16 @@ export interface CheckoutOptions {
 /**
  * Sandbox resource limits. An omitted field means "unlimited", except
  * `maxRecursionDepth`, which falls back to its 1000-frame default and cannot
- * be disabled.
+ * be disabled. `maxSuspensions` is enforced by the pool rather than the
+ * sandbox: the suspension past the budget ends the feed with an uncatchable
+ * `RuntimeError`, and the count is per checkout.
  */
 export interface ResourceLimits {
   maxDurationSecs?: number
   maxMemory?: number
   gcInterval?: number
   maxRecursionDepth?: number
+  maxSuspensions?: number
 }
 
 /**

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -79,11 +79,10 @@ export interface CheckoutOptions {
 }
 
 /**
- * Sandbox resource limits. An omitted field means "unlimited", except
- * `maxRecursionDepth`, which falls back to its 1000-frame default and cannot
- * be disabled. `maxSuspensions` is enforced by the pool rather than the
- * sandbox: the suspension past the budget ends the feed with an uncatchable
- * `RuntimeError`, and the count is per checkout.
+ * Sandbox resource limits. Omitted fields are unlimited except
+ * `maxRecursionDepth`, which retains its 1000-frame default. The pool counts
+ * `maxSuspensions` per checkout and aborts an over-budget feed with an
+ * uncatchable `RuntimeError`.
  */
 export interface ResourceLimits {
   maxDurationSecs?: number

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -80,9 +80,9 @@ export interface CheckoutOptions {
 
 /**
  * Sandbox resource limits. Omitted fields are unlimited except
- * `maxRecursionDepth`, which retains its 1000-frame default. The pool counts
- * `maxSuspensions` per checkout and aborts an over-budget feed with an
- * uncatchable `RuntimeError`.
+ * `maxRecursionDepth` and `maxSuspensions`, which keep their 1000 defaults.
+ * The pool counts `maxSuspensions` per checkout and aborts an over-budget
+ * feed with an uncatchable `RuntimeError`.
  */
 export interface ResourceLimits {
   maxDurationSecs?: number

--- a/crates/monty-js/ts/worker/channel.ts
+++ b/crates/monty-js/ts/worker/channel.ts
@@ -81,7 +81,7 @@ export class WorkerChannel implements PooledWorker {
     if (!pending) return
     this.pending.delete(reply.id)
     if (pending.timer) clearTimeout(pending.timer)
-    pending.resolve({ status: reply.status, events: reply.events })
+    pending.resolve({ status: reply.status, events: reply.events, maxSuspensions: reply.maxSuspensions })
   }
 
   private onTimeout(): void {

--- a/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
+++ b/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
@@ -247,6 +247,7 @@ export interface ResourceLimits {
   maxMemoryBytes?: bigint
   gcInterval?: bigint
   maxRecursionDepth?: bigint
+  maxSuspensions?: bigint
 }
 /**
  * # Variants
@@ -348,6 +349,7 @@ export type Request =
   | RequestResumeCall
   | RequestResumeNameLookup
   | RequestResumeFutures
+  | RequestAbortFeed
   | RequestDump
   | RequestLoad
   | RequestReset
@@ -370,6 +372,10 @@ export interface RequestResumeNameLookup {
 export interface RequestResumeFutures {
   tag: 'resume-futures'
   val: Array<FutureResult>
+}
+export interface RequestAbortFeed {
+  tag: 'abort-feed'
+  val: RaisedError
 }
 export interface RequestDump {
   tag: 'dump'

--- a/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
+++ b/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
@@ -488,4 +488,5 @@ export interface EventShutdown {
 export interface DispatchResult {
   status: Status
   events: Array<Event>
+  maxSuspensions?: bigint
 }

--- a/crates/monty-js/ts/worker/serve.ts
+++ b/crates/monty-js/ts/worker/serve.ts
@@ -20,7 +20,7 @@ export async function serveDispatch(
 ): Promise<void> {
   const host = await WasmHost.create(modules)
   subscribe((request) => {
-    const { status, events } = host.dispatch(request.request)
-    post({ id: request.id, status, events })
+    const result = host.dispatch(request.request)
+    post({ id: request.id, ...result })
   })
 }

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -26,11 +26,7 @@ import { decodeValue, encodeValue } from './value.js'
 
 type OnPrint = (stream: 'stdout' | 'stderr', text: string) => void
 
-/**
- * Resource limits, mirroring the napi pool's. All but `maxSuspensions` are
- * enforced inside the worker; that one the transport enforces itself by
- * counting the suspensions it services.
- */
+/** Resource limits mirrored from the napi pool; the transport enforces `maxSuspensions`. */
 export interface ResourceLimits {
   maxDurationSecs?: number
   maxMemory?: number
@@ -68,7 +64,6 @@ export class WorkerTransport {
   /** Whether a crash or channel error made this worker unreusable. */
   private dead = false
 
-  /** `maxSuspensions`, and how many suspensions this session has produced. */
   private suspensionLimit: bigint | undefined
   private suspensionsSeen = 0n
 
@@ -264,8 +259,7 @@ export class WorkerTransport {
   private async enforceSuspensionLimit(turn: NativeTurn, onPrint: OnPrint): Promise<NativeTurn> {
     if (isSuspension(turn)) {
       this.suspensionsSeen += 1n
-      // the suspension past `maxSuspensions` is never handed out: the feed is
-      // ended in the sandbox with an uncatchable RuntimeError, as monty-pool does
+      // Abort instead of exposing an over-budget suspension to the host.
       if (this.suspensionLimit !== undefined && this.suspensionsSeen > this.suspensionLimit) {
         const message = `suspension limit exceeded: ${this.suspensionsSeen} > ${this.suspensionLimit}`
         const aborted = await this.run({ tag: 'abort-feed', val: { excType: 'RuntimeError', message } }, onPrint)
@@ -371,7 +365,7 @@ function encodeLimits(limits: ResourceLimits): ComponentResourceLimits {
   }
 }
 
-/** Whether a turn hands the host a suspension to answer. */
+/** Identifies turns that consume the host-side suspension budget. */
 function isSuspension(turn: NativeTurn): boolean {
   return (
     turn.kind === 'functionCall' ||

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -26,12 +26,17 @@ import { decodeValue, encodeValue } from './value.js'
 
 type OnPrint = (stream: 'stdout' | 'stderr', text: string) => void
 
-/** Resource limits enforced inside the worker, mirroring the napi pool's. */
+/**
+ * Resource limits, mirroring the napi pool's. All but `maxSuspensions` are
+ * enforced inside the worker; that one the transport enforces itself by
+ * counting the suspensions it services.
+ */
 export interface ResourceLimits {
   maxDurationSecs?: number
   maxMemory?: number
   gcInterval?: number
   maxRecursionDepth?: number
+  maxSuspensions?: number
 }
 
 /** Session-creation options sent to the component worker. */
@@ -63,6 +68,10 @@ export class WorkerTransport {
   /** Whether a crash or channel error made this worker unreusable. */
   private dead = false
 
+  /** `maxSuspensions`, and how many suspensions this session has produced. */
+  private suspensionLimit: number | undefined
+  private suspensionsSeen = 0
+
   /** Reports whether the worker can return to its pool when the session ends. */
   onFinish?: (reusable: boolean) => void
 
@@ -71,6 +80,7 @@ export class WorkerTransport {
   /** Creates a configured REPL session over `dispatcher`. */
   static async create(dispatcher: Dispatcher, config: WorkerSessionConfig = {}): Promise<WorkerTransport> {
     const transport = new WorkerTransport(dispatcher)
+    transport.suspensionLimit = config.limits?.maxSuspensions
     const assertMessageAnnotations = encodeAssertMessageAnnotations(config.assertMessageAnnotations)
     await transport.control(
       {
@@ -245,7 +255,17 @@ export class WorkerTransport {
   /** Sends one request and converts its terminating event into a native turn. */
   private async turn(request: ComponentRequest, onPrint: OnPrint): Promise<NativeTurn> {
     const event = await this.run(request, onPrint)
-    const turn = event ? this.toTurn(event) : crashed('worker exited without a turn-ending event')
+    let turn = event ? this.toTurn(event) : crashed('worker exited without a turn-ending event')
+    if (isSuspension(turn)) {
+      this.suspensionsSeen++
+      // the suspension past `maxSuspensions` is never handed out: the feed is
+      // ended in the sandbox with an uncatchable RuntimeError, as monty-pool does
+      if (this.suspensionLimit !== undefined && this.suspensionsSeen > this.suspensionLimit) {
+        const message = `suspension limit exceeded: ${this.suspensionsSeen} > ${this.suspensionLimit}`
+        const aborted = await this.run({ tag: 'abort-feed', val: { excType: 'RuntimeError', message } }, onPrint)
+        turn = aborted ? this.toTurn(aborted) : crashed('worker exited without a turn-ending event')
+      }
+    }
     if (turn.kind === 'crashed') this.dead = true
     return turn
   }
@@ -337,7 +357,18 @@ function encodeLimits(limits: ResourceLimits): ComponentResourceLimits {
     ...(limits.maxMemory === undefined ? {} : { maxMemoryBytes: BigInt(limits.maxMemory) }),
     ...(limits.gcInterval === undefined ? {} : { gcInterval: BigInt(limits.gcInterval) }),
     ...(limits.maxRecursionDepth === undefined ? {} : { maxRecursionDepth: BigInt(limits.maxRecursionDepth) }),
+    ...(limits.maxSuspensions === undefined ? {} : { maxSuspensions: BigInt(limits.maxSuspensions) }),
   }
+}
+
+/** Whether a turn hands the host a suspension to answer. */
+function isSuspension(turn: NativeTurn): boolean {
+  return (
+    turn.kind === 'functionCall' ||
+    turn.kind === 'osCall' ||
+    turn.kind === 'nameLookup' ||
+    turn.kind === 'resolveFutures'
+  )
 }
 
 /** Converts a host return value, turning conversion failures into Python `TypeError`. */

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -262,6 +262,13 @@ export class WorkerTransport {
         const message = `suspension limit ${this.suspensionLimit} exceeded`
         const aborted = await this.run({ tag: 'abort-feed', val: { excType: 'RuntimeError', message } }, onPrint)
         turn = aborted ? this.toTurn(aborted) : crashed('worker exited without a turn-ending event')
+        // the component answers an abort with an error, never a suspension;
+        // servicing one would let a compromised worker call the host past
+        // the budget, so it ends the worker instead
+        if (turn.kind !== 'error' && turn.kind !== 'crashed') {
+          this.dead = true
+          turn = { kind: 'protocol', message: `worker answered abort-feed with ${turn.kind}` }
+        }
       }
     }
     if (turn.kind === 'crashed') this.dead = true

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -259,7 +259,7 @@ export class WorkerTransport {
       this.suspensionsSeen += 1n
       // Abort instead of exposing an over-budget suspension to the host.
       if (this.suspensionLimit !== undefined && this.suspensionsSeen > this.suspensionLimit) {
-        const message = `suspension limit exceeded: ${this.suspensionsSeen} > ${this.suspensionLimit}`
+        const message = `suspension limit ${this.suspensionLimit} exceeded`
         const aborted = await this.run({ tag: 'abort-feed', val: { excType: 'RuntimeError', message } }, onPrint)
         turn = aborted ? this.toTurn(aborted) : crashed('worker exited without a turn-ending event')
       }

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -69,8 +69,8 @@ export class WorkerTransport {
   private dead = false
 
   /** `maxSuspensions`, and how many suspensions this session has produced. */
-  private suspensionLimit: number | undefined
-  private suspensionsSeen = 0
+  private suspensionLimit: bigint | undefined
+  private suspensionsSeen = 0n
 
   /** Reports whether the worker can return to its pool when the session ends. */
   onFinish?: (reusable: boolean) => void
@@ -80,7 +80,8 @@ export class WorkerTransport {
   /** Creates a configured REPL session over `dispatcher`. */
   static async create(dispatcher: Dispatcher, config: WorkerSessionConfig = {}): Promise<WorkerTransport> {
     const transport = new WorkerTransport(dispatcher)
-    transport.suspensionLimit = config.limits?.maxSuspensions
+    transport.suspensionLimit =
+      config.limits?.maxSuspensions === undefined ? undefined : BigInt(config.limits.maxSuspensions)
     const assertMessageAnnotations = encodeAssertMessageAnnotations(config.assertMessageAnnotations)
     await transport.control(
       {
@@ -229,7 +230,7 @@ export class WorkerTransport {
     }
     const event = await this.run({ tag: 'load', val: state }, onPrint)
     if (!event) return crashed('worker exited without a turn-ending event')
-    return event.tag === 'ok' ? { kind: 'loaded' } : this.toTurn(event)
+    return event.tag === 'ok' ? { kind: 'loaded' } : this.enforceSuspensionLimit(this.toTurn(event), onPrint)
   }
 
   /** Resets a live worker for reuse and disposes a dead worker. */
@@ -255,9 +256,14 @@ export class WorkerTransport {
   /** Sends one request and converts its terminating event into a native turn. */
   private async turn(request: ComponentRequest, onPrint: OnPrint): Promise<NativeTurn> {
     const event = await this.run(request, onPrint)
-    let turn = event ? this.toTurn(event) : crashed('worker exited without a turn-ending event')
+    const turn = event ? this.toTurn(event) : crashed('worker exited without a turn-ending event')
+    return this.enforceSuspensionLimit(turn, onPrint)
+  }
+
+  /** Counts a suspension and aborts the feed when it exceeds the session limit. */
+  private async enforceSuspensionLimit(turn: NativeTurn, onPrint: OnPrint): Promise<NativeTurn> {
     if (isSuspension(turn)) {
-      this.suspensionsSeen++
+      this.suspensionsSeen += 1n
       // the suspension past `maxSuspensions` is never handed out: the feed is
       // ended in the sandbox with an uncatchable RuntimeError, as monty-pool does
       if (this.suspensionLimit !== undefined && this.suspensionsSeen > this.suspensionLimit) {
@@ -284,6 +290,10 @@ export class WorkerTransport {
     try {
       const result = await this.dispatcher(request)
       if (result.status === 'shutdown') this.dead = true
+      if (request.tag === 'load') {
+        this.suspensionLimit = result.maxSuspensions
+        this.suspensionsSeen = 0n
+      }
       events = result.events
     } catch {
       return null

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -75,8 +75,6 @@ export class WorkerTransport {
   /** Creates a configured REPL session over `dispatcher`. */
   static async create(dispatcher: Dispatcher, config: WorkerSessionConfig = {}): Promise<WorkerTransport> {
     const transport = new WorkerTransport(dispatcher)
-    transport.suspensionLimit =
-      config.limits?.maxSuspensions === undefined ? undefined : BigInt(config.limits.maxSuspensions)
     const assertMessageAnnotations = encodeAssertMessageAnnotations(config.assertMessageAnnotations)
     await transport.control(
       {
@@ -284,7 +282,9 @@ export class WorkerTransport {
     try {
       const result = await this.dispatcher(request)
       if (result.status === 'shutdown') this.dead = true
-      if (request.tag === 'load') {
+      // the component reports the limit in force (the configured one, else
+      // the 1000 default; a dump's on load), so it is adopted from the reply
+      if (request.tag === 'configure' || request.tag === 'load') {
         this.suspensionLimit = result.maxSuspensions
         this.suspensionsSeen = 0n
       }

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -80,6 +80,8 @@ and restored later — including on a different worker or machine — with `Chec
   and catching hangs those limits cannot see. Synchronous host telemetry processors delay
   enforcement while they run because the timer cannot be polled. When a session has a `max_duration` budget,
   the deadline also enforces it (plus `duration_limit_grace`) from outside the child.
+  A `max_suspensions` budget is enforced by the pool alone: it counts the suspensions it services
+  and ends the feed past the budget with an uncatchable `RuntimeError` in the sandbox.
   `PoolConfig::subprocess` sets neither `request_timeout` nor `checkout_timeout` by
   default; set `request_timeout` yourself for untrusted code.
 - **Untrusted children** — the parent treats every frame from a (possibly compromised)

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -262,17 +262,9 @@ pub struct Checkout {
     /// Set while a turn's I/O is in flight; still set on the next call only
     /// if the previous turn future was cancelled mid-I/O (see the type docs).
     turn_in_flight: bool,
-    /// The session's `max_duration` budget for the parent-side backstop, when
-    /// configured. Set from the config on `create`; for `restore`d sessions it
-    /// is adopted from the timing fields on the worker's first reply (the limits
-    /// travel inside the opaque dump).
-    duration_budget: Option<Duration>,
-    /// Cumulative sandbox execution time as last reported by the worker —
-    /// the child's clock is the single source of truth (it runs only while
-    /// the interpreter executes, never during suspensions or between feeds,
-    /// and survives dump/load). Monotonic max across turns so a compromised
-    /// worker cannot rewind the parent's view of its consumed budget.
-    reported_execution: Duration,
+    /// The limits this checkout enforces or backstops itself, and what the
+    /// session has consumed of them.
+    budget: SessionBudget,
     /// The deadline armed for the most recent turn, surfaced by
     /// [`PoolError::Timeout`] when it fires.
     armed_deadline: Option<Duration>,
@@ -286,6 +278,112 @@ pub struct Checkout {
     /// Consulted only by [`Checkout::resume_from_mounts`]. Dropped when the
     /// feed ends so overlay writes never leak into the next feed.
     feed_mounts: Option<MountTable>,
+}
+
+/// The parent-side view of a session's resource budget: the `max_duration`
+/// backstop and the `max_suspensions` limit, which the parent alone enforces.
+///
+/// Set from the config on `create`; a `restore`d session forgets that and
+/// re-adopts the limits from the budget fields the worker stamps on its first
+/// reply (they travel inside the opaque dump). The suspension count is parent
+/// state and restarts at zero on restore.
+#[derive(Clone, Copy)]
+struct SessionBudget {
+    /// The session's `max_duration`, when configured.
+    duration_budget: Option<Duration>,
+    /// Cumulative sandbox execution time as last reported by the worker —
+    /// the child's clock is the single source of truth (it runs only while
+    /// the interpreter executes, never during suspensions or between feeds,
+    /// and survives dump/load). Monotonic max across turns so a compromised
+    /// worker cannot rewind the parent's view of its consumed budget.
+    reported_execution: Duration,
+    /// The session's `max_suspensions`, when configured.
+    suspension_limit: Option<u64>,
+    /// Suspensions this checkout has received from the worker.
+    suspensions_seen: u64,
+}
+
+impl SessionBudget {
+    /// The budget a fresh checkout starts with, from its `Configure` limits.
+    fn from_config(repl: &ReplConfig) -> Self {
+        let limits = repl.limits.as_ref();
+        Self {
+            duration_budget: limits.and_then(|limits| limits.max_duration),
+            reported_execution: Duration::ZERO,
+            suspension_limit: limits.and_then(|limits| limits.max_suspensions.map(|max| max as u64)),
+            suspensions_seen: 0,
+        }
+    }
+
+    /// Drops everything `Configure` established, ahead of a `Load` whose reply
+    /// carries the dump's own limits.
+    fn forget(&mut self) {
+        *self = Self {
+            duration_budget: None,
+            reported_execution: Duration::ZERO,
+            suspension_limit: None,
+            suspensions_seen: 0,
+        };
+    }
+
+    /// Adopts the budget fields the worker stamps onto every turn-ending
+    /// event, and counts the event if it is a suspension. The reported time
+    /// only ever ratchets up (a compromised worker can still under-report, but
+    /// each turn stays bounded by `budget + grace`); the limits are adopted only
+    /// when the parent doesn't already know them, i.e. after a restore. Print
+    /// events carry zero timing, so the ratchet makes them a no-op.
+    fn note(&mut self, event: &pb::ChildEvent) {
+        self.reported_execution = self
+            .reported_execution
+            .max(Duration::from_micros(event.total_execution_micros));
+        if self.duration_budget.is_none() {
+            self.duration_budget = event.max_duration_micros.map(Duration::from_micros);
+        }
+        if self.suspension_limit.is_none() {
+            self.suspension_limit = event.max_suspensions;
+        }
+        if is_suspension(event) {
+            self.suspensions_seen += 1;
+        }
+    }
+
+    /// `Some((seen, limit))` when `event` is the suspension that overran the
+    /// budget — the caller aborts the feed instead of surfacing it.
+    fn over_suspension_limit(&self, event: &pb::ChildEvent) -> Option<(u64, u64)> {
+        let limit = self.suspension_limit?;
+        (is_suspension(event) && self.suspensions_seen > limit).then_some((self.suspensions_seen, limit))
+    }
+
+    /// Parent-side kill deadline derived from the session's `max_duration`:
+    /// the execution budget remaining after the time the worker has reported
+    /// consuming so far, plus the configured grace. The child enforces the
+    /// limit itself with a clean `TimeoutError`; this deadline only fires
+    /// when that enforcement fails (e.g. a wedged or compromised child that
+    /// stops checking its clock).
+    fn backstop_deadline(&self, grace: Option<Duration>) -> Option<Duration> {
+        Some(self.duration_budget?.saturating_sub(self.reported_execution) + grace?)
+    }
+}
+
+/// Whether a turn-ending event hands the parent a suspension to answer.
+fn is_suspension(event: &pb::ChildEvent) -> bool {
+    matches!(
+        event.kind,
+        Some(
+            pb::child_event::Kind::FunctionCall(_)
+                | pb::child_event::Kind::OsCall(_)
+                | pb::child_event::Kind::NameLookup(_)
+                | pb::child_event::Kind::ResolveFutures(_)
+        )
+    )
+}
+
+/// The exception a feed is aborted with once it suspends past `max_suspensions`.
+fn suspension_limit_exceeded(seen: u64, limit: u64) -> MontyException {
+    MontyException::new(
+        ExcType::RuntimeError,
+        Some(format!("suspension limit exceeded: {seen} > {limit}")),
+    )
 }
 
 /// Which kind of suspension is awaiting an answer.
@@ -330,8 +428,7 @@ impl Checkout {
             pool,
             pending: None,
             turn_in_flight: false,
-            duration_budget: repl.limits.as_ref().and_then(|limits| limits.max_duration),
-            reported_execution: Duration::ZERO,
+            budget: SessionBudget::from_config(repl),
             armed_deadline: None,
             restored_script_name: None,
             feed_mounts: None,
@@ -362,7 +459,7 @@ impl Checkout {
     /// is that same [`TurnEvent::OsCall`] — restoring never answers it here.
     /// The session's resource budget is taken from the dump, so the prior
     /// `Configure` limits are dropped here and re-adopted from the worker's
-    /// reply.
+    /// reply; the `max_suspensions` count restarts at zero.
     ///
     /// Returns the re-announced suspension (`Some` — a suspended dump) or `None`
     /// (an idle dump), paired with the worker's adopted script name (the dump's,
@@ -378,8 +475,7 @@ impl Checkout {
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
-        self.duration_budget = None;
-        self.reported_execution = Duration::ZERO;
+        self.budget.forget();
         self.restored_script_name = None;
         self.feed_mounts = feed_mounts;
         let request = request(pb::parent_request::Kind::Load(pb::Load { state }));
@@ -739,30 +835,31 @@ impl Checkout {
         }
     }
 
-    /// Parent-side kill deadline derived from the session's `max_duration`:
-    /// the execution budget remaining after the time the worker has reported
-    /// consuming so far, plus the configured grace. The child enforces the
-    /// limit itself with a clean `TimeoutError`; this deadline only fires
-    /// when that enforcement fails (e.g. a wedged or compromised child that
-    /// stops checking its clock).
+    /// The `max_duration` backstop deadline; see [`SessionBudget::backstop_deadline`].
     fn backstop_deadline(&self) -> Option<Duration> {
-        let budget = self.duration_budget?;
-        let grace = self.pool.config.duration_limit_grace?;
-        Some(budget.saturating_sub(self.reported_execution) + grace)
+        self.budget.backstop_deadline(self.pool.config.duration_limit_grace)
     }
 
-    /// Adopts the timing fields the worker stamps onto every turn-ending
-    /// event. The reported total only ever ratchets up — a compromised worker
-    /// must not rewind the parent's view of its consumed budget (it can still
-    /// under-report, but each turn stays bounded by `budget + grace`). The
-    /// budget itself is only adopted when the parent doesn't already know it,
-    /// i.e. after [`Checkout::restore`].
-    fn note_reported_time(&mut self, event: &pb::ChildEvent) {
-        self.reported_execution = self
-            .reported_execution
-            .max(Duration::from_micros(event.total_execution_micros));
-        if self.duration_budget.is_none() {
-            self.duration_budget = event.max_duration_micros.map(Duration::from_micros);
+    /// Records a worker event against the session budget and, when it is the
+    /// suspension past `max_suspensions`, sends `AbortFeed` so the sandbox
+    /// raises the limit uncatchably instead of the caller seeing the
+    /// suspension. Returns `Ok(true)` when the feed was aborted — the caller
+    /// keeps reading for the abort's turn-ender — and `Ok(false)` to handle
+    /// the event as usual.
+    async fn note_event(&mut self, event: &pb::ChildEvent) -> Result<bool, PoolError> {
+        self.budget.note(event);
+        let Some((seen, limit)) = self.budget.over_suspension_limit(event) else {
+            return Ok(false);
+        };
+        let abort = request(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
+            exception: Some((&suspension_limit_exceeded(seen, limit)).into()),
+        }));
+        let Some(worker) = self.worker.as_mut() else {
+            return Err(PoolError::Finished);
+        };
+        match worker.send(&abort).await {
+            Ok(()) => Ok(true),
+            Err(_) => Err(self.poison("aborting a feed").await),
         }
     }
 
@@ -804,9 +901,10 @@ impl Checkout {
     ///
     /// **Bypasses this checkout's suspension bookkeeping** (`pending`,
     /// `feed_mounts`, `restored_script_name`) — never interleave with
-    /// `feed`/`resume`/`restore`. Worker lifecycle, poisoning and the
-    /// `max_duration` backstop work as on the typed path; a raw `Load`
-    /// re-adopts the dump's budget like [`Checkout::restore`]. A `FatalError`
+    /// `feed`/`resume`/`restore`. Worker lifecycle, poisoning, the
+    /// `max_duration` backstop and `max_suspensions` enforcement work as on
+    /// the typed path; a raw `Load` re-adopts the dump's budget like
+    /// [`Checkout::restore`]. A `FatalError`
     /// (or WebSocket `ShutdownDump`) turn-ender is returned so the driver can
     /// forward it, but discards the worker first — later calls report
     /// [`PoolError::Finished`].
@@ -844,13 +942,11 @@ impl Checkout {
             ));
         }
         // As `restore`: forget the Configure-time budget and re-adopt the
-        // dump's from the reply's timing fields. Snapshotted because the
+        // dump's from the reply's budget fields. Snapshotted because the
         // pre-send frame-size rejection leaves the session live.
-        let saved_timing = matches!(request.kind, Some(pb::parent_request::Kind::Load(_)))
-            .then(|| (self.duration_budget, self.reported_execution));
-        if saved_timing.is_some() {
-            self.duration_budget = None;
-            self.reported_execution = Duration::ZERO;
+        let saved_budget = matches!(request.kind, Some(pb::parent_request::Kind::Load(_))).then_some(self.budget);
+        if saved_budget.is_some() {
+            self.budget.forget();
         }
         self.turn_in_flight = true;
         // as `expect_turn`: `request_timeout` alone would drop the `max_duration`
@@ -867,12 +963,11 @@ impl Checkout {
         self.turn_in_flight = false;
         // an error with the worker still alive is the pre-send frame-size
         // rejection: the `Load` never reached the child, put the budget back
-        if let Some((budget, reported)) = saved_timing
+        if let Some(budget) = saved_budget
             && outcome.is_err()
             && self.worker.is_some()
         {
-            self.duration_budget = budget;
-            self.reported_execution = reported;
+            self.budget = budget;
         }
         outcome
     }
@@ -911,7 +1006,9 @@ impl Checkout {
                 }
                 Err(_) => return Err(self.poison("waiting for a reply").await),
             };
-            self.note_reported_time(&event);
+            if self.note_event(&event).await? {
+                continue;
+            }
             // strict alternation: zero or more `Print`s, then exactly one
             // turn-ender — so anything that is not a print ends the turn
             if matches!(event.kind, Some(pb::child_event::Kind::Print(_))) {
@@ -1001,9 +1098,11 @@ impl Checkout {
                 }
                 Err(_) => return Err(self.poison("waiting for a reply").await),
             };
-            // Print events carry no timing (the fields are zero), so this is
-            // a no-op for them thanks to the monotonic-max ratchet.
-            self.note_reported_time(&event);
+            // a suspension past `max_suspensions` is aborted here and never
+            // reaches the caller; the abort's reply is the next event
+            if self.note_event(&event).await? {
+                continue;
+            }
             // Only a `Load` reply carries this; it lets `restore` report the
             // dump's script name without parsing the opaque dump bytes.
             if let Some(name) = &event.restored_script_name {

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -264,6 +264,12 @@ pub struct Checkout {
     turn_in_flight: bool,
     /// Parent-enforced limits and the session's consumption of them.
     budget: SessionBudget,
+    /// The budget in force before an in-flight `Load`, put back by
+    /// [`Checkout::note_event`] unless the child's first reply confirms the
+    /// dump was adopted (an `Ok`, or the re-announced suspension) — so a
+    /// refused `Load` cannot reset the suspension count, and an abort of the
+    /// re-announced suspension does not discard the dump's limit.
+    pending_load_budget: Option<SessionBudget>,
     /// The deadline armed for the most recent turn, surfaced by
     /// [`PoolError::Timeout`] when it fires.
     armed_deadline: Option<Duration>,
@@ -345,9 +351,8 @@ impl SessionBudget {
     }
 
     /// Reports when this event exceeds the suspension limit.
-    fn over_suspension_limit(&self, event: &pb::ChildEvent) -> Option<(u64, u64)> {
-        (is_suspension(event) && self.suspensions_seen > self.suspension_limit)
-            .then_some((self.suspensions_seen, self.suspension_limit))
+    fn over_suspension_limit(&self, event: &pb::ChildEvent) -> Option<u64> {
+        (is_suspension(event) && self.suspensions_seen > self.suspension_limit).then_some(self.suspension_limit)
     }
 
     /// Returns the remaining `max_duration` plus grace.
@@ -355,7 +360,11 @@ impl SessionBudget {
     /// The child normally raises `TimeoutError`; this catches one that stops
     /// checking its clock.
     fn backstop_deadline(&self, grace: Option<Duration>) -> Option<Duration> {
-        Some(self.duration_budget?.saturating_sub(self.reported_execution) + grace?)
+        Some(
+            self.duration_budget?
+                .saturating_sub(self.reported_execution)
+                .saturating_add(grace?),
+        )
     }
 }
 
@@ -373,10 +382,10 @@ fn is_suspension(event: &pb::ChildEvent) -> bool {
 }
 
 /// The exception a feed is aborted with once it suspends past `max_suspensions`.
-fn suspension_limit_exceeded(seen: u64, limit: u64) -> MontyException {
+fn suspension_limit_exceeded(limit: u64) -> MontyException {
     MontyException::new(
         ExcType::RuntimeError,
-        Some(format!("suspension limit exceeded: {seen} > {limit}")),
+        Some(format!("suspension limit {limit} exceeded")),
     )
 }
 
@@ -423,6 +432,7 @@ impl Checkout {
             pending: None,
             turn_in_flight: false,
             budget: SessionBudget::from_config(repl),
+            pending_load_budget: None,
             armed_deadline: None,
             restored_script_name: None,
             feed_mounts: None,
@@ -468,28 +478,22 @@ impl Checkout {
         self.ensure_ready()?;
         let feed_mounts = Self::build_feed_mounts(mounts);
         // the dump carries its own limits/consumed time/script name — forget
-        // what the worker's Configure established and re-adopt from the reply.
-        // Snapshotted so a rejected `Load` (the child already has a session)
-        // cannot reset the suspension count, see `turn_raw`.
+        // what the worker's Configure established and re-adopt from the reply
+        // (see `pending_load_budget` for when the old budget comes back)
         self.pending = None;
-        let saved_budget = self.budget;
-        self.budget.forget();
+        self.begin_load();
         self.restored_script_name = None;
         self.feed_mounts = feed_mounts;
         let request = request(pb::parent_request::Kind::Load(pb::Load { state }));
-        let event = match self
+        let outcome = self
             .request_turn(&request, self.pool.config.request_timeout, on_print)
-            .await
-        {
-            Ok(ControlEvent::Ok) => None,
-            Ok(ControlEvent::Turn(event)) => Some(event),
-            Ok(other @ ControlEvent::Dump(_)) => {
-                self.budget = saved_budget;
+            .await;
+        self.end_load();
+        let event = match outcome? {
+            ControlEvent::Ok => None,
+            ControlEvent::Turn(event) => Some(event),
+            other @ ControlEvent::Dump(_) => {
                 return Err(self.protocol_violation(format!("unexpected reply to Load: {other:?}")));
-            }
-            Err(err) => {
-                self.budget = saved_budget;
-                return Err(err);
             }
         };
         Ok((event, self.restored_script_name.take()))
@@ -843,17 +847,42 @@ impl Checkout {
         self.budget.backstop_deadline(self.pool.config.duration_limit_grace)
     }
 
+    /// Snapshots the budget and forgets it ahead of a `Load`, so the reply can
+    /// re-adopt the dump's.
+    fn begin_load(&mut self) {
+        self.pending_load_budget = Some(self.budget);
+        self.budget.forget();
+    }
+
+    /// Puts the pre-`Load` budget back if no reply ever decided its fate (the
+    /// pre-send frame-size rejection, or a worker that died first).
+    fn end_load(&mut self) {
+        if let Some(budget) = self.pending_load_budget.take() {
+            self.budget = budget;
+        }
+    }
+
     /// Records an event and aborts a suspension past `max_suspensions`.
+    ///
+    /// The first non-`Print` reply to a `Load` settles `pending_load_budget`:
+    /// an `Ok` or the re-announced suspension means the dump was adopted,
+    /// anything else (the child refusing it) keeps the live session's budget.
     ///
     /// Returns `true` after sending `AbortFeed`, so the caller reads its
     /// turn-ender; `false` means to handle the event normally.
     async fn note_event(&mut self, event: &pb::ChildEvent) -> Result<bool, PoolError> {
+        if !matches!(event.kind, Some(pb::child_event::Kind::Print(_)))
+            && let Some(saved) = self.pending_load_budget.take()
+            && !(matches!(event.kind, Some(pb::child_event::Kind::Ok(_))) || is_suspension(event))
+        {
+            self.budget = saved;
+        }
         self.budget.note(event);
-        let Some((seen, limit)) = self.budget.over_suspension_limit(event) else {
+        let Some(limit) = self.budget.over_suspension_limit(event) else {
             return Ok(false);
         };
         let abort = request(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
-            exception: Some((&suspension_limit_exceeded(seen, limit)).into()),
+            exception: Some((&suspension_limit_exceeded(limit)).into()),
         }));
         let Some(worker) = self.worker.as_mut() else {
             return Err(PoolError::Finished);
@@ -942,13 +971,10 @@ impl Checkout {
             ));
         }
         // As `restore`: forget the Configure-time budget and re-adopt the
-        // dump's from the reply's budget fields. Snapshotted because a `Load`
-        // the child does not act on (the pre-send frame-size rejection, or the
-        // child refusing it once a session exists) must not reset the count a
-        // hostile client is trying to escape.
-        let saved_budget = matches!(request.kind, Some(pb::parent_request::Kind::Load(_))).then_some(self.budget);
-        if saved_budget.is_some() {
-            self.budget.forget();
+        // dump's from the reply's budget fields (see `pending_load_budget`).
+        let is_load = matches!(request.kind, Some(pb::parent_request::Kind::Load(_)));
+        if is_load {
+            self.begin_load();
         }
         self.turn_in_flight = true;
         // as `expect_turn`: `request_timeout` alone would drop the `max_duration`
@@ -963,16 +989,8 @@ impl Checkout {
             None => self.turn_io_raw(request, on_event).await,
         };
         self.turn_in_flight = false;
-        // only a reply confirming the dump was adopted (idle: `Ok`, suspended:
-        // the re-announced suspension) carries the dump's budget; anything
-        // else means the session the budget belongs to is still the live one
-        let load_adopted = outcome
-            .as_ref()
-            .is_ok_and(|event| matches!(event.kind, Some(pb::child_event::Kind::Ok(_))) || is_suspension(event));
-        if let Some(budget) = saved_budget
-            && !load_adopted
-        {
-            self.budget = budget;
+        if is_load {
+            self.end_load();
         }
         outcome
     }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -3,6 +3,7 @@
 use std::{
     borrow::Cow,
     future::{Future, ready},
+    mem,
     path::Path,
     pin::Pin,
     process::ExitStatus,
@@ -262,6 +263,10 @@ pub struct Checkout {
     /// Set while a turn's I/O is in flight; still set on the next call only
     /// if the previous turn future was cancelled mid-I/O (see the type docs).
     turn_in_flight: bool,
+    /// Set between sending `AbortFeed` and its reply. The child answers an
+    /// abort with `Error` (or a crash announcement), never a suspension, so
+    /// anything else is a protocol violation rather than a turn to service.
+    abort_in_flight: bool,
     /// Parent-enforced limits and the session's consumption of them.
     budget: SessionBudget,
     /// The budget in force before an in-flight `Load`, put back by
@@ -381,6 +386,17 @@ fn is_suspension(event: &pb::ChildEvent) -> bool {
     )
 }
 
+/// Recognizes the turn-enders a child may answer `AbortFeed` with: the
+/// uncatchable exception's `Error`, or the announcement that it died.
+fn is_abort_reply(event: &pb::ChildEvent) -> bool {
+    matches!(
+        event.kind,
+        Some(
+            pb::child_event::Kind::Error(_) | pb::child_event::Kind::FatalError(_) | pb::child_event::Kind::Shutdown(_)
+        )
+    )
+}
+
 /// The exception a feed is aborted with once it suspends past `max_suspensions`.
 fn suspension_limit_exceeded(limit: u64) -> MontyException {
     MontyException::new(
@@ -431,6 +447,7 @@ impl Checkout {
             pool,
             pending: None,
             turn_in_flight: false,
+            abort_in_flight: false,
             budget: SessionBudget::from_config(repl),
             pending_load_budget: None,
             armed_deadline: None,
@@ -869,9 +886,17 @@ impl Checkout {
     /// anything else (the child refusing it) keeps the live session's budget.
     ///
     /// Returns `true` after sending `AbortFeed`, so the caller reads its
-    /// turn-ender; `false` means to handle the event normally.
+    /// turn-ender; `false` means to handle the event normally. The abort's
+    /// reply must be an `Error` or a crash announcement: a child that answers
+    /// with another suspension would otherwise be aborted again forever, and
+    /// a suspension whose payload the typed path would reject is a protocol
+    /// violation, not a feed to abort.
     async fn abort_if_over_budget(&mut self, event: &pb::ChildEvent) -> Result<bool, PoolError> {
-        if !matches!(event.kind, Some(pb::child_event::Kind::Print(_)))
+        let is_print = matches!(event.kind, Some(pb::child_event::Kind::Print(_)));
+        if !is_print && mem::take(&mut self.abort_in_flight) && !is_abort_reply(event) {
+            return Err(self.protocol_violation("worker answered AbortFeed with something other than an Error"));
+        }
+        if !is_print
             && let Some(saved) = self.pending_load_budget.take()
             && !(matches!(event.kind, Some(pb::child_event::Kind::Ok(_))) || is_suspension(event))
         {
@@ -881,6 +906,16 @@ impl Checkout {
         let Some(limit) = self.budget.over_suspension_limit(event) else {
             return Ok(false);
         };
+        if let Some(pb::child_event::Kind::OsCall(call)) = &event.kind {
+            match &call.call {
+                None => return Err(self.protocol_violation("OsCall event with no call")),
+                Some(kind) => {
+                    if let Err(err) = OsFunctionCall::try_from(kind.clone()) {
+                        return Err(self.protocol_violation(format!("invalid OS call payload: {err}")));
+                    }
+                }
+            }
+        }
         let abort = request(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
             exception: Some((&suspension_limit_exceeded(limit)).into()),
         }));
@@ -888,7 +923,10 @@ impl Checkout {
             return Err(PoolError::Finished);
         };
         match worker.send(&abort).await {
-            Ok(()) => Ok(true),
+            Ok(()) => {
+                self.abort_in_flight = true;
+                Ok(true)
+            }
             Err(_) => Err(self.poison("aborting a feed").await),
         }
     }
@@ -1436,6 +1474,7 @@ impl Checkout {
         self.pending = None;
         self.feed_mounts = None;
         self.turn_in_flight = false;
+        self.abort_in_flight = false;
     }
 }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -262,8 +262,7 @@ pub struct Checkout {
     /// Set while a turn's I/O is in flight; still set on the next call only
     /// if the previous turn future was cancelled mid-I/O (see the type docs).
     turn_in_flight: bool,
-    /// The limits this checkout enforces or backstops itself, and what the
-    /// session has consumed of them.
+    /// Parent-enforced limits and the session's consumption of them.
     budget: SessionBudget,
     /// The deadline armed for the most recent turn, surfaced by
     /// [`PoolError::Timeout`] when it fires.
@@ -280,22 +279,16 @@ pub struct Checkout {
     feed_mounts: Option<MountTable>,
 }
 
-/// The parent-side view of a session's resource budget: the `max_duration`
-/// backstop and the `max_suspensions` limit, which the parent alone enforces.
+/// Tracks limits the parent enforces or backstops.
 ///
-/// Set from the config on `create`; a `restore`d session forgets that and
-/// re-adopts the limits from the budget fields the worker stamps on its first
-/// reply (they travel inside the opaque dump). The suspension count is parent
-/// state and restarts at zero on restore.
+/// Limits come from `Configure` or the first reply after `Load`. Suspension
+/// counts are parent state and restart at zero on restore.
 #[derive(Clone, Copy)]
 struct SessionBudget {
     /// The session's `max_duration`, when configured.
     duration_budget: Option<Duration>,
-    /// Cumulative sandbox execution time as last reported by the worker —
-    /// the child's clock is the single source of truth (it runs only while
-    /// the interpreter executes, never during suspensions or between feeds,
-    /// and survives dump/load). Monotonic max across turns so a compromised
-    /// worker cannot rewind the parent's view of its consumed budget.
+    /// Monotonic worker-reported sandbox time, preventing a compromised worker
+    /// from rewinding the parent's view.
     reported_execution: Duration,
     /// The session's `max_suspensions`, when configured.
     suspension_limit: Option<u64>,
@@ -304,7 +297,7 @@ struct SessionBudget {
 }
 
 impl SessionBudget {
-    /// The budget a fresh checkout starts with, from its `Configure` limits.
+    /// Creates a fresh budget from `Configure` limits.
     fn from_config(repl: &ReplConfig) -> Self {
         let limits = repl.limits.as_ref();
         Self {
@@ -315,8 +308,7 @@ impl SessionBudget {
         }
     }
 
-    /// Drops everything `Configure` established, ahead of a `Load` whose reply
-    /// carries the dump's own limits.
+    /// Clears `Configure` state before adopting a dump's budget.
     fn forget(&mut self) {
         *self = Self {
             duration_budget: None,
@@ -326,12 +318,10 @@ impl SessionBudget {
         };
     }
 
-    /// Adopts the budget fields the worker stamps onto every turn-ending
-    /// event, and counts the event if it is a suspension. The reported time
-    /// only ever ratchets up (a compromised worker can still under-report, but
-    /// each turn stays bounded by `budget + grace`); the limits are adopted only
-    /// when the parent doesn't already know them, i.e. after a restore. Print
-    /// events carry zero timing, so the ratchet makes them a no-op.
+    /// Adopts unknown limits and records an event's consumption.
+    ///
+    /// Reported time only ratchets up so a compromised worker cannot rewind it.
+    /// Suspension events increment the parent-owned count.
     fn note(&mut self, event: &pb::ChildEvent) {
         self.reported_execution = self
             .reported_execution
@@ -347,25 +337,22 @@ impl SessionBudget {
         }
     }
 
-    /// `Some((seen, limit))` when `event` is the suspension that overran the
-    /// budget — the caller aborts the feed instead of surfacing it.
+    /// Reports when this event exceeds the suspension limit.
     fn over_suspension_limit(&self, event: &pb::ChildEvent) -> Option<(u64, u64)> {
         let limit = self.suspension_limit?;
         (is_suspension(event) && self.suspensions_seen > limit).then_some((self.suspensions_seen, limit))
     }
 
-    /// Parent-side kill deadline derived from the session's `max_duration`:
-    /// the execution budget remaining after the time the worker has reported
-    /// consuming so far, plus the configured grace. The child enforces the
-    /// limit itself with a clean `TimeoutError`; this deadline only fires
-    /// when that enforcement fails (e.g. a wedged or compromised child that
-    /// stops checking its clock).
+    /// Returns the remaining `max_duration` plus grace.
+    ///
+    /// The child normally raises `TimeoutError`; this catches one that stops
+    /// checking its clock.
     fn backstop_deadline(&self, grace: Option<Duration>) -> Option<Duration> {
         Some(self.duration_budget?.saturating_sub(self.reported_execution) + grace?)
     }
 }
 
-/// Whether a turn-ending event hands the parent a suspension to answer.
+/// Recognizes turn-ending events that await a host answer.
 fn is_suspension(event: &pb::ChildEvent) -> bool {
     matches!(
         event.kind,
@@ -840,12 +827,10 @@ impl Checkout {
         self.budget.backstop_deadline(self.pool.config.duration_limit_grace)
     }
 
-    /// Records a worker event against the session budget and, when it is the
-    /// suspension past `max_suspensions`, sends `AbortFeed` so the sandbox
-    /// raises the limit uncatchably instead of the caller seeing the
-    /// suspension. Returns `Ok(true)` when the feed was aborted — the caller
-    /// keeps reading for the abort's turn-ender — and `Ok(false)` to handle
-    /// the event as usual.
+    /// Records an event and aborts a suspension past `max_suspensions`.
+    ///
+    /// Returns `true` after sending `AbortFeed`, so the caller reads its
+    /// turn-ender; `false` means to handle the event normally.
     async fn note_event(&mut self, event: &pb::ChildEvent) -> Result<bool, PoolError> {
         self.budget.note(event);
         let Some((seen, limit)) = self.budget.over_suspension_limit(event) else {
@@ -901,9 +886,8 @@ impl Checkout {
     ///
     /// **Bypasses this checkout's suspension bookkeeping** (`pending`,
     /// `feed_mounts`, `restored_script_name`) — never interleave with
-    /// `feed`/`resume`/`restore`. Worker lifecycle, poisoning, the
-    /// `max_duration` backstop and `max_suspensions` enforcement work as on
-    /// the typed path; a raw `Load` re-adopts the dump's budget like
+    /// `feed`/`resume`/`restore`. Worker lifecycle, poisoning and parent-side
+    /// limits work as on the typed path; a raw `Load` re-adopts its budget like
     /// [`Checkout::restore`]. A `FatalError`
     /// (or WebSocket `ShutdownDump`) turn-ender is returned so the driver can
     /// forward it, but discards the worker first — later calls report

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -460,20 +460,28 @@ impl Checkout {
         self.ensure_ready()?;
         let feed_mounts = Self::build_feed_mounts(mounts);
         // the dump carries its own limits/consumed time/script name — forget
-        // what the worker's Configure established and re-adopt from the reply
+        // what the worker's Configure established and re-adopt from the reply.
+        // Snapshotted so a rejected `Load` (the child already has a session)
+        // cannot reset the suspension count, see `turn_raw`.
         self.pending = None;
+        let saved_budget = self.budget;
         self.budget.forget();
         self.restored_script_name = None;
         self.feed_mounts = feed_mounts;
         let request = request(pb::parent_request::Kind::Load(pb::Load { state }));
         let event = match self
             .request_turn(&request, self.pool.config.request_timeout, on_print)
-            .await?
+            .await
         {
-            ControlEvent::Ok => None,
-            ControlEvent::Turn(event) => Some(event),
-            other @ ControlEvent::Dump(_) => {
+            Ok(ControlEvent::Ok) => None,
+            Ok(ControlEvent::Turn(event)) => Some(event),
+            Ok(other @ ControlEvent::Dump(_)) => {
+                self.budget = saved_budget;
                 return Err(self.protocol_violation(format!("unexpected reply to Load: {other:?}")));
+            }
+            Err(err) => {
+                self.budget = saved_budget;
+                return Err(err);
             }
         };
         Ok((event, self.restored_script_name.take()))
@@ -926,8 +934,10 @@ impl Checkout {
             ));
         }
         // As `restore`: forget the Configure-time budget and re-adopt the
-        // dump's from the reply's budget fields. Snapshotted because the
-        // pre-send frame-size rejection leaves the session live.
+        // dump's from the reply's budget fields. Snapshotted because a `Load`
+        // the child does not act on (the pre-send frame-size rejection, or the
+        // child refusing it once a session exists) must not reset the count a
+        // hostile client is trying to escape.
         let saved_budget = matches!(request.kind, Some(pb::parent_request::Kind::Load(_))).then_some(self.budget);
         if saved_budget.is_some() {
             self.budget.forget();
@@ -945,11 +955,14 @@ impl Checkout {
             None => self.turn_io_raw(request, on_event).await,
         };
         self.turn_in_flight = false;
-        // an error with the worker still alive is the pre-send frame-size
-        // rejection: the `Load` never reached the child, put the budget back
+        // only a reply confirming the dump was adopted (idle: `Ok`, suspended:
+        // the re-announced suspension) carries the dump's budget; anything
+        // else means the session the budget belongs to is still the live one
+        let load_adopted = outcome
+            .as_ref()
+            .is_ok_and(|event| matches!(event.kind, Some(pb::child_event::Kind::Ok(_))) || is_suspension(event));
         if let Some(budget) = saved_budget
-            && outcome.is_err()
-            && self.worker.is_some()
+            && !load_adopted
         {
             self.budget = budget;
         }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -265,7 +265,7 @@ pub struct Checkout {
     /// Parent-enforced limits and the session's consumption of them.
     budget: SessionBudget,
     /// The budget in force before an in-flight `Load`, put back by
-    /// [`Checkout::note_event`] unless the child's first reply confirms the
+    /// [`Checkout::abort_if_over_budget`] unless the child's first reply confirms the
     /// dump was adopted (an `Ok`, or the re-announced suspension) — so a
     /// refused `Load` cannot reset the suspension count, and an abort of the
     /// re-announced suspension does not discard the dump's limit.
@@ -335,7 +335,7 @@ impl SessionBudget {
     /// A reported suspension limit only ever tightens the one in force (an
     /// ordinary reply echoes it; a `Load` reply carries the dump's). Suspension
     /// events increment the parent-owned count.
-    fn note(&mut self, event: &pb::ChildEvent) {
+    fn update_from(&mut self, event: &pb::ChildEvent) {
         self.reported_execution = self
             .reported_execution
             .max(Duration::from_micros(event.total_execution_micros));
@@ -870,14 +870,14 @@ impl Checkout {
     ///
     /// Returns `true` after sending `AbortFeed`, so the caller reads its
     /// turn-ender; `false` means to handle the event normally.
-    async fn note_event(&mut self, event: &pb::ChildEvent) -> Result<bool, PoolError> {
+    async fn abort_if_over_budget(&mut self, event: &pb::ChildEvent) -> Result<bool, PoolError> {
         if !matches!(event.kind, Some(pb::child_event::Kind::Print(_)))
             && let Some(saved) = self.pending_load_budget.take()
             && !(matches!(event.kind, Some(pb::child_event::Kind::Ok(_))) || is_suspension(event))
         {
             self.budget = saved;
         }
-        self.budget.note(event);
+        self.budget.update_from(event);
         let Some(limit) = self.budget.over_suspension_limit(event) else {
             return Ok(false);
         };
@@ -1029,7 +1029,7 @@ impl Checkout {
                 }
                 Err(_) => return Err(self.poison("waiting for a reply").await),
             };
-            if self.note_event(&event).await? {
+            if self.abort_if_over_budget(&event).await? {
                 continue;
             }
             // strict alternation: zero or more `Print`s, then exactly one
@@ -1123,7 +1123,7 @@ impl Checkout {
             };
             // a suspension past `max_suspensions` is aborted here and never
             // reaches the caller; the abort's reply is the next event
-            if self.note_event(&event).await? {
+            if self.abort_if_over_budget(&event).await? {
                 continue;
             }
             // Only a `Load` reply carries this; it lets `restore` report the

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -282,7 +282,10 @@ pub struct Checkout {
 /// Tracks limits the parent enforces or backstops.
 ///
 /// Limits come from `Configure` or the first reply after `Load`. Suspension
-/// counts are parent state and restart at zero on restore.
+/// counts are parent state and restart at zero on restore. The suspension
+/// limit survives a restore and a reply can only tighten it: the reply's
+/// value is untrusted (a compromised worker could omit or inflate it), so it
+/// never loosens what this checkout was configured with.
 #[derive(Clone, Copy)]
 struct SessionBudget {
     /// The session's `max_duration`, when configured.
@@ -290,7 +293,7 @@ struct SessionBudget {
     /// Monotonic worker-reported sandbox time, preventing a compromised worker
     /// from rewinding the parent's view.
     reported_execution: Duration,
-    /// The session's `max_suspensions`, when configured.
+    /// The session's `max_suspensions` in force, when any.
     suspension_limit: Option<u64>,
     /// Suspensions this checkout has received from the worker.
     suspensions_seen: u64,
@@ -308,12 +311,13 @@ impl SessionBudget {
         }
     }
 
-    /// Clears `Configure` state before adopting a dump's budget.
+    /// Clears `Configure` state before adopting a dump's budget. The
+    /// suspension limit stays: it is the ceiling on the dump's.
     fn forget(&mut self) {
         *self = Self {
             duration_budget: None,
             reported_execution: Duration::ZERO,
-            suspension_limit: None,
+            suspension_limit: self.suspension_limit,
             suspensions_seen: 0,
         };
     }
@@ -321,7 +325,9 @@ impl SessionBudget {
     /// Adopts unknown limits and records an event's consumption.
     ///
     /// Reported time only ratchets up so a compromised worker cannot rewind it.
-    /// Suspension events increment the parent-owned count.
+    /// A reported suspension limit only ever tightens the one in force (an
+    /// ordinary reply echoes it; a `Load` reply carries the dump's). Suspension
+    /// events increment the parent-owned count.
     fn note(&mut self, event: &pb::ChildEvent) {
         self.reported_execution = self
             .reported_execution
@@ -329,9 +335,10 @@ impl SessionBudget {
         if self.duration_budget.is_none() {
             self.duration_budget = event.max_duration_micros.map(Duration::from_micros);
         }
-        if self.suspension_limit.is_none() {
-            self.suspension_limit = event.max_suspensions;
-        }
+        self.suspension_limit = match (self.suspension_limit, event.max_suspensions) {
+            (Some(current), Some(reported)) => Some(current.min(reported)),
+            (current, reported) => current.or(reported),
+        };
         if is_suspension(event) {
             self.suspensions_seen += 1;
         }
@@ -446,7 +453,8 @@ impl Checkout {
     /// is that same [`TurnEvent::OsCall`] — restoring never answers it here.
     /// The session's resource budget is taken from the dump, so the prior
     /// `Configure` limits are dropped here and re-adopted from the worker's
-    /// reply; the `max_suspensions` count restarts at zero.
+    /// reply — except that this checkout's configured `max_suspensions` stays
+    /// as a ceiling on the re-adopted one; the count restarts at zero.
     ///
     /// Returns the re-announced suspension (`Some` — a suspended dump) or `None`
     /// (an idle dump), paired with the worker's adopted script name (the dump's,

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -13,8 +13,8 @@ use std::{
 use monty_fs::{MountCallOutcome, MountMode, MountRoot, MountTable, OverlayState};
 use monty_proto::{FrameError, PROTOCOL_VERSION, exceeds_max_value_depth, pb, validate_requirement};
 use monty_types::{
-    AssertMessageAnnotations, ExcType, MONTY_VERSION, MontyException, MontyObject, MontyUuid, NameLookupResult,
-    OsFunctionCall, PrintStream, ResourceLimits, TypeCheckingConfig,
+    AssertMessageAnnotations, DEFAULT_MAX_SUSPENSIONS, ExcType, MONTY_VERSION, MontyException, MontyObject, MontyUuid,
+    NameLookupResult, OsFunctionCall, PrintStream, ResourceLimits, TypeCheckingConfig,
 };
 use tokio::{task::spawn_blocking, time::timeout};
 
@@ -293,8 +293,9 @@ struct SessionBudget {
     /// Monotonic worker-reported sandbox time, preventing a compromised worker
     /// from rewinding the parent's view.
     reported_execution: Duration,
-    /// The session's `max_suspensions` in force, when any.
-    suspension_limit: Option<u64>,
+    /// The session's `max_suspensions` in force (the configured one, else
+    /// [`DEFAULT_MAX_SUSPENSIONS`]).
+    suspension_limit: u64,
     /// Suspensions this checkout has received from the worker.
     suspensions_seen: u64,
 }
@@ -306,7 +307,7 @@ impl SessionBudget {
         Self {
             duration_budget: limits.and_then(|limits| limits.max_duration),
             reported_execution: Duration::ZERO,
-            suspension_limit: limits.and_then(|limits| limits.max_suspensions.map(|max| max as u64)),
+            suspension_limit: limits.map_or(DEFAULT_MAX_SUSPENSIONS as u64, |limits| limits.max_suspensions as u64),
             suspensions_seen: 0,
         }
     }
@@ -335,10 +336,9 @@ impl SessionBudget {
         if self.duration_budget.is_none() {
             self.duration_budget = event.max_duration_micros.map(Duration::from_micros);
         }
-        self.suspension_limit = match (self.suspension_limit, event.max_suspensions) {
-            (Some(current), Some(reported)) => Some(current.min(reported)),
-            (current, reported) => current.or(reported),
-        };
+        if let Some(reported) = event.max_suspensions {
+            self.suspension_limit = self.suspension_limit.min(reported);
+        }
         if is_suspension(event) {
             self.suspensions_seen += 1;
         }
@@ -346,8 +346,8 @@ impl SessionBudget {
 
     /// Reports when this event exceeds the suspension limit.
     fn over_suspension_limit(&self, event: &pb::ChildEvent) -> Option<(u64, u64)> {
-        let limit = self.suspension_limit?;
-        (is_suspension(event) && self.suspensions_seen > limit).then_some((self.suspensions_seen, limit))
+        (is_suspension(event) && self.suspensions_seen > self.suspension_limit)
+            .then_some((self.suspensions_seen, self.suspension_limit))
     }
 
     /// Returns the remaining `max_duration` plus grace.

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -102,6 +102,7 @@ impl Recorder {
                 pb::parent_request::Kind::ResumeCall(_)
                     | pb::parent_request::Kind::ResumeNameLookup(_)
                     | pb::parent_request::Kind::ResumeFutures(_)
+                    | pb::parent_request::Kind::AbortFeed(_)
             )
         );
         if !is_resume {
@@ -133,6 +134,7 @@ impl Recorder {
                     max_memory_bytes = limits.and_then(|l| l.max_memory_bytes),
                     gc_interval = limits.and_then(|l| l.gc_interval),
                     max_recursion_depth = limits.and_then(|l| l.max_recursion_depth),
+                    max_suspensions = limits.and_then(|l| l.max_suspensions),
                     // i64: `tracing` has no typed u32 value, so a u32 would be
                     // recorded as its debug string
                     worker_pid = self.worker_pid.map(i64::from),
@@ -207,6 +209,12 @@ impl Recorder {
             Some(pb::parent_request::Kind::ResumeNameLookup(r)) => {
                 let (result, cut) = render_name_lookup(r.kind.as_ref());
                 self.close_pending("value", &result, cut);
+            }
+            // an abort answers the suspension too, with the exception the
+            // sandbox is about to raise instead of a value
+            Some(pb::parent_request::Kind::AbortFeed(a)) => {
+                let (result, cut) = a.exception.as_ref().map_or((MISSING.into(), false), render_raised);
+                self.close_pending("aborted_with", &result, cut);
             }
             Some(pb::parent_request::Kind::ResumeFutures(r)) => {
                 let pending = self.take_pending();
@@ -979,6 +987,7 @@ mod tests {
             kind: Some(kind),
             total_execution_micros: 42,
             max_duration_micros: None,
+            max_suspensions: None,
             restored_script_name: None,
         }
     }
@@ -1118,6 +1127,7 @@ mod tests {
             kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
             total_execution_micros: 42,
             max_duration_micros: None,
+            max_suspensions: None,
             restored_script_name: Some("dumped.py".to_owned()),
         });
         recorder.begin_turn(&request(pb::parent_request::Kind::Dump(pb::Dump {})));
@@ -1165,6 +1175,7 @@ mod tests {
             kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
             total_execution_micros: 42,
             max_duration_micros: None,
+            max_suspensions: None,
             restored_script_name: Some("restored.py".to_owned()),
         });
         recorder.begin_turn(&request(pb::parent_request::Kind::Feed(pb::Feed {

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -210,8 +210,7 @@ impl Recorder {
                 let (result, cut) = render_name_lookup(r.kind.as_ref());
                 self.close_pending("value", &result, cut);
             }
-            // an abort answers the suspension too, with the exception the
-            // sandbox is about to raise instead of a value
+            // An abort answers with the exception the sandbox will raise.
             Some(pb::parent_request::Kind::AbortFeed(a)) => {
                 let (result, cut) = a.exception.as_ref().map_or((MISSING.into(), false), render_raised);
                 self.close_pending("aborted_with", &result, cut);

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -292,8 +292,9 @@ impl Recorder {
                     length_limit_exceeded = cut.then_some(true),
                     total_execution_micros = micros,
                     max_duration_micros = max_duration,
-                    // filled in by the answering `ResumeCall`
+                    // filled in by the answering `ResumeCall`, or an `AbortFeed`
                     return_value = Empty,
+                    aborted_with = Empty,
                 ));
                 self.pending = Some(OpenSpan::new(span, cut));
             }
@@ -308,8 +309,9 @@ impl Recorder {
                     name = name,
                     total_execution_micros = micros,
                     max_duration_micros = max_duration,
-                    // filled in by the answering `ResumeNameLookup`
+                    // filled in by the answering `ResumeNameLookup`, or an `AbortFeed`
                     value = Empty,
+                    aborted_with = Empty,
                     length_limit_exceeded = cut.then_some(true),
                 ));
                 self.pending = Some(OpenSpan::new(span, cut));
@@ -323,6 +325,8 @@ impl Recorder {
                     length_limit_exceeded = cut.then_some(true),
                     total_execution_micros = micros,
                     max_duration_micros = max_duration,
+                    // filled in by an `AbortFeed`
+                    aborted_with = Empty,
                 ));
                 self.pending = Some(OpenSpan::new(span, cut));
             }
@@ -629,8 +633,9 @@ fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, pa
                 call_id = call_id,
                 total_execution_micros = micros,
                 max_duration_micros = max_duration,
-                // filled in by the answering `ResumeCall`
+                // filled in by the answering `ResumeCall`, or an `AbortFeed`
                 return_value = Empty,
+                aborted_with = Empty,
                 length_limit_exceeded = Empty,
             )
         };

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1481,6 +1481,92 @@ async fn suspension_time_does_not_consume_the_duration_budget() {
     session.finish().await.unwrap();
 }
 
+/// `max_suspensions` is the pool's own limit: the suspension past the budget
+/// is never handed to the caller — the feed ends with an uncatchable
+/// `RuntimeError` naming the limit — and the session stays usable for feeds
+/// that do not suspend, while any later suspension fails at once.
+#[tokio::test]
+async fn suspension_limit_aborts_the_feed() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(3)),
+            ..ReplConfig::default()
+        })
+        .await
+        .unwrap();
+    let code = "n = 0\nwhile True:\n    try:\n        open('/etc/passwd')\n    except Exception:\n        n += 1";
+    let mut event = session.feed(code, vec![], vec![], false, &mut no_print).await.unwrap();
+    for _ in 0..2 {
+        assert!(matches!(event, TurnEvent::OsCall { .. }), "got {event:?}");
+        event = session.resume(ResumeValue::NotHandled, &mut no_print).await.unwrap();
+    }
+    assert!(matches!(event, TurnEvent::OsCall { .. }), "got {event:?}");
+    let err = session
+        .resume(ResumeValue::NotHandled, &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.exc_type().to_string(), "RuntimeError");
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 4 > 3"));
+    // three refusals were caught before the fourth suspension was aborted
+    let event = session.feed("n", vec![], vec![], false, &mut no_print).await.unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(3));
+    // the budget stays spent: a fresh feed's first suspension is aborted too
+    let err = session
+        .feed("fetch('x')", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 5 > 3"));
+    session.finish().await.unwrap();
+}
+
+/// The `max_suspensions` budget travels in the dump and is re-adopted on
+/// restore, but the count is parent state and restarts at zero.
+#[tokio::test]
+async fn restored_session_readopts_its_suspension_limit() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(1)),
+            ..ReplConfig::default()
+        })
+        .await
+        .unwrap();
+    let event = session
+        .feed("fetch('x')", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap();
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+    let state = session.dump().await.unwrap();
+    drop(session);
+
+    let mut restored = pool.checkout(&ReplConfig::default()).await.unwrap();
+    let (event, _script_name) = restored.restore(state, vec![], &mut no_print).await.unwrap();
+    // the re-announced suspension is the restored checkout's first
+    assert!(matches!(event, Some(TurnEvent::FunctionCall { .. })), "got {event:?}");
+    let event = restored
+        .resume(ResumeValue::Return(MontyObject::Int(1)), &mut no_print)
+        .await
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(1));
+    // the dump's limit of one applies to the next suspension
+    let err = restored
+        .feed("fetch('y')", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 2 > 1"));
+    restored.finish().await.unwrap();
+}
+
 #[tokio::test]
 async fn loaded_session_keeps_its_duration_budget() {
     // The `max_duration` budget and consumed execution time travel inside the

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -709,6 +709,25 @@ async fn restored_os_call_is_serviced_by_restore_mounts() {
     restored.finish().await.unwrap();
 }
 
+/// A `max_duration` near `Duration::MAX` must not overflow the parent's
+/// backstop deadline arithmetic (limit plus grace).
+#[tokio::test]
+async fn huge_max_duration_does_not_overflow_the_backstop() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_duration(Duration::MAX)),
+            ..ReplConfig::default()
+        })
+        .await
+        .unwrap();
+    let event = session
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(2));
+}
+
 /// An over-limit frame must fail as a clean, session-preserving error rather
 /// than crashing the worker: `Worker::send` rejects it before writing any
 /// bytes, so the stream stays synced. Covers both directions — a request the
@@ -1508,7 +1527,7 @@ async fn suspension_limit_aborts_the_feed() {
         panic!("expected Runtime, got {err:?}");
     };
     assert_eq!(exc.exc_type().to_string(), "RuntimeError");
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 4 > 3"));
+    assert_eq!(exc.message(), Some("suspension limit 3 exceeded"));
     // three refusals were caught before the fourth suspension was aborted
     let event = session.feed("n", vec![], vec![], false, &mut no_print).await.unwrap();
     assert_eq!(expect_complete(event), MontyObject::Int(3));
@@ -1520,7 +1539,7 @@ async fn suspension_limit_aborts_the_feed() {
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 5 > 3"));
+    assert_eq!(exc.message(), Some("suspension limit 3 exceeded"));
     session.finish().await.unwrap();
 }
 
@@ -1561,7 +1580,7 @@ async fn restored_session_readopts_its_suspension_limit() {
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 2 > 1"));
+    assert_eq!(exc.message(), Some("suspension limit 1 exceeded"));
     restored.finish().await.unwrap();
 }
 

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1481,10 +1481,8 @@ async fn suspension_time_does_not_consume_the_duration_budget() {
     session.finish().await.unwrap();
 }
 
-/// `max_suspensions` is the pool's own limit: the suspension past the budget
-/// is never handed to the caller — the feed ends with an uncatchable
-/// `RuntimeError` naming the limit — and the session stays usable for feeds
-/// that do not suspend, while any later suspension fails at once.
+/// The pool aborts the first suspension past the limit uncatchably. The
+/// session remains usable, but its suspension budget stays spent.
 #[tokio::test]
 async fn suspension_limit_aborts_the_feed() {
     let pool = Pool::new(config()).await.unwrap();

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -17,7 +17,7 @@ use std::{
 use monty_pool::{
     Checkout, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
 };
-use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, decode_frame, encode_to_capped_vec, pb};
+use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, WireObject, decode_frame, encode_to_capped_vec, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits};
 use tokio::task::spawn_blocking;
 #[cfg(not(windows))]
@@ -364,6 +364,7 @@ async fn a_raw_load_adopts_the_dumps_duration_budget() {
             &pb::ChildEvent {
                 total_execution_micros: 0,
                 max_duration_micros: Some(100_000),
+                max_suspensions: None,
                 restored_script_name: None,
                 kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
             },
@@ -635,6 +636,7 @@ async fn restored_session_rearms_the_duration_backstop() {
                 restored_script_name: Some("restored.py".to_owned()),
                 total_execution_micros: 0,
                 max_duration_micros: Some(100_000),
+                max_suspensions: None,
             },
         );
         assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
@@ -658,6 +660,198 @@ async fn restored_session_rearms_the_duration_backstop() {
         panic!("expected Timeout, got {err:?}");
     };
     assert!(timeout <= Duration::from_millis(400), "deadline was {timeout:?}");
+    join_server(server).await;
+}
+
+/// Answers `Feed` and every `ResumeCall` with a fresh `FunctionCall`, then
+/// expects the parent to give up with `AbortFeed` after `expected_calls` and
+/// replies with the sandbox-side `Error` that abort produces.
+fn serve_endless_suspensions(socket: &mut WebSocket<TcpStream>, expected_calls: u32) {
+    let function_call = |call_id: u32| {
+        event_kind(pb::child_event::Kind::FunctionCall(WireFunctionCall {
+            function_name: "fetch".to_owned(),
+            args: vec![],
+            kwargs: vec![],
+            call_id,
+            object_id: None,
+        }))
+    };
+    assert!(matches!(read_request(socket), pb::parent_request::Kind::Feed(_)));
+    send_event(socket, &function_call(1));
+    for call_id in 2..=expected_calls {
+        assert!(matches!(read_request(socket), pb::parent_request::Kind::ResumeCall(_)));
+        send_event(socket, &function_call(call_id));
+    }
+    let pb::parent_request::Kind::AbortFeed(abort) = read_request(socket) else {
+        panic!("expected AbortFeed");
+    };
+    let exception = abort.exception.expect("abort carries the exception");
+    assert_eq!(exception.exc_type, "RuntimeError");
+    assert_eq!(
+        exception.message.as_deref(),
+        Some(&*format!(
+            "suspension limit exceeded: {expected_calls} > {}",
+            expected_calls - 1
+        ))
+    );
+    send_event(
+        socket,
+        &event_kind(pb::child_event::Kind::Error(pb::Error {
+            exception: Some(exception),
+        })),
+    );
+}
+
+/// The parent enforces `max_suspensions` itself: the suspension past the
+/// budget is answered with `AbortFeed` rather than surfaced, and the abort's
+/// `Error` reply is what the caller sees.
+#[tokio::test]
+async fn suspension_limit_is_enforced_by_the_parent() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        serve_endless_suspensions(&mut socket, 3);
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(2)),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let mut event = checkout
+        .feed("fetch()", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+    event = checkout
+        .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+        .await
+        .expect("second suspension");
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+    let err = checkout
+        .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 3 > 2"));
+    drop(checkout);
+    join_server(server).await;
+}
+
+/// The same enforcement on the raw path a relay drives.
+#[tokio::test]
+async fn suspension_limit_is_enforced_on_the_raw_path() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        serve_endless_suspensions(&mut socket, 2);
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(1)),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let feed = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "fetch()".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&feed, &mut on_event).await.expect("feed");
+    assert!(matches!(event.kind, Some(pb::child_event::Kind::FunctionCall(_))));
+    let resume = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::ResumeCall(pb::ResumeCall {
+            call_id: 1,
+            result: Some(pb::ExtFunctionResult {
+                kind: Some(pb::ext_function_result::Kind::ReturnValue(WireObject::new(
+                    MontyObject::None,
+                ))),
+            }),
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&resume, &mut on_event).await.expect("aborted turn");
+    let Some(pb::child_event::Kind::Error(error)) = event.kind else {
+        panic!("expected the abort's Error, got {event:?}");
+    };
+    assert_eq!(
+        error.exception.and_then(|e| e.message).as_deref(),
+        Some("suspension limit exceeded: 2 > 1")
+    );
+    drop(checkout);
+    join_server(server).await;
+}
+
+/// A restored session re-adopts its `max_suspensions` from the budget the
+/// worker stamps on the `Load` reply, like the duration budget.
+#[tokio::test]
+async fn restored_session_readopts_the_suspension_limit() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Load(_)));
+        send_event(
+            &mut socket,
+            &pb::ChildEvent {
+                kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
+                max_suspensions: Some(1),
+                ..Default::default()
+            },
+        );
+        serve_endless_suspensions(&mut socket, 2);
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    let (event, _) = checkout
+        .restore(vec![1, 2, 3], vec![], &mut no_print)
+        .await
+        .expect("restore");
+    assert!(event.is_none());
+    let event = checkout
+        .feed("fetch()", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+    let err = checkout
+        .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 2 > 1"));
+    drop(checkout);
     join_server(server).await;
 }
 

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -973,6 +973,46 @@ async fn configured_suspension_limit_caps_a_restored_one() {
     }
 }
 
+/// A checkout with no limits configured still enforces the 1000 default.
+#[tokio::test]
+async fn suspension_limit_defaults_to_one_thousand() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        serve_endless_suspensions(&mut socket, 1001);
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    let mut event = checkout
+        .feed("fetch()", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    for _ in 1..1000 {
+        assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+        event = checkout
+            .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+            .await
+            .expect("resume");
+    }
+    let err = checkout
+        .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 1001 > 1000"));
+    drop(checkout);
+    join_server(server).await;
+}
+
 /// Restores `max_suspensions` from the worker's `Load` reply.
 #[tokio::test]
 async fn restored_session_readopts_the_suspension_limit() {

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -663,9 +663,7 @@ async fn restored_session_rearms_the_duration_backstop() {
     join_server(server).await;
 }
 
-/// Answers `Feed` and every `ResumeCall` with a fresh `FunctionCall`, then
-/// expects the parent to give up with `AbortFeed` after `expected_calls` and
-/// replies with the sandbox-side `Error` that abort produces.
+/// Serves suspensions until the parent responds with the expected `AbortFeed`.
 fn serve_endless_suspensions(socket: &mut WebSocket<TcpStream>, expected_calls: u32) {
     let function_call = |call_id: u32| {
         event_kind(pb::child_event::Kind::FunctionCall(WireFunctionCall {
@@ -702,9 +700,7 @@ fn serve_endless_suspensions(socket: &mut WebSocket<TcpStream>, expected_calls: 
     );
 }
 
-/// The parent enforces `max_suspensions` itself: the suspension past the
-/// budget is answered with `AbortFeed` rather than surfaced, and the abort's
-/// `Error` reply is what the caller sees.
+/// The parent replaces an over-budget suspension with `AbortFeed`.
 #[tokio::test]
 async fn suspension_limit_is_enforced_by_the_parent() {
     let (listener, config) = ws_pool_config();
@@ -749,7 +745,7 @@ async fn suspension_limit_is_enforced_by_the_parent() {
     join_server(server).await;
 }
 
-/// The same enforcement on the raw path a relay drives.
+/// Enforces suspension limits when a relay uses the raw path.
 #[tokio::test]
 async fn suspension_limit_is_enforced_on_the_raw_path() {
     let (listener, config) = ws_pool_config();
@@ -806,8 +802,7 @@ async fn suspension_limit_is_enforced_on_the_raw_path() {
     join_server(server).await;
 }
 
-/// A restored session re-adopts its `max_suspensions` from the budget the
-/// worker stamps on the `Load` reply, like the duration budget.
+/// Restores `max_suspensions` from the worker's `Load` reply.
 #[tokio::test]
 async fn restored_session_readopts_the_suspension_limit() {
     let (listener, config) = ws_pool_config();

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -910,6 +910,69 @@ async fn rejected_raw_load_keeps_the_suspension_count() {
     join_server(server).await;
 }
 
+/// The checkout's configured `max_suspensions` caps whatever a `Load` reply
+/// reports: a larger reported limit is clamped, and an omitted one leaves
+/// the configured limit in force, so a compromised worker cannot lift the
+/// parent's ceiling by lying about the dump.
+#[tokio::test]
+async fn configured_suspension_limit_caps_a_restored_one() {
+    for reported in [Some(5), None] {
+        let (listener, config) = ws_pool_config();
+        let server = thread::spawn(move || {
+            let mut socket = accept_ws(&listener);
+            assert!(matches!(
+                read_request(&mut socket),
+                pb::parent_request::Kind::Configure(_)
+            ));
+            send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+            assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Load(_)));
+            send_event(
+                &mut socket,
+                &pb::ChildEvent {
+                    kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
+                    max_suspensions: reported,
+                    ..Default::default()
+                },
+            );
+            serve_endless_suspensions(&mut socket, 2);
+            let _ = socket.read();
+        });
+
+        let pool = Pool::new(config).await.expect("pool");
+        let mut checkout = pool
+            .checkout(&ReplConfig {
+                limits: Some(ResourceLimits::default().max_suspensions(1)),
+                ..ReplConfig::default()
+            })
+            .await
+            .expect("checkout");
+        let (event, _) = checkout
+            .restore(vec![1, 2, 3], vec![], &mut no_print)
+            .await
+            .expect("restore");
+        assert!(event.is_none());
+        let event = checkout
+            .feed("fetch()", vec![], vec![], false, &mut no_print)
+            .await
+            .expect("feed");
+        assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+        let err = checkout
+            .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+            .await
+            .unwrap_err();
+        let PoolError::Runtime(exc) = err else {
+            panic!("expected Runtime, got {err:?}");
+        };
+        assert_eq!(
+            exc.message(),
+            Some("suspension limit exceeded: 2 > 1"),
+            "reported {reported:?}"
+        );
+        drop(checkout);
+        join_server(server).await;
+    }
+}
+
 /// Restores `max_suspensions` from the worker's `Load` reply.
 #[tokio::test]
 async fn restored_session_readopts_the_suspension_limit() {

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -687,10 +687,7 @@ fn serve_endless_suspensions(socket: &mut WebSocket<TcpStream>, expected_calls: 
     assert_eq!(exception.exc_type, "RuntimeError");
     assert_eq!(
         exception.message.as_deref(),
-        Some(&*format!(
-            "suspension limit exceeded: {expected_calls} > {}",
-            expected_calls - 1
-        ))
+        Some(&*format!("suspension limit {} exceeded", expected_calls - 1))
     );
     send_event(
         socket,
@@ -740,7 +737,7 @@ async fn suspension_limit_is_enforced_by_the_parent() {
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 3 > 2"));
+    assert_eq!(exc.message(), Some("suspension limit 2 exceeded"));
     drop(checkout);
     join_server(server).await;
 }
@@ -796,7 +793,7 @@ async fn suspension_limit_is_enforced_on_the_raw_path() {
     };
     assert_eq!(
         error.exception.and_then(|e| e.message).as_deref(),
-        Some("suspension limit exceeded: 2 > 1")
+        Some("suspension limit 1 exceeded")
     );
     drop(checkout);
     join_server(server).await;
@@ -852,7 +849,7 @@ async fn rejected_raw_load_keeps_the_suspension_count() {
             panic!("expected AbortFeed");
         };
         let exception = abort.exception.expect("abort carries the exception");
-        assert_eq!(exception.message.as_deref(), Some("suspension limit exceeded: 2 > 1"));
+        assert_eq!(exception.message.as_deref(), Some("suspension limit 1 exceeded"));
         send_event(
             &mut socket,
             &event_kind(pb::child_event::Kind::Error(pb::Error {
@@ -904,7 +901,7 @@ async fn rejected_raw_load_keeps_the_suspension_count() {
     };
     assert_eq!(
         error.exception.and_then(|e| e.message).as_deref(),
-        Some("suspension limit exceeded: 2 > 1")
+        Some("suspension limit 1 exceeded")
     );
     drop(checkout);
     join_server(server).await;
@@ -965,7 +962,7 @@ async fn configured_suspension_limit_caps_a_restored_one() {
         };
         assert_eq!(
             exc.message(),
-            Some("suspension limit exceeded: 2 > 1"),
+            Some("suspension limit 1 exceeded"),
             "reported {reported:?}"
         );
         drop(checkout);
@@ -1008,7 +1005,98 @@ async fn suspension_limit_defaults_to_one_thousand() {
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 1001 > 1000"));
+    assert_eq!(exc.message(), Some("suspension limit 1000 exceeded"));
+    drop(checkout);
+    join_server(server).await;
+}
+
+/// A suspended dump whose re-announced suspension is already over its limit
+/// is aborted at once, and the dump's limit still sticks for later turns:
+/// adoption is decided by the first reply, not by the abort's `Error`.
+#[tokio::test]
+async fn aborted_restored_suspension_keeps_the_dump_limit() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        let function_call = |call_id: u32| WireFunctionCall {
+            function_name: "fetch".to_owned(),
+            args: vec![],
+            kwargs: vec![],
+            call_id,
+            object_id: None,
+        };
+        let abort_reply = |socket: &mut WebSocket<TcpStream>| {
+            let pb::parent_request::Kind::AbortFeed(abort) = read_request(socket) else {
+                panic!("expected AbortFeed");
+            };
+            let exception = abort.exception.expect("abort carries the exception");
+            assert_eq!(exception.message.as_deref(), Some("suspension limit 0 exceeded"));
+            send_event(
+                socket,
+                &event_kind(pb::child_event::Kind::Error(pb::Error {
+                    exception: Some(exception),
+                })),
+            );
+        };
+        // the dump's limit is 0, so its re-announced suspension is over budget
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Load(_)));
+        send_event(
+            &mut socket,
+            &pb::ChildEvent {
+                kind: Some(pb::child_event::Kind::FunctionCall(function_call(1))),
+                max_suspensions: Some(0),
+                ..Default::default()
+            },
+        );
+        abort_reply(&mut socket);
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        send_event(
+            &mut socket,
+            &event_kind(pb::child_event::Kind::FunctionCall(function_call(2))),
+        );
+        abort_reply(&mut socket);
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(1)),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let load = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Load(pb::Load { state: vec![1, 2, 3] })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&load, &mut on_event).await.expect("aborted restore");
+    assert!(
+        matches!(event.kind, Some(pb::child_event::Kind::Error(_))),
+        "got {event:?}"
+    );
+    let feed = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "fetch()".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&feed, &mut on_event).await.expect("aborted feed");
+    let Some(pb::child_event::Kind::Error(error)) = event.kind else {
+        panic!("expected the abort's Error, got {event:?}");
+    };
+    assert_eq!(
+        error.exception.and_then(|e| e.message).as_deref(),
+        Some("suspension limit 0 exceeded")
+    );
     drop(checkout);
     join_server(server).await;
 }
@@ -1056,7 +1144,7 @@ async fn restored_session_readopts_the_suspension_limit() {
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 2 > 1"));
+    assert_eq!(exc.message(), Some("suspension limit 1 exceeded"));
     drop(checkout);
     join_server(server).await;
 }

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -802,6 +802,114 @@ async fn suspension_limit_is_enforced_on_the_raw_path() {
     join_server(server).await;
 }
 
+/// A raw `Load` the child refuses (a session already exists) must not reset
+/// the suspension count: the reply's stamped limit describes the session that
+/// is still live, so its budget stays as it was.
+#[tokio::test]
+async fn rejected_raw_load_keeps_the_suspension_count() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        let function_call = |call_id: u32| {
+            event_kind(pb::child_event::Kind::FunctionCall(WireFunctionCall {
+                function_name: "fetch".to_owned(),
+                args: vec![],
+                kwargs: vec![],
+                call_id,
+                object_id: None,
+            }))
+        };
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        send_event(&mut socket, &function_call(1));
+        // the child's refusal: an ordinary Error, stamped like every reply
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Load(_)));
+        send_event(
+            &mut socket,
+            &pb::ChildEvent {
+                kind: Some(pb::child_event::Kind::Error(pb::Error {
+                    exception: Some(pb::RaisedException {
+                        exc_type: "RuntimeError".to_owned(),
+                        message: Some("protocol violation: Load requires a session that has not started".to_owned()),
+                        traceback: vec![],
+                        data: None,
+                    }),
+                })),
+                max_suspensions: Some(1),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::ResumeCall(_)
+        ));
+        send_event(&mut socket, &function_call(2));
+        let pb::parent_request::Kind::AbortFeed(abort) = read_request(&mut socket) else {
+            panic!("expected AbortFeed");
+        };
+        let exception = abort.exception.expect("abort carries the exception");
+        assert_eq!(exception.message.as_deref(), Some("suspension limit exceeded: 2 > 1"));
+        send_event(
+            &mut socket,
+            &event_kind(pb::child_event::Kind::Error(pb::Error {
+                exception: Some(exception),
+            })),
+        );
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(1)),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let feed = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "fetch()".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&feed, &mut on_event).await.expect("feed");
+    assert!(matches!(event.kind, Some(pb::child_event::Kind::FunctionCall(_))));
+    let load = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Load(pb::Load { state: vec![1, 2, 3] })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&load, &mut on_event).await.expect("refused load");
+    assert!(matches!(event.kind, Some(pb::child_event::Kind::Error(_))));
+    let resume = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::ResumeCall(pb::ResumeCall {
+            call_id: 1,
+            result: Some(pb::ExtFunctionResult {
+                kind: Some(pb::ext_function_result::Kind::ReturnValue(WireObject::new(
+                    MontyObject::None,
+                ))),
+            }),
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&resume, &mut on_event).await.expect("aborted turn");
+    let Some(pb::child_event::Kind::Error(error)) = event.kind else {
+        panic!("expected the abort's Error, got {event:?}");
+    };
+    assert_eq!(
+        error.exception.and_then(|e| e.message).as_deref(),
+        Some("suspension limit exceeded: 2 > 1")
+    );
+    drop(checkout);
+    join_server(server).await;
+}
+
 /// Restores `max_suspensions` from the worker's `Load` reply.
 #[tokio::test]
 async fn restored_session_readopts_the_suspension_limit() {

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -742,6 +742,96 @@ async fn suspension_limit_is_enforced_by_the_parent() {
     join_server(server).await;
 }
 
+/// A child that answers `AbortFeed` with another suspension is discarded
+/// rather than aborted again: servicing or re-aborting it would let a
+/// compromised worker run past the budget for as long as the turn deadline.
+#[tokio::test]
+async fn a_suspension_answering_an_abort_is_a_protocol_violation() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        expect_feed(&mut socket, "fetch()");
+        send_kind(&mut socket, function_call(1));
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::ResumeCall(_)
+        ));
+        send_kind(&mut socket, function_call(2));
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::AbortFeed(_)
+        ));
+        send_kind(&mut socket, function_call(3));
+        // no second AbortFeed: the parent hangs up instead
+        assert!(try_read_request(&mut socket).is_none());
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_suspensions(1)),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let event = checkout
+        .feed("fetch()", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }));
+    let err = checkout
+        .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Protocol(msg) = err else {
+        panic!("expected Protocol, got {err:?}");
+    };
+    assert_eq!(msg, "worker answered AbortFeed with something other than an Error");
+    assert!(matches!(
+        checkout.feed("1", vec![], vec![], false, &mut no_print).await,
+        Err(PoolError::Finished)
+    ));
+    join_server(server).await;
+}
+
+/// An over-budget `OsCall` is validated before the abort shortcut, so a
+/// malformed payload discards the worker as it would on the typed path
+/// instead of being aborted and reported as a runtime error.
+#[tokio::test]
+async fn a_malformed_over_budget_os_call_is_a_protocol_violation() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        expect_feed(&mut socket, "open('x')");
+        // the event shrinks the limit to zero itself, so this suspension is
+        // over budget on arrival
+        send_event(
+            &mut socket,
+            &pb::ChildEvent {
+                kind: Some(pb::child_event::Kind::OsCall(pb::OsCall { call_id: 1, call: None })),
+                max_suspensions: Some(0),
+                ..Default::default()
+            },
+        );
+        // no AbortFeed: the parent hangs up instead
+        assert!(try_read_request(&mut socket).is_none());
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    let err = checkout
+        .feed("open('x')", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap_err();
+    let PoolError::Protocol(msg) = err else {
+        panic!("expected Protocol, got {err:?}");
+    };
+    assert_eq!(msg, "OsCall event with no call");
+    join_server(server).await;
+}
+
 /// Enforces suspension limits when a relay uses the raw path.
 #[tokio::test]
 async fn suspension_limit_is_enforced_on_the_raw_path() {

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -345,12 +345,9 @@ message StackFrame {
 // Configuration
 // ============================================================================
 
-// Sandbox resource limits. Absent fields mean "unlimited" except recursion
-// depth, which defaults to monty's standard limit (1000) when absent. All but
-// `max_suspensions` are enforced inside the child; `max_suspensions` is the
-// budget the *parent* enforces by counting the suspensions it services and
-// ending the feed with `AbortFeed` — the child only stores it (so it travels
-// in dumps) and echoes it on `ChildEvent.max_suspensions`.
+// Sandbox resource limits. Absent fields are unlimited except recursion depth,
+// which defaults to 1000. The parent enforces `max_suspensions`; the child only
+// retains it for dumps and echoes it on `ChildEvent`.
 message ResourceLimits {
   optional uint64 max_duration_micros = 1;
   optional uint64 max_memory_bytes = 2;
@@ -493,14 +490,9 @@ message Feed {
   bool skip_type_check = 3;
 }
 
-// Ends a suspended feed instead of answering its suspension — whichever kind
-// (`FunctionCall`, `OsCall`, `NameLookup`, `ResolveFutures`) is pending. The
-// exception is raised at the suspension point uncatchably: every frame
-// unwinds into its traceback and no `except` runs, so a snippet retrying
-// refused calls cannot continue. The session survives (the reply is an
-// `Error` turn-ender) and later feeds work. This is how the parent enforces
-// `ResourceLimits.max_suspensions`, and a general host tool for ending a feed.
-// Valid only while a suspension is pending.
+// Ends a pending suspension by raising `exception` uncatchably at its site.
+// The session returns ready in an `Error` event. Hosts use this to stop a feed,
+// including when `max_suspensions` is exceeded.
 message AbortFeed {
   RaisedException exception = 1;
 }
@@ -609,9 +601,8 @@ message ChildEvent {
   // state bytes) still learns the budget.
   optional uint64 max_duration_micros = 21;
 
-  // The session's `max_suspensions` budget, when one is configured — the
-  // parent enforces it (see `AbortFeed`), so this is only how a parent that
-  // restored a session via `Load` learns the budget the dump carries.
+  // Echoes the parent-enforced budget so a host restoring an opaque dump can
+  // recover it.
   optional uint64 max_suspensions = 23;
 
   // The session's script name, surfaced on a `Load` reply so a parent that

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -345,14 +345,18 @@ message StackFrame {
 // Configuration
 // ============================================================================
 
-// Sandbox resource limits, enforced inside the child. Absent fields mean
-// "unlimited" except recursion depth, which defaults to monty's standard
-// limit (1000) when absent.
+// Sandbox resource limits. Absent fields mean "unlimited" except recursion
+// depth, which defaults to monty's standard limit (1000) when absent. All but
+// `max_suspensions` are enforced inside the child; `max_suspensions` is the
+// budget the *parent* enforces by counting the suspensions it services and
+// ending the feed with `AbortFeed` — the child only stores it (so it travels
+// in dumps) and echoes it on `ChildEvent.max_suspensions`.
 message ResourceLimits {
   optional uint64 max_duration_micros = 1;
   optional uint64 max_memory_bytes = 2;
   optional uint64 gc_interval = 3;
   optional uint64 max_recursion_depth = 4;
+  optional uint64 max_suspensions = 5;
 }
 
 // ============================================================================
@@ -413,6 +417,7 @@ message ParentRequest {
     Load load = 8;
     Reset reset = 9;
     Shutdown shutdown = 10;
+    AbortFeed abort_feed = 11;
   }
 
   // W3C `traceparent` identifying the caller's span, so a child that exports
@@ -486,6 +491,18 @@ message Feed {
   repeated NamedValue inputs = 2;
   // Skip type checking for this feed even when the session enables it.
   bool skip_type_check = 3;
+}
+
+// Ends a suspended feed instead of answering its suspension — whichever kind
+// (`FunctionCall`, `OsCall`, `NameLookup`, `ResolveFutures`) is pending. The
+// exception is raised at the suspension point uncatchably: every frame
+// unwinds into its traceback and no `except` runs, so a snippet retrying
+// refused calls cannot continue. The session survives (the reply is an
+// `Error` turn-ender) and later feeds work. This is how the parent enforces
+// `ResourceLimits.max_suspensions`, and a general host tool for ending a feed.
+// Valid only while a suspension is pending.
+message AbortFeed {
+  RaisedException exception = 1;
 }
 
 // Answers a `FunctionCall` or `OsCall` suspension. `call_id` must match the
@@ -591,6 +608,11 @@ message ChildEvent {
   // restored a session via `Load` (where the limits travel inside the opaque
   // state bytes) still learns the budget.
   optional uint64 max_duration_micros = 21;
+
+  // The session's `max_suspensions` budget, when one is configured — the
+  // parent enforces it (see `AbortFeed`), so this is only how a parent that
+  // restored a session via `Load` learns the budget the dump carries.
+  optional uint64 max_suspensions = 23;
 
   // The session's script name, surfaced on a `Load` reply so a parent that
   // restored a session (whose script name, like the limits above, travels

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -345,9 +345,10 @@ message StackFrame {
 // Configuration
 // ============================================================================
 
-// Sandbox resource limits. Absent fields are unlimited except recursion depth,
-// which defaults to 1000. The parent enforces `max_suspensions`; the child only
-// retains it for dumps and echoes it on `ChildEvent`.
+// Sandbox resource limits. Absent fields are unlimited except recursion depth
+// and `max_suspensions`, which both default to 1000. The parent enforces
+// `max_suspensions`; the child only retains it for dumps and echoes it on
+// `ChildEvent`.
 message ResourceLimits {
   optional uint64 max_duration_micros = 1;
   optional uint64 max_memory_bytes = 2;

--- a/crates/monty-proto/src/convert/limits.rs
+++ b/crates/monty-proto/src/convert/limits.rs
@@ -4,6 +4,8 @@
 //! saturates to `usize::MAX` on 32-bit hosts. Absent wire fields mean
 //! "unlimited", except recursion depth which falls back to monty's standard
 //! default — matching `ResourceLimits::default()` so an empty message is safe.
+//! `max_suspensions` rides along unchanged: the child stores it for dumps and
+//! echoes it, but the parent is what enforces it.
 
 use std::time::Duration;
 
@@ -20,6 +22,7 @@ impl From<&ResourceLimits> for pb::ResourceLimits {
             max_memory_bytes: limits.max_memory.map(|v| v as u64),
             gc_interval: limits.gc_interval.map(|v| v as u64),
             max_recursion_depth: Some(limits.max_recursion_depth as u64),
+            max_suspensions: limits.max_suspensions.map(|v| v as u64),
         }
     }
 }
@@ -31,6 +34,7 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             max_memory: usize_field(limits.max_memory_bytes),
             gc_interval: usize_field(limits.gc_interval),
             max_recursion_depth: usize_field(limits.max_recursion_depth).unwrap_or(DEFAULT_MAX_RECURSION_DEPTH),
+            max_suspensions: usize_field(limits.max_suspensions),
         }
     }
 }

--- a/crates/monty-proto/src/convert/limits.rs
+++ b/crates/monty-proto/src/convert/limits.rs
@@ -2,13 +2,14 @@
 //!
 //! Wire fields are `u64`; the Rust struct uses `usize`, so proto → Rust
 //! saturates to `usize::MAX` on 32-bit hosts. Absent wire fields mean
-//! "unlimited", except recursion depth which falls back to monty's standard
-//! default — matching `ResourceLimits::default()` so an empty message is safe.
-//! `max_suspensions` is preserved across dumps for parent-side enforcement.
+//! "unlimited", except recursion depth and `max_suspensions`, which fall back
+//! to monty's standard defaults — matching `ResourceLimits::default()` so an
+//! empty message is safe. `max_suspensions` is preserved across dumps for
+//! parent-side enforcement.
 
 use std::time::Duration;
 
-use monty_types::{DEFAULT_MAX_RECURSION_DEPTH, ResourceLimits};
+use monty_types::{DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_MAX_SUSPENSIONS, ResourceLimits};
 
 use crate::pb;
 
@@ -21,7 +22,7 @@ impl From<&ResourceLimits> for pb::ResourceLimits {
             max_memory_bytes: limits.max_memory.map(|v| v as u64),
             gc_interval: limits.gc_interval.map(|v| v as u64),
             max_recursion_depth: Some(limits.max_recursion_depth as u64),
-            max_suspensions: limits.max_suspensions.map(|v| v as u64),
+            max_suspensions: Some(limits.max_suspensions as u64),
         }
     }
 }
@@ -33,7 +34,7 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             max_memory: usize_field(limits.max_memory_bytes),
             gc_interval: usize_field(limits.gc_interval),
             max_recursion_depth: usize_field(limits.max_recursion_depth).unwrap_or(DEFAULT_MAX_RECURSION_DEPTH),
-            max_suspensions: usize_field(limits.max_suspensions),
+            max_suspensions: usize_field(limits.max_suspensions).unwrap_or(DEFAULT_MAX_SUSPENSIONS),
         }
     }
 }

--- a/crates/monty-proto/src/convert/limits.rs
+++ b/crates/monty-proto/src/convert/limits.rs
@@ -4,8 +4,7 @@
 //! saturates to `usize::MAX` on 32-bit hosts. Absent wire fields mean
 //! "unlimited", except recursion depth which falls back to monty's standard
 //! default — matching `ResourceLimits::default()` so an empty message is safe.
-//! `max_suspensions` rides along unchanged: the child stores it for dumps and
-//! echoes it, but the parent is what enforces it.
+//! `max_suspensions` is preserved across dumps for parent-side enforcement.
 
 use std::time::Duration;
 

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -333,12 +333,9 @@ pub struct StackFrame {
     #[prost(bool, tag = "7")]
     pub hide_frame_name: bool,
 }
-/// Sandbox resource limits. Absent fields mean "unlimited" except recursion
-/// depth, which defaults to monty's standard limit (1000) when absent. All but
-/// `max_suspensions` are enforced inside the child; `max_suspensions` is the
-/// budget the *parent* enforces by counting the suspensions it services and
-/// ending the feed with `AbortFeed` — the child only stores it (so it travels
-/// in dumps) and echoes it on `ChildEvent.max_suspensions`.
+/// Sandbox resource limits. Absent fields are unlimited except recursion depth,
+/// which defaults to 1000. The parent enforces `max_suspensions`; the child only
+/// retains it for dumps and echoes it on `ChildEvent`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]
@@ -506,14 +503,9 @@ pub struct Feed {
     #[prost(bool, tag = "3")]
     pub skip_type_check: bool,
 }
-/// Ends a suspended feed instead of answering its suspension — whichever kind
-/// (`FunctionCall`, `OsCall`, `NameLookup`, `ResolveFutures`) is pending. The
-/// exception is raised at the suspension point uncatchably: every frame
-/// unwinds into its traceback and no `except` runs, so a snippet retrying
-/// refused calls cannot continue. The session survives (the reply is an
-/// `Error` turn-ender) and later feeds work. This is how the parent enforces
-/// `ResourceLimits.max_suspensions`, and a general host tool for ending a feed.
-/// Valid only while a suspension is pending.
+/// Ends a pending suspension by raising `exception` uncatchably at its site.
+/// The session returns ready in an `Error` event. Hosts use this to stop a feed,
+/// including when `max_suspensions` is exceeded.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbortFeed {
     #[prost(message, optional, tag = "1")]
@@ -619,9 +611,8 @@ pub struct ChildEvent {
     /// state bytes) still learns the budget.
     #[prost(uint64, optional, tag = "21")]
     pub max_duration_micros: ::core::option::Option<u64>,
-    /// The session's `max_suspensions` budget, when one is configured — the
-    /// parent enforces it (see `AbortFeed`), so this is only how a parent that
-    /// restored a session via `Load` learns the budget the dump carries.
+    /// Echoes the parent-enforced budget so a host restoring an opaque dump can
+    /// recover it.
     #[prost(uint64, optional, tag = "23")]
     pub max_suspensions: ::core::option::Option<u64>,
     /// The session's script name, surfaced on a `Load` reply so a parent that

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -333,9 +333,10 @@ pub struct StackFrame {
     #[prost(bool, tag = "7")]
     pub hide_frame_name: bool,
 }
-/// Sandbox resource limits. Absent fields are unlimited except recursion depth,
-/// which defaults to 1000. The parent enforces `max_suspensions`; the child only
-/// retains it for dumps and echoes it on `ChildEvent`.
+/// Sandbox resource limits. Absent fields are unlimited except recursion depth
+/// and `max_suspensions`, which both default to 1000. The parent enforces
+/// `max_suspensions`; the child only retains it for dumps and echoes it on
+/// `ChildEvent`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -333,9 +333,12 @@ pub struct StackFrame {
     #[prost(bool, tag = "7")]
     pub hide_frame_name: bool,
 }
-/// Sandbox resource limits, enforced inside the child. Absent fields mean
-/// "unlimited" except recursion depth, which defaults to monty's standard
-/// limit (1000) when absent.
+/// Sandbox resource limits. Absent fields mean "unlimited" except recursion
+/// depth, which defaults to monty's standard limit (1000) when absent. All but
+/// `max_suspensions` are enforced inside the child; `max_suspensions` is the
+/// budget the *parent* enforces by counting the suspensions it services and
+/// ending the feed with `AbortFeed` — the child only stores it (so it travels
+/// in dumps) and echoes it on `ChildEvent.max_suspensions`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]
@@ -346,6 +349,8 @@ pub struct ResourceLimits {
     pub gc_interval: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "4")]
     pub max_recursion_depth: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "5")]
+    pub max_suspensions: ::core::option::Option<u64>,
 }
 /// Outcome of an external function / OS call, decided by the parent. Mirrors
 /// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can
@@ -408,7 +413,7 @@ pub struct ParentRequest {
     /// not depend on it, and it is absent whenever the parent is not tracing.
     #[prost(string, optional, tag = "20")]
     pub trace_parent: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(oneof = "parent_request::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof = "parent_request::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub kind: ::core::option::Option<parent_request::Kind>,
 }
 /// Nested message and enum types in `ParentRequest`.
@@ -435,6 +440,8 @@ pub mod parent_request {
         Reset(super::Reset),
         #[prost(message, tag = "10")]
         Shutdown(super::Shutdown),
+        #[prost(message, tag = "11")]
+        AbortFeed(super::AbortFeed),
     }
 }
 /// Configures the REPL session this child will serve until `Reset`, sent once
@@ -498,6 +505,19 @@ pub struct Feed {
     /// Skip type checking for this feed even when the session enables it.
     #[prost(bool, tag = "3")]
     pub skip_type_check: bool,
+}
+/// Ends a suspended feed instead of answering its suspension — whichever kind
+/// (`FunctionCall`, `OsCall`, `NameLookup`, `ResolveFutures`) is pending. The
+/// exception is raised at the suspension point uncatchably: every frame
+/// unwinds into its traceback and no `except` runs, so a snippet retrying
+/// refused calls cannot continue. The session survives (the reply is an
+/// `Error` turn-ender) and later feeds work. This is how the parent enforces
+/// `ResourceLimits.max_suspensions`, and a general host tool for ending a feed.
+/// Valid only while a suspension is pending.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AbortFeed {
+    #[prost(message, optional, tag = "1")]
+    pub exception: ::core::option::Option<RaisedException>,
 }
 /// Answers a `FunctionCall` or `OsCall` suspension. `call_id` must match the
 /// suspension event.
@@ -599,6 +619,11 @@ pub struct ChildEvent {
     /// state bytes) still learns the budget.
     #[prost(uint64, optional, tag = "21")]
     pub max_duration_micros: ::core::option::Option<u64>,
+    /// The session's `max_suspensions` budget, when one is configured — the
+    /// parent enforces it (see `AbortFeed`), so this is only how a parent that
+    /// restored a session via `Load` learns the budget the dump carries.
+    #[prost(uint64, optional, tag = "23")]
+    pub max_suspensions: ::core::option::Option<u64>,
     /// The session's script name, surfaced on a `Load` reply so a parent that
     /// restored a session (whose script name, like the limits above, travels
     /// inside the opaque dump bytes) learns it without parsing the dump. Set only

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -21,7 +21,7 @@ pub mod worker;
 /// or repurposing a field, changing a field's meaning, or adding one the child
 /// requires. Purely additive changes an older peer can ignore do not need a
 /// bump.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Oldest [`PROTOCOL_VERSION`] this build still serves.
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 2;

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -414,11 +414,7 @@ impl Child {
             // no repl materialized yet → no tracker to report
             SessionState::Configured(_) => return,
         };
-        event.total_execution_micros = u64::try_from(tracker.elapsed().as_micros()).unwrap_or(u64::MAX);
-        event.max_duration_micros = tracker
-            .max_duration()
-            .map(|max| u64::try_from(max.as_micros()).unwrap_or(u64::MAX));
-        event.max_suspensions = tracker.max_suspensions().map(|max| max as u64);
+        stamp_budget(event, tracker);
     }
 
     /// Stores the session config; the repl is built lazily by [`ensure_repl`]
@@ -785,11 +781,15 @@ impl Child {
                         result = call.resume(ExtFunctionResult::Error(err), PrintWriter::Callback(print));
                         continue;
                     }
-                    let event = suspension_event_os_call(&mut call);
+                    let mut event = suspension_event_os_call(&mut call);
+                    let progress = ReplProgress::OsCall(call);
+                    // stamped before the size check, so the frame measured is
+                    // the frame `handle` sends
+                    stamp_budget(&mut event, progress.tracker());
                     if let Some(message) = oversize_suspension_error_message(&event) {
-                        return self.abort_feed_with_runtime_error(call.into_repl(), &message);
+                        return self.abort_feed_with_runtime_error(progress.into_repl(), &message);
                     }
-                    self.state = SessionState::Suspended(Box::new(ReplProgress::OsCall(call)));
+                    self.state = SessionState::Suspended(Box::new(progress));
                     return event;
                 }
                 Ok(ReplProgress::FunctionCall(mut call)) => {
@@ -801,11 +801,13 @@ impl Child {
                         result = call.resume(ExtFunctionResult::Error(err), PrintWriter::Callback(print));
                         continue;
                     }
-                    let event = suspension_event_function_call(&mut call);
+                    let mut event = suspension_event_function_call(&mut call);
+                    let progress = ReplProgress::FunctionCall(call);
+                    stamp_budget(&mut event, progress.tracker());
                     if let Some(message) = oversize_suspension_error_message(&event) {
-                        return self.abort_feed_with_runtime_error(call.into_repl(), &message);
+                        return self.abort_feed_with_runtime_error(progress.into_repl(), &message);
                     }
-                    self.state = SessionState::Suspended(Box::new(ReplProgress::FunctionCall(call)));
+                    self.state = SessionState::Suspended(Box::new(progress));
                     return event;
                 }
                 Ok(mut progress) => {
@@ -924,10 +926,22 @@ fn error_event(exc_type: ExcType, message: &str) -> pb::ChildEvent {
     }))
 }
 
+/// Stamps `tracker`'s timing and parent-enforced limits onto an event. Called
+/// again by [`Child::handle`] just before sending, so a suspension announcement
+/// is size-checked with the stamps it will carry.
+fn stamp_budget(event: &mut pb::ChildEvent, tracker: &ResourceTracker) {
+    event.total_execution_micros = u64::try_from(tracker.elapsed().as_micros()).unwrap_or(u64::MAX);
+    event.max_duration_micros = tracker
+        .max_duration()
+        .map(|max| u64::try_from(max.as_micros()).unwrap_or(u64::MAX));
+    event.max_suspensions = tracker.max_suspensions().map(|max| max as u64);
+}
+
 /// Describes a suspension announcement that would exceed the wire frame limit.
 ///
 /// The child turns this into a host-visible error before entering the
 /// suspension, because the parent cannot resume a call it never received.
+/// The event must already carry its session stamps (see [`stamp_budget`]).
 fn oversize_suspension_error_message(event: &pb::ChildEvent) -> Option<String> {
     exceeds_max_frame_len(event)
         .map(|len| format!("argument frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"))

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -151,9 +151,10 @@ fn dispatch_into(child: &mut Child, request_frame: &[u8], sink: &mut VecEventSin
     }
 }
 
-/// The sandbox budget of the child's current session, as a host outside the
-/// interpreter sees it. Hosts use the memory fields to arm their allocator and
-/// `max_suspensions` when restoring parent-side suspension accounting.
+/// The current sandbox budget visible to an external host.
+///
+/// Hosts use the memory fields to arm their allocator and `max_suspensions` to
+/// restore their accounting.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SessionBudget {
     /// `max_memory` in bytes; `None` when unlimited, or when no session exists.
@@ -402,11 +403,10 @@ impl Child {
         }
     }
 
-    /// Stamps cumulative execution time and the `max_duration` budget onto a
-    /// turn-ending event, making the child the single source of truth for
-    /// timing (the parent's watchdog derives its backstop from these fields),
-    /// plus the `max_suspensions` budget so a parent restoring a dump learns
-    /// the limit it is to enforce. Left zero/absent when no session exists.
+    /// Stamps session timing and parent-enforced limits onto an event.
+    ///
+    /// Reported timing drives the parent's backstop. Fields are absent without
+    /// a session.
     fn stamp_session_budget(&self, event: &mut pb::ChildEvent) {
         let tracker = match &self.state {
             SessionState::Ready(repl) => repl.tracker(),
@@ -604,12 +604,10 @@ impl Child {
         event
     }
 
-    /// Ends the suspended feed by raising the parent's exception uncatchably
-    /// at the suspension point, whatever its kind (see `AbortFeed` in the
-    /// schema). The session comes back `Ready` inside the `Error` turn-ender.
+    /// Raises the parent's exception uncatchably at any pending suspension.
+    /// The `Error` reply returns the session to `Ready`.
     fn handle_abort_feed(&mut self, abort: pb::AbortFeed, sink: &mut dyn EventSink) -> pb::ChildEvent {
-        // `drive` only ever stores suspensions here, so `Complete` cannot be
-        // pending; the guard keeps that a violation rather than a crash
+        // Guard against a corrupt `Complete` state instead of crashing.
         let suspended = matches!(&self.state, SessionState::Suspended(progress)
             if !matches!(progress.as_ref(), ReplProgress::Complete { .. }));
         if !suspended {

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -723,7 +723,9 @@ impl Child {
                     if suspension_args_too_deep(&progress) {
                         protocol_violation("dump suspension arguments exceed the maximum wire depth")
                     } else {
-                        let event = suspension_event(&mut progress);
+                        let mut event = suspension_event(&mut progress);
+                        // size-checked with the stamps `handle` sends it with
+                        stamp_budget(&mut event, progress.tracker());
                         if let Some(message) = oversize_suspension_error_message(&event) {
                             protocol_violation(&message)
                         } else {

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -152,14 +152,16 @@ fn dispatch_into(child: &mut Child, request_frame: &[u8], sink: &mut VecEventSin
 }
 
 /// The sandbox budget of the child's current session, as a host outside the
-/// interpreter sees it. Both fields describe how much memory the session may
-/// need: the tracked budget, and whether type checking's untracked caches load.
+/// interpreter sees it. Hosts use the memory fields to arm their allocator and
+/// `max_suspensions` when restoring parent-side suspension accounting.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SessionBudget {
     /// `max_memory` in bytes; `None` when unlimited, or when no session exists.
     pub max_memory: Option<usize>,
     /// Whether the session type checks each fed snippet.
     pub type_check: bool,
+    /// Maximum suspensions the host may service; enforced outside the child.
+    pub max_suspensions: Option<usize>,
 }
 
 /// REPL session state of the child.
@@ -330,6 +332,11 @@ impl Child {
                     .and_then(|limits| limits.max_memory_bytes)
                     .map(|v| usize::try_from(v).unwrap_or(usize::MAX)),
                 type_check: config.type_check,
+                max_suspensions: config
+                    .limits
+                    .as_ref()
+                    .and_then(|limits| limits.max_suspensions)
+                    .map(|v| usize::try_from(v).unwrap_or(usize::MAX)),
             },
             SessionState::Configured(None) => SessionBudget::default(),
             SessionState::Ready(repl) => self.tracker_budget(repl.tracker()),
@@ -342,6 +349,7 @@ impl Child {
         SessionBudget {
             max_memory: tracker.max_memory(),
             type_check: self.type_check.is_some(),
+            max_suspensions: tracker.max_suspensions(),
         }
     }
 

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -245,6 +245,7 @@ impl Child {
             pb::parent_request::Kind::ResumeCall(resume) => self.handle_resume_call(resume, sink),
             pb::parent_request::Kind::ResumeNameLookup(resume) => self.handle_resume_name_lookup(resume, sink),
             pb::parent_request::Kind::ResumeFutures(resume) => self.handle_resume_futures(resume, sink),
+            pb::parent_request::Kind::AbortFeed(abort) => self.handle_abort_feed(abort, sink),
             pb::parent_request::Kind::Dump(_) => self.handle_dump(),
             pb::parent_request::Kind::Load(load) => self.handle_load(&load),
             pb::parent_request::Kind::Reset(_) => match self.reset() {
@@ -264,7 +265,7 @@ impl Child {
                 return Ok(HandleOutcome::Shutdown);
             }
         };
-        self.stamp_execution_time(&mut event);
+        self.stamp_session_budget(&mut event);
         let sent = sink.send(&event);
         // a suspension announcement was *lent* the payload it announces, so
         // take it back before anything can observe the stored suspension
@@ -352,7 +353,7 @@ impl Child {
         let mut event = fatal_error_event(message);
         // fatal paths bypass `handle`, so stamp timing here to keep the
         // "every turn-ending event carries timing" contract intact
-        self.stamp_execution_time(&mut event);
+        self.stamp_session_budget(&mut event);
         event
     }
 
@@ -386,7 +387,7 @@ impl Child {
                     ExcType::RuntimeError,
                     &format!("result frame of {len} bytes exceeds the maximum of {max} bytes"),
                 );
-                self.stamp_execution_time(&mut event);
+                self.stamp_session_budget(&mut event);
                 sink.send(&event)
             }
             other => Err(other),
@@ -395,9 +396,10 @@ impl Child {
 
     /// Stamps cumulative execution time and the `max_duration` budget onto a
     /// turn-ending event, making the child the single source of truth for
-    /// timing (the parent's watchdog derives its backstop from these fields).
-    /// Left zero/absent when no session exists.
-    fn stamp_execution_time(&self, event: &mut pb::ChildEvent) {
+    /// timing (the parent's watchdog derives its backstop from these fields),
+    /// plus the `max_suspensions` budget so a parent restoring a dump learns
+    /// the limit it is to enforce. Left zero/absent when no session exists.
+    fn stamp_session_budget(&self, event: &mut pb::ChildEvent) {
         let tracker = match &self.state {
             SessionState::Ready(repl) => repl.tracker(),
             SessionState::Suspended(progress) => progress.tracker(),
@@ -408,6 +410,7 @@ impl Child {
         event.max_duration_micros = tracker
             .max_duration()
             .map(|max| u64::try_from(max.as_micros()).unwrap_or(u64::MAX));
+        event.max_suspensions = tracker.max_suspensions().map(|max| max as u64);
     }
 
     /// Stores the session config; the repl is built lazily by [`ensure_repl`]
@@ -588,6 +591,40 @@ impl Child {
         };
         let mut print = ProtoPrint::new(sink);
         let outcome = lookup.resume(result, PrintWriter::Callback(&mut print));
+        let event = self.drive(outcome, &mut print);
+        print.drain();
+        event
+    }
+
+    /// Ends the suspended feed by raising the parent's exception uncatchably
+    /// at the suspension point, whatever its kind (see `AbortFeed` in the
+    /// schema). The session comes back `Ready` inside the `Error` turn-ender.
+    fn handle_abort_feed(&mut self, abort: pb::AbortFeed, sink: &mut dyn EventSink) -> pb::ChildEvent {
+        // `drive` only ever stores suspensions here, so `Complete` cannot be
+        // pending; the guard keeps that a violation rather than a crash
+        let suspended = matches!(&self.state, SessionState::Suspended(progress)
+            if !matches!(progress.as_ref(), ReplProgress::Complete { .. }));
+        if !suspended {
+            return protocol_violation("AbortFeed without a suspended feed");
+        }
+        let Some(exception) = abort.exception else {
+            return protocol_violation("AbortFeed has no exception");
+        };
+        let exc = match MontyException::try_from(exception) {
+            Ok(exc) => exc,
+            Err(err) => return protocol_violation(&format!("invalid exception: {err}")),
+        };
+        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
+            unreachable!("checked above");
+        };
+        let mut print = ProtoPrint::new(sink);
+        let outcome = match *progress {
+            ReplProgress::FunctionCall(call) => call.abort(exc, PrintWriter::Callback(&mut print)),
+            ReplProgress::OsCall(call) => call.abort(exc, PrintWriter::Callback(&mut print)),
+            ReplProgress::NameLookup(lookup) => lookup.abort(exc, PrintWriter::Callback(&mut print)),
+            ReplProgress::ResolveFutures(state) => state.abort(exc, PrintWriter::Callback(&mut print)),
+            ReplProgress::Complete { .. } => unreachable!("checked above"),
+        };
         let event = self.drive(outcome, &mut print);
         print.drain();
         event

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -22,7 +22,7 @@ use monty::{Dump, MontyRepl, ReplProgress, ReplStartError, Session, SessionRef, 
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
     AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, OsFunctionCall,
-    PrintWriter, PrintWriterCallback, ResourceTracker, TypeCheckState, TypeCheckingConfig,
+    PrintWriter, PrintWriterCallback, ResourceLimits, ResourceTracker, TypeCheckState, TypeCheckingConfig,
 };
 
 use super::{
@@ -162,6 +162,7 @@ pub struct SessionBudget {
     /// Whether the session type checks each fed snippet.
     pub type_check: bool,
     /// Maximum suspensions the host may service; enforced outside the child.
+    /// `None` only when no session exists.
     pub max_suspensions: Option<usize>,
 }
 
@@ -333,11 +334,8 @@ impl Child {
                     .and_then(|limits| limits.max_memory_bytes)
                     .map(|v| usize::try_from(v).unwrap_or(usize::MAX)),
                 type_check: config.type_check,
-                max_suspensions: config
-                    .limits
-                    .as_ref()
-                    .and_then(|limits| limits.max_suspensions)
-                    .map(|v| usize::try_from(v).unwrap_or(usize::MAX)),
+                // the wire default applies before the repl exists too
+                max_suspensions: Some(ResourceLimits::from(config.limits.unwrap_or_default()).max_suspensions),
             },
             SessionState::Configured(None) => SessionBudget::default(),
             SessionState::Ready(repl) => self.tracker_budget(repl.tracker()),
@@ -350,7 +348,7 @@ impl Child {
         SessionBudget {
             max_memory: tracker.max_memory(),
             type_check: self.type_check.is_some(),
-            max_suspensions: tracker.max_suspensions(),
+            max_suspensions: Some(tracker.max_suspensions()),
         }
     }
 
@@ -934,7 +932,7 @@ fn stamp_budget(event: &mut pb::ChildEvent, tracker: &ResourceTracker) {
     event.max_duration_micros = tracker
         .max_duration()
         .map(|max| u64::try_from(max.as_micros()).unwrap_or(u64::MAX));
-    event.max_suspensions = tracker.max_suspensions().map(|max| max as u64);
+    event.max_suspensions = Some(tracker.max_suspensions() as u64);
 }
 
 /// Describes a suspension announcement that would exceed the wire frame limit.

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -261,7 +261,7 @@ fn abort_feed_ends_a_suspended_feed_uncatchably() {
     let request = frame_request(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
         exception: Some(pb::RaisedException {
             exc_type: "RuntimeError".to_owned(),
-            message: Some("suspension limit exceeded: 4 > 3".to_owned()),
+            message: Some("suspension limit 3 exceeded".to_owned()),
             traceback: vec![],
             data: None,
         }),
@@ -274,7 +274,7 @@ fn abort_feed_ends_a_suspended_feed_uncatchably() {
     };
     let exception = error.exception.expect("error carries the exception");
     assert_eq!(exception.exc_type, "RuntimeError");
-    assert_eq!(exception.message.as_deref(), Some("suspension limit exceeded: 4 > 3"));
+    assert_eq!(exception.message.as_deref(), Some("suspension limit 3 exceeded"));
     // raised where the feed stopped: the traceback names the call's line
     assert_eq!(exception.traceback.len(), 1);
     assert_eq!(exception.traceback[0].start.map(|loc| loc.line), Some(3));

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -236,8 +236,7 @@ fn load_rejects_dump_with_over_deep_suspension_args() {
     assert_eq!(expect_complete(event), MontyObject::Int(2));
 }
 
-/// Decodes a turn's frames keeping the whole `ChildEvent`, for the budget
-/// fields stamped beside the kind.
+/// Decodes complete events, including their session budget fields.
 fn decode_full_events(bytes: &[u8]) -> Vec<pb::ChildEvent> {
     let mut reader = FrameReader::new(bytes);
     let mut events = Vec::new();
@@ -247,9 +246,7 @@ fn decode_full_events(bytes: &[u8]) -> Vec<pb::ChildEvent> {
     events
 }
 
-/// `AbortFeed` ends a suspended feed with the parent's exception raised
-/// uncatchably at the suspension — the `except` around the call never runs —
-/// and the session stays usable for the next feed.
+/// `AbortFeed` raises the supplied error uncatchably and leaves the session usable.
 #[test]
 fn abort_feed_ends_a_suspended_feed_uncatchably() {
     let mut child = Child::default();

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -235,3 +235,110 @@ fn load_rejects_dump_with_over_deep_suspension_args() {
     let (_, event) = feed(&mut child, "1 + 1");
     assert_eq!(expect_complete(event), MontyObject::Int(2));
 }
+
+/// Decodes a turn's frames keeping the whole `ChildEvent`, for the budget
+/// fields stamped beside the kind.
+fn decode_full_events(bytes: &[u8]) -> Vec<pb::ChildEvent> {
+    let mut reader = FrameReader::new(bytes);
+    let mut events = Vec::new();
+    while let Some(event) = reader.read::<pb::ChildEvent>().expect("reply frames decode") {
+        events.push(event);
+    }
+    events
+}
+
+/// `AbortFeed` ends a suspended feed with the parent's exception raised
+/// uncatchably at the suspension — the `except` around the call never runs —
+/// and the session stays usable for the next feed.
+#[test]
+fn abort_feed_ends_a_suspended_feed_uncatchably() {
+    let mut child = Child::default();
+    create_repl(&mut child);
+    let (_, event) = feed(
+        &mut child,
+        "x = 41\ntry:\n    fetch('x')\nexcept Exception:\n    x = 0\n",
+    );
+    let pb::child_event::Kind::FunctionCall(_) = event else {
+        panic!("expected FunctionCall, got {event:?}");
+    };
+    let request = frame_request(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
+        exception: Some(pb::RaisedException {
+            exc_type: "RuntimeError".to_owned(),
+            message: Some("suspension limit exceeded: 4 > 3".to_owned()),
+            traceback: vec![],
+            data: None,
+        }),
+    }));
+    let (bytes, outcome) = dispatch_frame(&mut child, &request);
+    assert_eq!(outcome, HandleOutcome::Continue);
+    let (_, event) = split_turn(&bytes);
+    let pb::child_event::Kind::Error(error) = event else {
+        panic!("expected Error, got {event:?}");
+    };
+    let exception = error.exception.expect("error carries the exception");
+    assert_eq!(exception.exc_type, "RuntimeError");
+    assert_eq!(exception.message.as_deref(), Some("suspension limit exceeded: 4 > 3"));
+    // raised where the feed stopped: the traceback names the call's line
+    assert_eq!(exception.traceback.len(), 1);
+    assert_eq!(exception.traceback[0].start.map(|loc| loc.line), Some(3));
+    // the session survives with the globals from before the suspension
+    let (_, event) = feed(&mut child, "x");
+    assert_eq!(expect_complete(event), MontyObject::Int(41));
+}
+
+/// `AbortFeed` is only meaningful while a feed is suspended.
+#[test]
+fn abort_feed_without_a_suspension_is_a_protocol_violation() {
+    let mut child = Child::default();
+    create_repl(&mut child);
+    let request = frame_request(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
+        exception: Some(pb::RaisedException {
+            exc_type: "RuntimeError".to_owned(),
+            message: None,
+            traceback: vec![],
+            data: None,
+        }),
+    }));
+    let (bytes, outcome) = dispatch_frame(&mut child, &request);
+    assert_eq!(outcome, HandleOutcome::Continue);
+    let (_, event) = split_turn(&bytes);
+    let pb::child_event::Kind::Error(error) = event else {
+        panic!("expected Error, got {event:?}");
+    };
+    let exception = error.exception.expect("error carries the exception");
+    assert_eq!(
+        exception.message.as_deref(),
+        Some("protocol violation: AbortFeed without a suspended feed")
+    );
+    // the session is untouched
+    let (_, event) = feed(&mut child, "1 + 1");
+    assert_eq!(expect_complete(event), MontyObject::Int(2));
+}
+
+/// The child echoes the session's `max_suspensions` on every turn-ending
+/// event, so a parent restoring a dump learns the budget it must enforce.
+#[test]
+fn turn_events_carry_the_suspension_budget() {
+    let mut child = Child::default();
+    let request = frame_request(pb::parent_request::Kind::Configure(pb::Configure {
+        script_name: "main.py".to_owned(),
+        limits: Some(pb::ResourceLimits {
+            max_suspensions: Some(3),
+            ..Default::default()
+        }),
+        monty_version: MONTY_VERSION.to_owned(),
+        protocol_version: PROTOCOL_VERSION,
+        ..Default::default()
+    }));
+    let (_, outcome) = dispatch_frame(&mut child, &request);
+    assert_eq!(outcome, HandleOutcome::Continue);
+    let request = frame_request(pb::parent_request::Kind::Feed(pb::Feed {
+        code: "1 + 1".to_owned(),
+        inputs: vec![],
+        skip_type_check: false,
+    }));
+    let (bytes, _) = dispatch_frame(&mut child, &request);
+    let events = decode_full_events(&bytes);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].max_suspensions, Some(3));
+}

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -431,12 +431,9 @@ pub struct StackFrame {
     #[prost(bool, tag = "7")]
     pub hide_frame_name: bool,
 }
-/// Sandbox resource limits. Absent fields mean "unlimited" except recursion
-/// depth, which defaults to monty's standard limit (1000) when absent. All but
-/// `max_suspensions` are enforced inside the child; `max_suspensions` is the
-/// budget the *parent* enforces by counting the suspensions it services and
-/// ending the feed with `AbortFeed` — the child only stores it (so it travels
-/// in dumps) and echoes it on `ChildEvent.max_suspensions`.
+/// Sandbox resource limits. Absent fields are unlimited except recursion depth,
+/// which defaults to 1000. The parent enforces `max_suspensions`; the child only
+/// retains it for dumps and echoes it on `ChildEvent`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]
@@ -604,14 +601,9 @@ pub struct Feed {
     #[prost(bool, tag = "3")]
     pub skip_type_check: bool,
 }
-/// Ends a suspended feed instead of answering its suspension — whichever kind
-/// (`FunctionCall`, `OsCall`, `NameLookup`, `ResolveFutures`) is pending. The
-/// exception is raised at the suspension point uncatchably: every frame
-/// unwinds into its traceback and no `except` runs, so a snippet retrying
-/// refused calls cannot continue. The session survives (the reply is an
-/// `Error` turn-ender) and later feeds work. This is how the parent enforces
-/// `ResourceLimits.max_suspensions`, and a general host tool for ending a feed.
-/// Valid only while a suspension is pending.
+/// Ends a pending suspension by raising `exception` uncatchably at its site.
+/// The session returns ready in an `Error` event. Hosts use this to stop a feed,
+/// including when `max_suspensions` is exceeded.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbortFeed {
     #[prost(message, optional, tag = "1")]
@@ -717,9 +709,8 @@ pub struct ChildEvent {
     /// state bytes) still learns the budget.
     #[prost(uint64, optional, tag = "21")]
     pub max_duration_micros: ::core::option::Option<u64>,
-    /// The session's `max_suspensions` budget, when one is configured — the
-    /// parent enforces it (see `AbortFeed`), so this is only how a parent that
-    /// restored a session via `Load` learns the budget the dump carries.
+    /// Echoes the parent-enforced budget so a host restoring an opaque dump can
+    /// recover it.
     #[prost(uint64, optional, tag = "23")]
     pub max_suspensions: ::core::option::Option<u64>,
     /// The session's script name, surfaced on a `Load` reply so a parent that

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -431,9 +431,10 @@ pub struct StackFrame {
     #[prost(bool, tag = "7")]
     pub hide_frame_name: bool,
 }
-/// Sandbox resource limits. Absent fields are unlimited except recursion depth,
-/// which defaults to 1000. The parent enforces `max_suspensions`; the child only
-/// retains it for dumps and echoes it on `ChildEvent`.
+/// Sandbox resource limits. Absent fields are unlimited except recursion depth
+/// and `max_suspensions`, which both default to 1000. The parent enforces
+/// `max_suspensions`; the child only retains it for dumps and echoes it on
+/// `ChildEvent`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -431,9 +431,12 @@ pub struct StackFrame {
     #[prost(bool, tag = "7")]
     pub hide_frame_name: bool,
 }
-/// Sandbox resource limits, enforced inside the child. Absent fields mean
-/// "unlimited" except recursion depth, which defaults to monty's standard
-/// limit (1000) when absent.
+/// Sandbox resource limits. Absent fields mean "unlimited" except recursion
+/// depth, which defaults to monty's standard limit (1000) when absent. All but
+/// `max_suspensions` are enforced inside the child; `max_suspensions` is the
+/// budget the *parent* enforces by counting the suspensions it services and
+/// ending the feed with `AbortFeed` — the child only stores it (so it travels
+/// in dumps) and echoes it on `ChildEvent.max_suspensions`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     #[prost(uint64, optional, tag = "1")]
@@ -444,6 +447,8 @@ pub struct ResourceLimits {
     pub gc_interval: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "4")]
     pub max_recursion_depth: ::core::option::Option<u64>,
+    #[prost(uint64, optional, tag = "5")]
+    pub max_suspensions: ::core::option::Option<u64>,
 }
 /// Outcome of an external function / OS call, decided by the parent. Mirrors
 /// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can
@@ -506,7 +511,7 @@ pub struct ParentRequest {
     /// not depend on it, and it is absent whenever the parent is not tracing.
     #[prost(string, optional, tag = "20")]
     pub trace_parent: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(oneof = "parent_request::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof = "parent_request::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub kind: ::core::option::Option<parent_request::Kind>,
 }
 /// Nested message and enum types in `ParentRequest`.
@@ -533,6 +538,8 @@ pub mod parent_request {
         Reset(super::Reset),
         #[prost(message, tag = "10")]
         Shutdown(super::Shutdown),
+        #[prost(message, tag = "11")]
+        AbortFeed(super::AbortFeed),
     }
 }
 /// Configures the REPL session this child will serve until `Reset`, sent once
@@ -596,6 +603,19 @@ pub struct Feed {
     /// Skip type checking for this feed even when the session enables it.
     #[prost(bool, tag = "3")]
     pub skip_type_check: bool,
+}
+/// Ends a suspended feed instead of answering its suspension — whichever kind
+/// (`FunctionCall`, `OsCall`, `NameLookup`, `ResolveFutures`) is pending. The
+/// exception is raised at the suspension point uncatchably: every frame
+/// unwinds into its traceback and no `except` runs, so a snippet retrying
+/// refused calls cannot continue. The session survives (the reply is an
+/// `Error` turn-ender) and later feeds work. This is how the parent enforces
+/// `ResourceLimits.max_suspensions`, and a general host tool for ending a feed.
+/// Valid only while a suspension is pending.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AbortFeed {
+    #[prost(message, optional, tag = "1")]
+    pub exception: ::core::option::Option<RaisedException>,
 }
 /// Answers a `FunctionCall` or `OsCall` suspension. `call_id` must match the
 /// suspension event.
@@ -697,6 +717,11 @@ pub struct ChildEvent {
     /// state bytes) still learns the budget.
     #[prost(uint64, optional, tag = "21")]
     pub max_duration_micros: ::core::option::Option<u64>,
+    /// The session's `max_suspensions` budget, when one is configured — the
+    /// parent enforces it (see `AbortFeed`), so this is only how a parent that
+    /// restored a session via `Load` learns the budget the dump carries.
+    #[prost(uint64, optional, tag = "23")]
+    pub max_suspensions: ::core::option::Option<u64>,
     /// The session's script name, surfaced on a `Load` reply so a parent that
     /// restored a session (whose script name, like the limits above, travels
     /// inside the opaque dump bytes) learns it without parsing the dump. Set only

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -571,12 +571,14 @@ fn resource_limits_round_trip() {
         max_memory: Some(64 * 1024 * 1024),
         gc_interval: Some(100),
         max_recursion_depth: 50,
+        max_suspensions: Some(7),
     };
     let back = ResourceLimits::from(pb::ResourceLimits::from(&limits));
     assert_eq!(back.max_duration, limits.max_duration);
     assert_eq!(back.max_memory, limits.max_memory);
     assert_eq!(back.gc_interval, limits.gc_interval);
     assert_eq!(back.max_recursion_depth, limits.max_recursion_depth);
+    assert_eq!(back.max_suspensions, limits.max_suspensions);
 }
 
 #[test]
@@ -589,6 +591,7 @@ fn empty_resource_limits_default_recursion_depth() {
     assert_eq!(back.max_memory, expected.max_memory);
     assert_eq!(back.gc_interval, expected.gc_interval);
     assert_eq!(back.max_recursion_depth, expected.max_recursion_depth);
+    assert_eq!(back.max_suspensions, None);
 }
 
 #[test]

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -571,7 +571,7 @@ fn resource_limits_round_trip() {
         max_memory: Some(64 * 1024 * 1024),
         gc_interval: Some(100),
         max_recursion_depth: 50,
-        max_suspensions: Some(7),
+        max_suspensions: 7,
     };
     let back = ResourceLimits::from(pb::ResourceLimits::from(&limits));
     assert_eq!(back.max_duration, limits.max_duration);
@@ -584,14 +584,15 @@ fn resource_limits_round_trip() {
 #[test]
 fn empty_resource_limits_default_recursion_depth() {
     // an all-absent wire message must behave like ResourceLimits::default():
-    // unlimited everything except the standard recursion-depth default
+    // unlimited everything except the recursion-depth and suspension defaults
     let back = ResourceLimits::from(pb::ResourceLimits::default());
     let expected = ResourceLimits::default();
     assert_eq!(back.max_duration, expected.max_duration);
     assert_eq!(back.max_memory, expected.max_memory);
     assert_eq!(back.gc_interval, expected.gc_interval);
     assert_eq!(back.max_recursion_depth, expected.max_recursion_depth);
-    assert_eq!(back.max_suspensions, None);
+    assert_eq!(back.max_suspensions, expected.max_suspensions);
+    assert_eq!(back.max_suspensions, 1000);
 }
 
 #[test]

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -55,9 +55,9 @@ with Monty() as pool:
         #> 3
 ```
 
-`max_suspensions` limits external calls, OS callbacks, name lookups and future-resolution turns for one checkout.
-The pool ends the feed with an uncatchable `RuntimeError` on the suspension past the limit.
-The session remains usable for code that does not suspend, but the suspension count remains spent.
+`max_suspensions` limits host-serviced suspensions per checkout. Exceeding it
+aborts the feed with an uncatchable `RuntimeError`; the session remains usable,
+but its suspension count remains spent.
 
 or in async code:
 

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -55,7 +55,8 @@ with Monty() as pool:
         #> 3
 ```
 
-`max_suspensions` limits host-serviced suspensions per checkout. Exceeding it
+`max_suspensions` limits host-serviced suspensions per checkout (default
+1000; it cannot be disabled). Exceeding it
 aborts the feed with an uncatchable `RuntimeError`; the session remains usable,
 but its suspension count remains spent.
 

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -50,10 +50,14 @@ installed as part of the `pydantic-monty` meta-package.
 from pydantic_monty import Monty
 
 with Monty() as pool:
-    with pool.checkout() as session:
+    with pool.checkout(limits={'max_suspensions': 100}) as session:
         print(session.feed_run('1 + 2'))
         #> 3
 ```
+
+`max_suspensions` limits external calls, OS callbacks, name lookups and future-resolution turns for one checkout.
+The pool ends the feed with an uncatchable `RuntimeError` on the suspension past the limit.
+The session remains usable for code that does not suspend, but the suspension count remains spent.
 
 or in async code:
 

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -112,8 +112,9 @@ class ResourceLimits(TypedDict, total=False):
     Configuration for resource limits during code execution.
 
     All limits are optional. Omit a key — or set it to `None` explicitly —
-    to disable that limit, with one exception: `max_recursion_depth` cannot
-    be disabled, and omitting it leaves the 1000-frame default in place.
+    to disable that limit, with two exceptions: `max_recursion_depth` and
+    `max_suspensions` cannot be disabled, and omitting either leaves its
+    1000 default in place.
     """
 
     max_duration_secs: float | None

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -129,12 +129,10 @@ class ResourceLimits(TypedDict, total=False):
     """Maximum function call stack depth (default: 1000)."""
 
     max_suspensions: int | None
-    """Maximum number of suspensions — external function calls, `os` callbacks,
-    name lookups and future resolutions — the session may hand to the host.
+    """Maximum external calls, `os` callbacks, name lookups and future resolutions per checkout.
 
-    Enforced by the pool, not the interpreter: on the one past the budget the feed
-    ends with an uncatchable `RuntimeError` and the session stays usable. The
-    count is per checkout and restarts when a dump is restored."""
+    The pool aborts an over-budget feed with an uncatchable `RuntimeError`; the
+    session remains usable. Restoring a dump resets the count."""
 
 
 class ExternalReturnValue(TypedDict):

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -129,7 +129,7 @@ class ResourceLimits(TypedDict, total=False):
     """Maximum function call stack depth (default: 1000)."""
 
     max_suspensions: int | None
-    """Maximum external calls, `os` callbacks, name lookups and future resolutions per checkout.
+    """Maximum external calls, `os` callbacks, name lookups and future resolutions per checkout (default: 1000).
 
     The pool aborts an over-budget feed with an uncatchable `RuntimeError`; the
     session remains usable. Restoring a dump resets the count."""

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -128,6 +128,14 @@ class ResourceLimits(TypedDict, total=False):
     max_recursion_depth: int | None
     """Maximum function call stack depth (default: 1000)."""
 
+    max_suspensions: int | None
+    """Maximum number of suspensions — external function calls, `os` callbacks,
+    name lookups and future resolutions — the session may hand to the host.
+
+    Enforced by the pool, not the interpreter: on the one past the budget the feed
+    ends with an uncatchable `RuntimeError` and the session stays usable. The
+    count is per checkout and restarts when a dump is restored."""
+
 
 class ExternalReturnValue(TypedDict):
     """Represents the return value of an external function call."""

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -544,7 +544,8 @@ class Monty:
 
         Arguments:
             script_name: Name used in tracebacks and error messages.
-            limits: Resource limits enforced inside the worker.
+            limits: Resource limits enforced inside the worker, plus `max_suspensions`,
+                which the pool enforces itself.
             type_check: Type-check each fed snippet before executing it; each
                 successfully executed snippet is appended to the accumulated
                 context used for type-checking subsequent snippets.

--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -11,6 +11,7 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 /// - `max_memory`: Maximum heap memory in bytes (int)
 /// - `gc_interval`: Run garbage collection every N allocations (int)
 /// - `max_recursion_depth`: Maximum function call stack depth (int, default: 1000)
+/// - `max_suspensions`: Maximum host round trips the pool will service (int)
 ///
 /// If a key is missing or set to `None`, that limit is not applied
 /// (except `max_recursion_depth` which defaults to 1000).
@@ -40,6 +41,7 @@ pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty_types::Resourc
             LimitKey::MaxMemory => limits.max_memory(value.extract()?),
             LimitKey::GcInterval => limits.gc_interval(value.extract()?),
             LimitKey::MaxRecursionDepth => limits.max_recursion_depth(value.extract()?),
+            LimitKey::MaxSuspensions => limits.max_suspensions(value.extract()?),
         };
     }
     Ok(limits)
@@ -53,6 +55,7 @@ enum LimitKey {
     MaxMemory,
     GcInterval,
     MaxRecursionDepth,
+    MaxSuspensions,
 }
 
 impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
@@ -64,6 +67,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
             "max_memory" => Ok(Self::MaxMemory),
             "gc_interval" => Ok(Self::GcInterval),
             "max_recursion_depth" => Ok(Self::MaxRecursionDepth),
+            "max_suspensions" => Ok(Self::MaxSuspensions),
             _ => {
                 // `repr()` runs user `__repr__`, which may itself raise — fall
                 // back so the promised `ValueError` is raised for every unknown key.
@@ -72,7 +76,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
                     .map_or_else(|_| "<unprintable key>".to_owned(), |r| r.to_string());
                 Err(PyValueError::new_err(format!(
                     "unknown limits key {key_repr}; accepted keys are 'max_duration_secs', \
-                     'max_memory', 'gc_interval', 'max_recursion_depth'"
+                     'max_memory', 'gc_interval', 'max_recursion_depth', 'max_suspensions'"
                 )))
             }
         }

--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -11,10 +11,10 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 /// - `max_memory`: Maximum heap memory in bytes (int)
 /// - `gc_interval`: Run garbage collection every N allocations (int)
 /// - `max_recursion_depth`: Maximum function call stack depth (int, default: 1000)
-/// - `max_suspensions`: Maximum host round trips the pool will service (int)
+/// - `max_suspensions`: Maximum host round trips the pool will service (int, default: 1000)
 ///
 /// If a key is missing or set to `None`, that limit is not applied
-/// (except `max_recursion_depth` which defaults to 1000).
+/// (except `max_recursion_depth` and `max_suspensions`, which default to 1000).
 ///
 /// Raises `TypeError` if a value is present but has the wrong type.
 /// Raises `ValueError` if the dict contains an unknown key — limits are a

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -17,11 +17,13 @@ def test_resource_limits_typed_dict():
         max_memory=1024,
         gc_interval=10,
         max_recursion_depth=500,
+        max_suspensions=20,
     )
     assert limits.get('max_duration_secs') == snapshot(5.0)
     assert limits.get('max_memory') == snapshot(1024)
     assert limits.get('gc_interval') == snapshot(10)
     assert limits.get('max_recursion_depth') == snapshot(500)
+    assert limits.get('max_suspensions') == snapshot(20)
 
 
 def test_resource_limits_repr():
@@ -98,6 +100,33 @@ def test_session_exhausted_after_resource_error_but_worker_reusable(pool: Monty)
         assert session.feed_run('1 + 1') == snapshot(2)
 
 
+def test_suspension_limit(pool: Monty):
+    """`max_suspensions` is enforced by the pool: the suspension past the budget ends the
+    feed with an uncatchable `RuntimeError`, the session stays usable, and the count is
+    per checkout so a later suspending feed fails on its first suspension."""
+    code = """
+n = 0
+while True:
+    try:
+        fetch('x')
+    except Exception:
+        n += 1
+"""
+
+    def fetch(url: str) -> None:
+        raise ValueError('refused')
+
+    with pool.checkout(limits={'max_suspensions': 3}) as session:
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.feed_run(code, external_lookup={'fetch': fetch})
+        assert isinstance(exc_info.value.exception(), RuntimeError)
+        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit exceeded: 4 > 3')
+        assert session.feed_run('n') == snapshot(3)
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.feed_run('fetch("y")', external_lookup={'fetch': fetch})
+        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit exceeded: 5 > 3')
+
+
 def test_limits_with_inputs(monty_run: RunMonty):
     assert monty_run('x * 2', inputs={'x': 21}, limits={'max_duration_secs': 5.0}) == snapshot(42)
 
@@ -114,7 +143,7 @@ def test_limits_unknown_key_raises_error(pool: Monty):
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key 'max_memroy'; accepted keys are 'max_duration_secs', 'max_memory', "
-        "'gc_interval', 'max_recursion_depth'"
+        "'gc_interval', 'max_recursion_depth', 'max_suspensions'"
     )
 
 
@@ -124,7 +153,7 @@ def test_limits_non_string_key_raises_error(pool: Monty):
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key 1; accepted keys are 'max_duration_secs', 'max_memory', "
-        "'gc_interval', 'max_recursion_depth'"
+        "'gc_interval', 'max_recursion_depth', 'max_suspensions'"
     )
 
 
@@ -138,7 +167,7 @@ def test_limits_unprintable_key_still_raises_value_error(pool: Monty):
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key <unprintable key>; accepted keys are 'max_duration_secs', 'max_memory', "
-        "'gc_interval', 'max_recursion_depth'"
+        "'gc_interval', 'max_recursion_depth', 'max_suspensions'"
     )
 
 

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -101,9 +101,6 @@ def test_session_exhausted_after_resource_error_but_worker_reusable(pool: Monty)
 
 
 def test_suspension_limit(pool: Monty):
-    """`max_suspensions` is enforced by the pool: the suspension past the budget ends the
-    feed with an uncatchable `RuntimeError`, the session stays usable, and the count is
-    per checkout so a later suspending feed fails on its first suspension."""
     code = """
 n = 0
 while True:

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -124,6 +124,27 @@ while True:
         assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit exceeded: 5 > 3')
 
 
+def test_suspension_limit_defaults_to_one_thousand(pool: Monty):
+    """A checkout with no limits still stops a sandbox looping on host calls."""
+    code = """
+n = 0
+while True:
+    fetch('x')
+    n += 1
+"""
+
+    def fetch(url: str) -> None:
+        return None
+
+    with pool.checkout() as session:
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.feed_run(code, external_lookup={'fetch': fetch})
+        assert exc_info.value.display(format='type-msg') == snapshot(
+            'RuntimeError: suspension limit exceeded: 1001 > 1000'
+        )
+        assert session.feed_run('n') == snapshot(1000)
+
+
 def test_limits_with_inputs(monty_run: RunMonty):
     assert monty_run('x * 2', inputs={'x': 21}, limits={'max_duration_secs': 5.0}) == snapshot(42)
 

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -117,11 +117,11 @@ while True:
         with pytest.raises(MontyRuntimeError) as exc_info:
             session.feed_run(code, external_lookup={'fetch': fetch})
         assert isinstance(exc_info.value.exception(), RuntimeError)
-        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit exceeded: 4 > 3')
+        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit 3 exceeded')
         assert session.feed_run('n') == snapshot(3)
         with pytest.raises(MontyRuntimeError) as exc_info:
             session.feed_run('fetch("y")', external_lookup={'fetch': fetch})
-        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit exceeded: 5 > 3')
+        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit 3 exceeded')
 
 
 def test_suspension_limit_defaults_to_one_thousand(pool: Monty):
@@ -139,9 +139,7 @@ while True:
     with pool.checkout() as session:
         with pytest.raises(MontyRuntimeError) as exc_info:
             session.feed_run(code, external_lookup={'fetch': fetch})
-        assert exc_info.value.display(format='type-msg') == snapshot(
-            'RuntimeError: suspension limit exceeded: 1001 > 1000'
-        )
+        assert exc_info.value.display(format='type-msg') == snapshot('RuntimeError: suspension limit 1000 exceeded')
         assert session.feed_run('n') == snapshot(1000)
 
 

--- a/crates/monty-runtime/README-crate.md
+++ b/crates/monty-runtime/README-crate.md
@@ -24,7 +24,7 @@ hello world
 - `-m` / `--mount /host/path::/virtual/path[::mode[::write_limit_bytes]]` —
   mount a host directory into the sandbox (`ro`, `rw`, or `overlay`)
 - `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
-  `--gc-interval` — sandbox resource limits
+  `--gc-interval`, `--max-suspensions` — sandbox resource limits
 
 ## Features
 

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -39,7 +39,7 @@ monty --help
 - `-m` / `--mount /host/path::/virtual/path[::mode[::write_limit_bytes]]` —
   mount a host directory into the sandbox (`ro`, `rw`, or `overlay`)
 - `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
-  `--gc-interval` — sandbox resource limits
+  `--gc-interval`, `--max-suspensions` — sandbox resource limits
 
 ## Worker mode
 

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -72,7 +72,7 @@ pub(crate) struct Cli {
     #[arg(long)]
     max_recursion_depth: Option<usize>,
 
-    /// Maximum number of suspensions (OS calls, name lookups) serviced per run.
+    /// Maximum suspensions serviced in one CLI session.
     #[arg(long)]
     max_suspensions: Option<usize>,
 

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -72,7 +72,7 @@ pub(crate) struct Cli {
     #[arg(long)]
     max_recursion_depth: Option<usize>,
 
-    /// Maximum suspensions serviced in one CLI session.
+    /// Maximum suspensions serviced in one CLI session (defaults to 1000).
     #[arg(long)]
     max_suspensions: Option<usize>,
 

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -72,6 +72,10 @@ pub(crate) struct Cli {
     #[arg(long)]
     max_recursion_depth: Option<usize>,
 
+    /// Maximum number of suspensions (OS calls, name lookups) serviced per run.
+    #[arg(long)]
+    max_suspensions: Option<usize>,
+
     #[command(subcommand)]
     subcommand: Option<Command>,
 }
@@ -118,6 +122,7 @@ impl Cli {
             || self.max_memory.is_some()
             || self.gc_interval.is_some()
             || self.max_recursion_depth.is_some()
+            || self.max_suspensions.is_some()
     }
 
     /// Builds `ResourceLimits` from the parsed CLI arguments.
@@ -142,6 +147,9 @@ impl Cli {
         }
         if let Some(depth) = self.max_recursion_depth {
             limits = limits.max_recursion_depth(depth);
+        }
+        if let Some(max) = self.max_suspensions {
+            limits = limits.max_suspensions(max);
         }
         Ok(limits)
     }

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -582,7 +582,7 @@ impl SuspensionBudget {
         (self.seen > limit).then(|| {
             MontyException::new(
                 ExcType::RuntimeError,
-                Some(format!("suspension limit exceeded: {} > {limit}", self.seen)),
+                Some(format!("suspension limit {limit} exceeded")),
             )
         })
     }

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -23,8 +23,8 @@ use monty::{MontyRepl, MontyRun, ReplContinuationMode, ReplProgress, RunProgress
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
-    CompileOptions, ExtFunctionResult, MontyObject, NameLookupResult, OsFunctionCall, PrintWriter, ResourceLimits,
-    ResourceTracker, TypeCheckingConfig,
+    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult, OsFunctionCall,
+    PrintWriter, ResourceLimits, ResourceTracker, TypeCheckingConfig,
 };
 use rustyline::{DefaultEditor, error::ReadlineError};
 #[cfg(feature = "telemetry")]
@@ -222,7 +222,8 @@ fn run_script(
             }
         };
 
-        match run_until_complete(progress, &mut mount_table) {
+        let mut suspensions = SuspensionBudget::from_progress(&progress);
+        match run_until_complete(progress, &mut mount_table, &mut suspensions) {
             Ok(value) => {
                 let elapsed = start.elapsed();
                 eprintln!(
@@ -273,10 +274,11 @@ fn run_script(
 /// Returns `ExitCode::SUCCESS` on EOF or `exit`, and `ExitCode::FAILURE` on
 /// initialization or I/O errors.
 fn run_repl(file_path: &str, code: &str, tracker: ResourceTracker, mut mount_table: Option<MountTable>) -> ExitCode {
+    let mut suspensions = SuspensionBudget::new(&tracker);
     let mut repl = Some(MontyRepl::new(file_path, tracker, CompileOptions::default()));
 
     if !code.is_empty() {
-        execute_repl_snippet(&mut repl, code, &mut mount_table);
+        execute_repl_snippet(&mut repl, code, &mut mount_table, &mut suspensions);
     }
 
     eprintln!("Monty v{} REPL. Type `exit` to exit.", env!("CARGO_PKG_VERSION"));
@@ -335,7 +337,7 @@ fn run_repl(file_path: &str, code: &str, tracker: ResourceTracker, mut mount_tab
 
         if continuation_mode == ReplContinuationMode::IncompleteBlock && snippet.is_empty() {
             let _ = rl.add_history_entry(pending_snippet.trim_end());
-            execute_repl_snippet(&mut repl, &pending_snippet, &mut mount_table);
+            execute_repl_snippet(&mut repl, &pending_snippet, &mut mount_table, &mut suspensions);
             pending_snippet.clear();
             continuation_mode = ReplContinuationMode::Complete;
             continue;
@@ -348,7 +350,7 @@ fn run_repl(file_path: &str, code: &str, tracker: ResourceTracker, mut mount_tab
                     continue;
                 }
                 let _ = rl.add_history_entry(pending_snippet.trim_end());
-                execute_repl_snippet(&mut repl, &pending_snippet, &mut mount_table);
+                execute_repl_snippet(&mut repl, &pending_snippet, &mut mount_table, &mut suspensions);
                 pending_snippet.clear();
                 continuation_mode = ReplContinuationMode::Complete;
             }
@@ -369,11 +371,16 @@ fn run_repl(file_path: &str, code: &str, tracker: ResourceTracker, mut mount_tab
 ///
 /// Takes `&mut Option<MontyRepl>` because `feed_start` consumes the repl —
 /// we `take()` it out, run to completion, then put it back.
-fn execute_repl_snippet(repl: &mut Option<MontyRepl>, snippet: &str, mount_table: &mut Option<MountTable>) {
+fn execute_repl_snippet(
+    repl: &mut Option<MontyRepl>,
+    snippet: &str,
+    mount_table: &mut Option<MountTable>,
+    suspensions: &mut SuspensionBudget,
+) {
     let r = repl.take().expect("repl must be present");
 
     if mount_table.is_some() {
-        match execute_repl_with_mounts(r, snippet, mount_table) {
+        match execute_repl_with_mounts(r, snippet, mount_table, suspensions) {
             Ok((returned_repl, output)) => {
                 if output != MontyObject::None {
                     println!("{output}");
@@ -411,6 +418,7 @@ fn execute_repl_with_mounts(
     r: MontyRepl,
     snippet: &str,
     mount_table: &mut Option<MountTable>,
+    suspensions: &mut SuspensionBudget,
 ) -> Result<(MontyRepl, MontyObject), (MontyRepl, String)> {
     let mut progress = match r.feed_start(snippet, vec![], PrintWriter::Stdout) {
         Ok(p) => p,
@@ -418,6 +426,21 @@ fn execute_repl_with_mounts(
     };
 
     loop {
+        // the CLI is the host here, so it enforces `--max-suspensions` itself
+        if let Some(exc) = suspensions.note(&progress) {
+            let outcome = match progress {
+                ReplProgress::OsCall(call) => call.abort(exc, PrintWriter::Stdout),
+                ReplProgress::FunctionCall(call) => call.abort(exc, PrintWriter::Stdout),
+                ReplProgress::NameLookup(lookup) => lookup.abort(exc, PrintWriter::Stdout),
+                ReplProgress::ResolveFutures(state) => state.abort(exc, PrintWriter::Stdout),
+                ReplProgress::Complete { .. } => unreachable!("only suspensions are counted"),
+            };
+            match outcome {
+                Ok(p) => progress = p,
+                Err(err) => return Err((err.repl, format!("{}", err.error))),
+            }
+            continue;
+        }
         match progress {
             ReplProgress::Complete { repl, value } => return Ok((repl, value)),
             ReplProgress::OsCall(call) => {
@@ -452,8 +475,24 @@ fn execute_repl_with_mounts(
 /// When a mount table is provided, filesystem `OsCall`s are handled via the
 /// mount table. Non-filesystem `OsCall`s and `OsCall`s without a mount table
 /// produce an error.
-fn run_until_complete(mut progress: RunProgress, mount_table: &mut Option<MountTable>) -> Result<MontyObject, String> {
+fn run_until_complete(
+    mut progress: RunProgress,
+    mount_table: &mut Option<MountTable>,
+    suspensions: &mut SuspensionBudget,
+) -> Result<MontyObject, String> {
     loop {
+        // the CLI is the host here, so it enforces `--max-suspensions` itself
+        if let Some(exc) = suspensions.note_run(&progress) {
+            progress = match progress {
+                RunProgress::OsCall(call) => call.abort(exc, PrintWriter::Stdout),
+                RunProgress::FunctionCall(call) => call.abort(exc, PrintWriter::Stdout),
+                RunProgress::NameLookup(lookup) => lookup.abort(exc, PrintWriter::Stdout),
+                RunProgress::ResolveFutures(state) => state.abort(exc, PrintWriter::Stdout),
+                RunProgress::Complete(_) => unreachable!("only suspensions are counted"),
+            }
+            .map_err(|err| format!("{err}"))?;
+            continue;
+        }
         match progress {
             RunProgress::Complete(value) => return Ok(value),
             RunProgress::FunctionCall(call) => {
@@ -487,6 +526,66 @@ fn run_until_complete(mut progress: RunProgress, mount_table: &mut Option<MountT
                     .map_err(|err| format!("{err}"))?;
             }
         }
+    }
+}
+
+/// The CLI's `--max-suspensions` accounting: the host that services
+/// suspensions enforces the limit, and here that host is the CLI. One count
+/// spans every snippet of a REPL session.
+struct SuspensionBudget {
+    limit: Option<usize>,
+    seen: usize,
+}
+
+impl SuspensionBudget {
+    /// A budget from the limits the tracker was built with.
+    fn new(tracker: &ResourceTracker) -> Self {
+        Self {
+            limit: tracker.max_suspensions(),
+            seen: 0,
+        }
+    }
+
+    /// As [`Self::new`], reading the limit off a one-shot run's first progress.
+    fn from_progress(progress: &RunProgress) -> Self {
+        let limit = match progress {
+            RunProgress::FunctionCall(call) => call.tracker().max_suspensions(),
+            RunProgress::OsCall(call) => call.tracker().max_suspensions(),
+            RunProgress::NameLookup(lookup) => lookup.tracker().max_suspensions(),
+            RunProgress::ResolveFutures(state) => state.tracker().max_suspensions(),
+            RunProgress::Complete(_) => None,
+        };
+        Self { limit, seen: 0 }
+    }
+
+    /// Counts a REPL suspension, returning the exception to abort it with when
+    /// it is the one past the budget.
+    fn note(&mut self, progress: &ReplProgress) -> Option<MontyException> {
+        if matches!(progress, ReplProgress::Complete { .. }) {
+            None
+        } else {
+            self.count()
+        }
+    }
+
+    /// [`Self::note`] for one-shot runs.
+    fn note_run(&mut self, progress: &RunProgress) -> Option<MontyException> {
+        if matches!(progress, RunProgress::Complete(_)) {
+            None
+        } else {
+            self.count()
+        }
+    }
+
+    fn count(&mut self) -> Option<MontyException> {
+        self.seen += 1;
+        let limit = self.limit?;
+        (self.seen > limit).then(|| {
+            MontyException::new(
+                ExcType::RuntimeError,
+                Some(format!("suspension limit exceeded: {} > {limit}", self.seen)),
+            )
+        })
     }
 }
 

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -426,7 +426,7 @@ fn execute_repl_with_mounts(
     };
 
     loop {
-        // the CLI is the host here, so it enforces `--max-suspensions` itself
+        // The CLI, as host, enforces `--max-suspensions`.
         if let Some(exc) = suspensions.note(&progress) {
             let outcome = match progress {
                 ReplProgress::OsCall(call) => call.abort(exc, PrintWriter::Stdout),
@@ -481,7 +481,7 @@ fn run_until_complete(
     suspensions: &mut SuspensionBudget,
 ) -> Result<MontyObject, String> {
     loop {
-        // the CLI is the host here, so it enforces `--max-suspensions` itself
+        // The CLI, as host, enforces `--max-suspensions`.
         if let Some(exc) = suspensions.note_run(&progress) {
             progress = match progress {
                 RunProgress::OsCall(call) => call.abort(exc, PrintWriter::Stdout),
@@ -529,16 +529,14 @@ fn run_until_complete(
     }
 }
 
-/// The CLI's `--max-suspensions` accounting: the host that services
-/// suspensions enforces the limit, and here that host is the CLI. One count
-/// spans every snippet of a REPL session.
+/// Tracks the CLI-enforced suspension limit across an entire REPL session.
 struct SuspensionBudget {
     limit: Option<usize>,
     seen: usize,
 }
 
 impl SuspensionBudget {
-    /// A budget from the limits the tracker was built with.
+    /// Initializes a budget from the tracker's limits.
     fn new(tracker: &ResourceTracker) -> Self {
         Self {
             limit: tracker.max_suspensions(),
@@ -546,7 +544,7 @@ impl SuspensionBudget {
         }
     }
 
-    /// As [`Self::new`], reading the limit off a one-shot run's first progress.
+    /// Reads a one-shot run's limit from its initial progress.
     fn from_progress(progress: &RunProgress) -> Self {
         let limit = match progress {
             RunProgress::FunctionCall(call) => call.tracker().max_suspensions(),
@@ -558,8 +556,7 @@ impl SuspensionBudget {
         Self { limit, seen: 0 }
     }
 
-    /// Counts a REPL suspension, returning the exception to abort it with when
-    /// it is the one past the budget.
+    /// Counts a REPL suspension and returns the exception once over budget.
     fn note(&mut self, progress: &ReplProgress) -> Option<MontyException> {
         if matches!(progress, ReplProgress::Complete { .. }) {
             None
@@ -577,6 +574,7 @@ impl SuspensionBudget {
         }
     }
 
+    /// Counts one suspension and builds the over-budget exception.
     fn count(&mut self) -> Option<MontyException> {
         self.seen += 1;
         let limit = self.limit?;

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -23,8 +23,8 @@ use monty::{MontyRepl, MontyRun, ReplContinuationMode, ReplProgress, RunProgress
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
-    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult, OsFunctionCall,
-    PrintWriter, ResourceLimits, ResourceTracker, TypeCheckingConfig,
+    CompileOptions, DEFAULT_MAX_SUSPENSIONS, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult,
+    OsFunctionCall, PrintWriter, ResourceLimits, ResourceTracker, TypeCheckingConfig,
 };
 use rustyline::{DefaultEditor, error::ReadlineError};
 #[cfg(feature = "telemetry")]
@@ -531,7 +531,7 @@ fn run_until_complete(
 
 /// Tracks the CLI-enforced suspension limit across an entire REPL session.
 struct SuspensionBudget {
-    limit: Option<usize>,
+    limit: usize,
     seen: usize,
 }
 
@@ -551,7 +551,8 @@ impl SuspensionBudget {
             RunProgress::OsCall(call) => call.tracker().max_suspensions(),
             RunProgress::NameLookup(lookup) => lookup.tracker().max_suspensions(),
             RunProgress::ResolveFutures(state) => state.tracker().max_suspensions(),
-            RunProgress::Complete(_) => None,
+            // never counted, so the value is immaterial
+            RunProgress::Complete(_) => DEFAULT_MAX_SUSPENSIONS,
         };
         Self { limit, seen: 0 }
     }
@@ -577,7 +578,7 @@ impl SuspensionBudget {
     /// Counts one suspension and builds the over-budget exception.
     fn count(&mut self) -> Option<MontyException> {
         self.seen += 1;
-        let limit = self.limit?;
+        let limit = self.limit;
         (self.seen > limit).then(|| {
             MontyException::new(
                 ExcType::RuntimeError,

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -427,7 +427,9 @@ fn execute_repl_with_mounts(
 
     loop {
         // The CLI, as host, enforces `--max-suspensions`.
-        if let Some(exc) = suspensions.note(&progress) {
+        if !matches!(progress, ReplProgress::Complete { .. })
+            && let Some(exc) = suspensions.record_suspension()
+        {
             let outcome = match progress {
                 ReplProgress::OsCall(call) => call.abort(exc, PrintWriter::Stdout),
                 ReplProgress::FunctionCall(call) => call.abort(exc, PrintWriter::Stdout),
@@ -482,7 +484,9 @@ fn run_until_complete(
 ) -> Result<MontyObject, String> {
     loop {
         // The CLI, as host, enforces `--max-suspensions`.
-        if let Some(exc) = suspensions.note_run(&progress) {
+        if !matches!(progress, RunProgress::Complete(_))
+            && let Some(exc) = suspensions.record_suspension()
+        {
             progress = match progress {
                 RunProgress::OsCall(call) => call.abort(exc, PrintWriter::Stdout),
                 RunProgress::FunctionCall(call) => call.abort(exc, PrintWriter::Stdout),
@@ -557,26 +561,9 @@ impl SuspensionBudget {
         Self { limit, seen: 0 }
     }
 
-    /// Counts a REPL suspension and returns the exception once over budget.
-    fn note(&mut self, progress: &ReplProgress) -> Option<MontyException> {
-        if matches!(progress, ReplProgress::Complete { .. }) {
-            None
-        } else {
-            self.count()
-        }
-    }
-
-    /// [`Self::note`] for one-shot runs.
-    fn note_run(&mut self, progress: &RunProgress) -> Option<MontyException> {
-        if matches!(progress, RunProgress::Complete(_)) {
-            None
-        } else {
-            self.count()
-        }
-    }
-
-    /// Counts one suspension and builds the over-budget exception.
-    fn count(&mut self) -> Option<MontyException> {
+    /// Counts one suspension and returns the exception to abort it with once
+    /// the count is over budget.
+    fn record_suspension(&mut self) -> Option<MontyException> {
         self.seen += 1;
         let limit = self.limit;
         (self.seen > limit).then(|| {

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -324,6 +324,35 @@ fn external_function_round_trip() {
     child.shutdown();
 }
 
+/// The parent's way to end a feed it will not answer: the exception is
+/// raised uncatchably at the suspended call — the retry loop from
+/// pydantic/monty#736 cannot swallow it — and the session survives.
+#[test]
+fn abort_feed_round_trip() {
+    let mut child = ChildProc::spawn();
+    child.create_repl();
+    let (_, event) =
+        child.feed("while True:\n    try:\n        open('/etc/passwd')\n    except Exception:\n        pass");
+    let pb::child_event::Kind::OsCall(_) = event else {
+        panic!("expected OsCall, got {event:?}");
+    };
+    child.send(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
+        exception: Some(pb::RaisedException {
+            exc_type: "RuntimeError".to_owned(),
+            message: Some("suspension limit exceeded: 4 > 3".to_owned()),
+            traceback: vec![],
+            data: None,
+        }),
+    }));
+    let (_, event) = child.recv_turn();
+    let error = expect_error(event);
+    assert_eq!(error.exc_type, "RuntimeError");
+    assert_eq!(error.message.as_deref(), Some("suspension limit exceeded: 4 > 3"));
+    assert_eq!(error.traceback[0].start.map(|loc| loc.line), Some(3));
+    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+    child.shutdown();
+}
+
 #[test]
 fn name_lookup_round_trip() {
     let mut child = ChildProc::spawn();

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use monty_proto::{
-    FrameError, FrameReader, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, WireObject, pb, write_frame,
+    FrameError, FrameReader, MAX_FRAME_LEN, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, WireFunctionCall,
+    WireObject, exceeds_max_frame_len, pb, write_frame,
 };
 use monty_types::MontyObject;
 
@@ -346,7 +347,72 @@ fn abort_feed_round_trip() {
     let error = expect_error(event);
     assert_eq!(error.exc_type, "RuntimeError");
     assert_eq!(error.message.as_deref(), Some("suspension limit exceeded: 4 > 3"));
-    assert_eq!(error.traceback[0].start.map(|loc| loc.line), Some(3));
+    assert_eq!(
+        error
+            .traceback
+            .first()
+            .and_then(|frame| frame.start.map(|loc| loc.line)),
+        Some(3)
+    );
+    assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+    child.shutdown();
+}
+
+/// A suspension announcement is size-checked *with* its session stamps: one
+/// that fits `MAX_FRAME_LEN` only before the stamps are added must be refused
+/// as the clean oversized-argument error, not fail at send time and kill the
+/// worker (the parent would never learn the resume point).
+///
+/// Allocates ~256 MiB several times over (sizing here, the sandbox string, its
+/// wire copy), so it is memory-heavy; disable it if it proves flaky in CI.
+#[test]
+fn near_limit_suspension_is_refused_cleanly() {
+    let announcement = |arg_len: usize| pb::ChildEvent {
+        kind: Some(pb::child_event::Kind::FunctionCall(WireFunctionCall {
+            function_name: "f".to_owned(),
+            args: vec![MontyObject::String("x".repeat(arg_len))],
+            kwargs: vec![],
+            call_id: 1,
+            object_id: None,
+        })),
+        ..Default::default()
+    };
+    // Size the argument so the unstamped announcement is exactly
+    // `MAX_FRAME_LEN`: shrink an oversize probe by its excess, then walk up
+    // past the length varints that lose a byte as the sizes they describe
+    // drop below 2^28 (= `MAX_FRAME_LEN`).
+    let probe = MAX_FRAME_LEN as usize + 16;
+    let probe_len = exceeds_max_frame_len(&announcement(probe)).expect("probe exceeds the limit") as usize;
+    let mut arg_len = probe - (probe_len - MAX_FRAME_LEN as usize);
+    while exceeds_max_frame_len(&announcement(arg_len + 1)).is_none() {
+        arg_len += 1;
+    }
+    assert!(exceeds_max_frame_len(&announcement(arg_len)).is_none());
+
+    let mut child = ChildProc::spawn();
+    // a configured limit is stamped on every reply, so the sent frame is
+    // always larger than the unstamped announcement
+    child.create_repl_with(pb::Configure {
+        script_name: "main.py".to_owned(),
+        limits: Some(pb::ResourceLimits {
+            max_suspensions: Some(5),
+            ..Default::default()
+        }),
+        monty_version: env!("CARGO_PKG_VERSION").to_owned(),
+        protocol_version: PROTOCOL_VERSION,
+        ..Default::default()
+    });
+    let (_, event) = child.feed(&format!("f('x' * {arg_len})"));
+    let error = expect_error(event);
+    assert_eq!(error.exc_type, "RuntimeError");
+    assert!(
+        error
+            .message
+            .as_deref()
+            .is_some_and(|m| m.starts_with("argument frame of ") && m.contains("exceeds the maximum of")),
+        "unexpected message: {:?}",
+        error.message
+    );
     assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
     child.shutdown();
 }

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -338,7 +338,7 @@ fn abort_feed_round_trip() {
     child.send(pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
         exception: Some(pb::RaisedException {
             exc_type: "RuntimeError".to_owned(),
-            message: Some("suspension limit exceeded: 4 > 3".to_owned()),
+            message: Some("suspension limit 3 exceeded".to_owned()),
             traceback: vec![],
             data: None,
         }),
@@ -346,7 +346,7 @@ fn abort_feed_round_trip() {
     let (_, event) = child.recv_turn();
     let error = expect_error(event);
     assert_eq!(error.exc_type, "RuntimeError");
-    assert_eq!(error.message.as_deref(), Some("suspension limit exceeded: 4 > 3"));
+    assert_eq!(error.message.as_deref(), Some("suspension limit 3 exceeded"));
     assert_eq!(
         error
             .traceback

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -324,9 +324,7 @@ fn external_function_round_trip() {
     child.shutdown();
 }
 
-/// The parent's way to end a feed it will not answer: the exception is
-/// raised uncatchably at the suspended call — the retry loop from
-/// pydantic/monty#736 cannot swallow it — and the session survives.
+/// `AbortFeed` raises the supplied error uncatchably and keeps the session usable.
 #[test]
 fn abort_feed_round_trip() {
     let mut child = ChildProc::spawn();

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -16,7 +16,8 @@ implementation**.
   (file reads/writes, `open()`, `os.getenv`, ...), plus the `stat_result`
   builders hosts use to answer them.
 - `ResourceTracker` / `ResourceLimits` — the resource tracker the
-  interpreter uses to enforce time/memory/recursion limits.
+  interpreter uses to enforce time/memory/recursion limits, plus the
+  `max_suspensions` budget hosts enforce themselves.
 - `PrintStream` / `PrintWriter` — `print()` output capture.
 - `CompileOptions`, `ExtFunctionResult`, `NameLookupResult`, `FileMode`, and
   the CPython-compatible formatting helpers behind their `repr()`s.

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -36,8 +36,8 @@ pub use crate::{
         RenameCallArgs, dir_stat, file_stat, stat_result, symlink_stat,
     },
     resource::{
-        BASELINE_MEMORY, DEFAULT_MAX_RECURSION_DEPTH, LARGE_RESULT_THRESHOLD, LIVE_MEMORY, OOM_EXIT_CODE,
-        ResourceError, ResourceLimits, ResourceTracker,
+        BASELINE_MEMORY, DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_MAX_SUSPENSIONS, LARGE_RESULT_THRESHOLD, LIVE_MEMORY,
+        OOM_EXIT_CODE, ResourceError, ResourceLimits, ResourceTracker,
     },
     results::{ExtFunctionResult, NameLookupResult},
     run_options::{AssertMessageAnnotations, CompileOptions},

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -94,15 +94,22 @@ pub struct ResourceLimits {
     pub gc_interval: Option<usize>,
     /// Maximum recursion depth (function call stack depth).
     pub max_recursion_depth: usize,
-    /// Maximum suspensions the host may service.
+    /// Maximum suspensions the host may service (default
+    /// [`DEFAULT_MAX_SUSPENSIONS`]; always bounded, like recursion depth).
     /// The interpreter only stores this limit; hosts must enforce it.
-    pub max_suspensions: Option<usize>,
+    pub max_suspensions: usize,
 }
 
 /// Recommended maximum recursion depth if not otherwise specified.
 pub const DEFAULT_MAX_RECURSION_DEPTH: usize = 1000;
 
-/// Creates a new ResourceLimits with all limits disabled, except max recursion which is set to 1000.
+/// Maximum suspensions a host services per session if not otherwise
+/// specified: a backstop against a sandbox looping on host calls while
+/// `max_duration` is paused.
+pub const DEFAULT_MAX_SUSPENSIONS: usize = 1000;
+
+/// Creates a new ResourceLimits with all limits disabled, except max recursion
+/// depth and max suspensions, which are set to 1000.
 impl Default for ResourceLimits {
     fn default() -> Self {
         Self {
@@ -110,7 +117,7 @@ impl Default for ResourceLimits {
             max_memory: None,
             gc_interval: None,
             max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
-            max_suspensions: None,
+            max_suspensions: DEFAULT_MAX_SUSPENSIONS,
         }
     }
 }
@@ -150,7 +157,7 @@ impl ResourceLimits {
     /// Sets the host-enforced maximum number of suspensions.
     #[must_use]
     pub fn max_suspensions(mut self, limit: usize) -> Self {
-        self.max_suspensions = Some(limit);
+        self.max_suspensions = limit;
         self
     }
 }
@@ -259,7 +266,7 @@ impl ResourceTracker {
 
     /// Returns the host-enforced suspension budget, if any.
     #[must_use]
-    pub fn max_suspensions(&self) -> Option<usize> {
+    pub fn max_suspensions(&self) -> usize {
         self.limits.max_suspensions
     }
 

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -94,14 +94,8 @@ pub struct ResourceLimits {
     pub gc_interval: Option<usize>,
     /// Maximum recursion depth (function call stack depth).
     pub max_recursion_depth: usize,
-    /// Maximum number of suspensions (external calls, OS calls, name lookups,
-    /// future resolution) a session may hand to the host.
-    ///
-    /// Enforced by the host that services suspensions — `monty-pool` and the
-    /// wasm worker pool — not by the interpreter: the host counts the
-    /// suspensions it answers and aborts the feed with an uncatchable
-    /// `RuntimeError` on the one past the budget. A host driving the
-    /// interpreter directly must count for itself.
+    /// Maximum suspensions the host may service.
+    /// The interpreter only stores this limit; hosts must enforce it.
     pub max_suspensions: Option<usize>,
 }
 
@@ -153,8 +147,7 @@ impl ResourceLimits {
         self
     }
 
-    /// Sets the maximum number of suspensions the host will service; see the
-    /// field docs for who enforces it.
+    /// Sets the host-enforced maximum number of suspensions.
     #[must_use]
     pub fn max_suspensions(mut self, limit: usize) -> Self {
         self.max_suspensions = Some(limit);
@@ -264,8 +257,7 @@ impl ResourceTracker {
         self.limits.max_memory
     }
 
-    /// Returns the configured suspension budget, if any. The interpreter never
-    /// reads it; a worker echoes it to the host that enforces it.
+    /// Returns the host-enforced suspension budget, if any.
     #[must_use]
     pub fn max_suspensions(&self) -> Option<usize> {
         self.limits.max_suspensions

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -76,10 +76,11 @@ impl Error for ResourceError {}
 
 /// Configuration for resource limits.
 ///
-/// The time/memory/GC/suspension limits are optional — set to `None` to
-/// disable — but recursion depth is always bounded (default
-/// [`DEFAULT_MAX_RECURSION_DEPTH`]): unbounded recursion would let sandboxed
-/// code overflow the native stack and abort the process. Use
+/// The time/memory/GC limits are optional — set to `None` to disable — but
+/// recursion depth and the suspension budget are always bounded (defaults
+/// [`DEFAULT_MAX_RECURSION_DEPTH`] and [`DEFAULT_MAX_SUSPENSIONS`]): unbounded
+/// recursion would let sandboxed code overflow the native stack and abort the
+/// process, and unbounded suspensions would let it loop on host calls. Use
 /// `ResourceLimits::default()` for the recursion-only defaults, or build
 /// custom limits with the builder pattern.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -264,7 +265,8 @@ impl ResourceTracker {
         self.limits.max_memory
     }
 
-    /// Returns the host-enforced suspension budget, if any.
+    /// Returns the host-enforced suspension budget (default
+    /// [`DEFAULT_MAX_SUSPENSIONS`]; never unlimited).
     #[must_use]
     pub fn max_suspensions(&self) -> usize {
         self.limits.max_suspensions

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -76,8 +76,8 @@ impl Error for ResourceError {}
 
 /// Configuration for resource limits.
 ///
-/// The time/memory/GC limits are optional — set to `None` to disable — but
-/// recursion depth is always bounded (default
+/// The time/memory/GC/suspension limits are optional — set to `None` to
+/// disable — but recursion depth is always bounded (default
 /// [`DEFAULT_MAX_RECURSION_DEPTH`]): unbounded recursion would let sandboxed
 /// code overflow the native stack and abort the process. Use
 /// `ResourceLimits::default()` for the recursion-only defaults, or build
@@ -94,6 +94,15 @@ pub struct ResourceLimits {
     pub gc_interval: Option<usize>,
     /// Maximum recursion depth (function call stack depth).
     pub max_recursion_depth: usize,
+    /// Maximum number of suspensions (external calls, OS calls, name lookups,
+    /// future resolution) a session may hand to the host.
+    ///
+    /// Enforced by the host that services suspensions — `monty-pool` and the
+    /// wasm worker pool — not by the interpreter: the host counts the
+    /// suspensions it answers and aborts the feed with an uncatchable
+    /// `RuntimeError` on the one past the budget. A host driving the
+    /// interpreter directly must count for itself.
+    pub max_suspensions: Option<usize>,
 }
 
 /// Recommended maximum recursion depth if not otherwise specified.
@@ -107,6 +116,7 @@ impl Default for ResourceLimits {
             max_memory: None,
             gc_interval: None,
             max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
+            max_suspensions: None,
         }
     }
 }
@@ -140,6 +150,14 @@ impl ResourceLimits {
     #[must_use]
     pub fn max_recursion_depth(mut self, limit: usize) -> Self {
         self.max_recursion_depth = limit;
+        self
+    }
+
+    /// Sets the maximum number of suspensions the host will service; see the
+    /// field docs for who enforces it.
+    #[must_use]
+    pub fn max_suspensions(mut self, limit: usize) -> Self {
+        self.max_suspensions = Some(limit);
         self
     }
 }
@@ -244,6 +262,13 @@ impl ResourceTracker {
     #[must_use]
     pub fn max_memory(&self) -> Option<usize> {
         self.limits.max_memory
+    }
+
+    /// Returns the configured suspension budget, if any. The interpreter never
+    /// reads it; a worker echoes it to the host that enforces it.
+    #[must_use]
+    pub fn max_suspensions(&self) -> Option<usize> {
+        self.limits.max_suspensions
     }
 
     /// Returns whether the VM has a memory or time limit configured.

--- a/crates/monty-wasm-runtime/src/lib.rs
+++ b/crates/monty-wasm-runtime/src/lib.rs
@@ -47,8 +47,9 @@ struct Component;
 impl Guest for Component {
     fn dispatch(request: Request) -> DispatchResult {
         let (result, allocator_ready) = CHILD.with_borrow_mut(|child| {
-            let result = dispatch(child, request);
+            let mut result = dispatch(child, request);
             let budget = child.session_budget();
+            result.max_suspensions = budget.max_suspensions.map(|limit| limit as u64);
             let allocator_ready = monty_alloc::set_limit(budget.max_memory, budget.type_check);
             (result, allocator_ready)
         });
@@ -56,6 +57,7 @@ impl Guest for Component {
             DispatchResult {
                 status: Status::Shutdown,
                 events: vec![Event::FatalError(error.to_owned())],
+                max_suspensions: result.max_suspensions,
             }
         } else {
             result
@@ -73,6 +75,7 @@ fn dispatch(child: &mut Child, request: Request) -> DispatchResult {
                 events: vec![event_from_proto(protocol_violation(&format!(
                     "malformed component request: {error}"
                 )))],
+                max_suspensions: None,
             };
         }
     };
@@ -82,6 +85,7 @@ fn dispatch(child: &mut Child, request: Request) -> DispatchResult {
             events: vec![event_from_proto(child.fatal_event(&format!(
                 "request frame of {len} bytes exceeds maximum of {MAX_FRAME_LEN} bytes"
             )))],
+            max_suspensions: None,
         };
     }
 
@@ -105,6 +109,7 @@ fn dispatch(child: &mut Child, request: Request) -> DispatchResult {
             Status::Shutdown
         },
         events: sink.events,
+        max_suspensions: None,
     }
 }
 

--- a/crates/monty-wasm-runtime/src/lib.rs
+++ b/crates/monty-wasm-runtime/src/lib.rs
@@ -277,6 +277,9 @@ fn request_from_component(request: Request) -> Result<pb::ParentRequest, String>
                 })
                 .collect::<Result<_, String>>()?,
         }),
+        Request::AbortFeed(error) => pb::parent_request::Kind::AbortFeed(pb::AbortFeed {
+            exception: Some(raised_exception_from_component(error)),
+        }),
         Request::Dump => pb::parent_request::Kind::Dump(pb::Dump {}),
         Request::Load(state) => pb::parent_request::Kind::Load(pb::Load { state }),
         Request::Reset => pb::parent_request::Kind::Reset(pb::Reset {}),
@@ -296,6 +299,7 @@ fn configure_from_component(request: ConfigureRequest) -> pb::Configure {
             max_memory_bytes: limits.max_memory_bytes,
             gc_interval: limits.gc_interval,
             max_recursion_depth: limits.max_recursion_depth,
+            max_suspensions: limits.max_suspensions,
         }),
         type_check: request.type_check,
         type_check_stubs: request.type_check_stubs,

--- a/crates/monty-wasm-runtime/wit/runtime.wit
+++ b/crates/monty-wasm-runtime/wit/runtime.wit
@@ -176,12 +176,15 @@ interface worker {
         value: value,
     }
 
-    /// Resource limits enforced by the sandbox.
+    /// Resource limits. All but `max-suspensions` are enforced by the
+    /// sandbox; that one is the budget the host enforces by counting the
+    /// suspensions it services and ending the feed with `abort-feed`.
     record resource-limits {
         max-duration-micros: option<u64>,
         max-memory-bytes: option<u64>,
         gc-interval: option<u64>,
         max-recursion-depth: option<u64>,
+        max-suspensions: option<u64>,
     }
 
     /// Available renderings for type-check diagnostics.
@@ -259,6 +262,9 @@ interface worker {
         resume-call(resume-call-request),
         resume-name-lookup(name-lookup-result),
         resume-futures(list<future-result>),
+        /// Ends the pending suspension (whatever its kind) by raising the
+        /// error uncatchably at that point; the session stays usable.
+        abort-feed(raised-error),
         dump,
         load(list<u8>),
         reset,

--- a/crates/monty-wasm-runtime/wit/runtime.wit
+++ b/crates/monty-wasm-runtime/wit/runtime.wit
@@ -349,6 +349,9 @@ interface worker {
         status: status,
         /// Buffered prints followed by exactly one turn-ending event.
         events: list<event>,
+        /// The current session's suspension limit. A host uses this after
+        /// `load`, whose dump replaces the configured session limits.
+        max-suspensions: option<u64>,
     }
 
     /// Handles one semantic request using the retained child.

--- a/crates/monty-wasm-runtime/wit/runtime.wit
+++ b/crates/monty-wasm-runtime/wit/runtime.wit
@@ -176,9 +176,8 @@ interface worker {
         value: value,
     }
 
-    /// Resource limits. All but `max-suspensions` are enforced by the
-    /// sandbox; that one is the budget the host enforces by counting the
-    /// suspensions it services and ending the feed with `abort-feed`.
+    /// Resource limits. The host enforces `max-suspensions`; the sandbox
+    /// enforces the others.
     record resource-limits {
         max-duration-micros: option<u64>,
         max-memory-bytes: option<u64>,
@@ -262,8 +261,7 @@ interface worker {
         resume-call(resume-call-request),
         resume-name-lookup(name-lookup-result),
         resume-futures(list<future-result>),
-        /// Ends the pending suspension (whatever its kind) by raising the
-        /// error uncatchably at that point; the session stays usable.
+        /// Raises an error uncatchably at any pending suspension; the session stays usable.
         abort-feed(raised-error),
         dump,
         load(list<u8>),

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -46,7 +46,7 @@ Errors are returned as `MontyException`, with a traceback matching what CPython 
 
 ## Resource limits
 
-Untrusted code shouldn't be able to hog the host. `ResourceTracker` enforces execution-time and recursion limits and configures GC scheduling. Memory limits additionally require `monty-alloc` as the executable's global allocator:
+Untrusted code shouldn't be able to hog the host. `ResourceTracker` enforces execution-time and recursion limits and configures GC scheduling. Memory limits additionally require `monty-alloc` as the executable's global allocator. `max_suspensions` is the host's to enforce: count the suspensions you answer and end the feed with `abort` (on `FunctionCall`, `OsCall`, `NameLookup` and `ResolveFutures`) on the one past the budget, which raises your exception uncatchably at the suspension point:
 
 ```rust
 use std::time::Duration;

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -46,7 +46,9 @@ Errors are returned as `MontyException`, with a traceback matching what CPython 
 
 ## Resource limits
 
-Untrusted code shouldn't be able to hog the host. `ResourceTracker` enforces execution-time and recursion limits and configures GC scheduling. Memory limits additionally require `monty-alloc` as the executable's global allocator. `max_suspensions` is the host's to enforce: count the suspensions you answer and end the feed with `abort` (on `FunctionCall`, `OsCall`, `NameLookup` and `ResolveFutures`) on the one past the budget, which raises your exception uncatchably at the suspension point:
+Untrusted code shouldn't be able to hog the host. `ResourceTracker` enforces execution-time and recursion limits and configures GC scheduling. Memory limits additionally require `monty-alloc` as the executable's global allocator.
+
+Hosts enforce `max_suspensions`: count answered suspensions, then call `abort` on `FunctionCall`, `OsCall`, `NameLookup`, or `ResolveFutures` at the first excess. The supplied exception bypasses sandbox exception handlers:
 
 ```rust
 use std::time::Duration;

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -947,6 +947,27 @@ impl<'h> VM<'h> {
         self.scheduler.pending_call_ids()
     }
 
+    /// Raises `exc` uncatchably at the suspension point, for hosts enforcing
+    /// a limit while execution is suspended.
+    ///
+    /// A `ResolveFutures` snapshot is parked when the last runnable task
+    /// finished with the rest still blocked, so the VM holds a placeholder
+    /// frame and every real frame lives in the scheduler. Raising there would
+    /// point the traceback at line 1, so the main task is reloaded first: it
+    /// is always alive while futures are pending, and its `await` is the
+    /// suspension the user sees.
+    pub fn abort(&mut self, exc: MontyException) -> RunResult<FrameExit> {
+        let main = TaskId::default();
+        if self.current_frame.is_parked
+            && self.scheduler.has_task(main)
+            && !self.scheduler.get_task_mut(main).frames.is_empty()
+        {
+            self.scheduler.set_current_task(Some(main));
+            self.load_or_init_task(main)?;
+        }
+        self.resume_with_exception(RunError::uncatchable(exc))
+    }
+
     /// Resolves external futures and resumes execution.
     ///
     /// This is the standard sequence for resuming after a `FrameExit::ResolveFutures`:

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -26,7 +26,7 @@ const MAGIC: &[u8; 6] = b"MONTY\0";
 /// rejected instead of decoding as their neighbour. That covers the
 /// interpreter's own types *and* everything reachable from [`Dump`] — notably
 /// [`TypeCheckingConfig`](monty_types::TypeCheckingConfig) in `monty-types`.
-pub const DUMP_VERSION: u16 = 9;
+pub const DUMP_VERSION: u16 = 8;
 
 /// Number of bytes before the postcard payload.
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u16>();

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -26,7 +26,7 @@ const MAGIC: &[u8; 6] = b"MONTY\0";
 /// rejected instead of decoding as their neighbour. That covers the
 /// interpreter's own types *and* everything reachable from [`Dump`] — notably
 /// [`TypeCheckingConfig`](monty_types::TypeCheckingConfig) in `monty-types`.
-pub const DUMP_VERSION: u16 = 8;
+pub const DUMP_VERSION: u16 = 9;
 
 /// Number of bytes before the postcard payload.
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u16>();

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -2444,11 +2444,12 @@ pub(crate) enum RunError {
     Internal(Cow<'static, str>),
     /// Catchable Python exception (e.g., ValueError, TypeError).
     Exc(ExceptionRaise),
-    /// Uncatchable Python exception from resource limits (MemoryError, TimeoutError).
+    /// Uncatchable Python exception: a resource limit (MemoryError,
+    /// TimeoutError) or a host aborting a suspended feed.
     ///
     /// These exceptions display with proper tracebacks like normal Python exceptions,
     /// but cannot be caught by try/except blocks. This prevents untrusted code from
-    /// suppressing resource limit violations.
+    /// suppressing resource limit violations or a host's decision to end the feed.
     UncatchableExc(ExceptionRaise),
 }
 
@@ -2497,11 +2498,19 @@ impl RunError {
     /// exhaustion.
     ///
     /// Excluding `UncatchableExc` is defensive — it is only ever built from a
-    /// `ResourceError` — but spelled out so a future uncatchable variant cannot
-    /// read as "the iterator finished", letting sandboxed code absorb its own
-    /// limit breach.
+    /// `ResourceError` or a host abort — but spelled out so a future uncatchable
+    /// variant cannot read as "the iterator finished", letting sandboxed code
+    /// absorb its own limit breach.
     pub(crate) fn is_stop_iteration(&self) -> bool {
         matches!(self, Self::Exc(raise) if matches!(raise.exc.exc_type(), ExcType::StopIteration))
+    }
+
+    /// Wraps a host-supplied exception so that, raised into the sandbox, it
+    /// unwinds every frame for its traceback and no `except` can catch it —
+    /// how a host ends a suspended feed for its own reasons (a suspension
+    /// budget, a policy decision) without the sandbox retrying.
+    pub(crate) fn uncatchable(exc: MontyException) -> Self {
+        Self::UncatchableExc(exc.into())
     }
 
     /// Converts this runtime error to a `MontyException` for the public API.

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -2432,7 +2432,7 @@ impl RawStackFrame {
 /// Three variants:
 /// - `Internal`: Bug in interpreter implementation (static message)
 /// - `Exc`: Python exception that can be caught by try/except (when implemented)
-/// - `UncatchableExc`: Python exception from resource limits that CANNOT be caught
+/// - `UncatchableExc`: Python exception from a resource limit or host abort
 ///
 /// `Clone` is implemented so an error can be cached for later re-raising
 /// (e.g. a failed `GatherFuture` replaying the same exception on every
@@ -2444,12 +2444,9 @@ pub(crate) enum RunError {
     Internal(Cow<'static, str>),
     /// Catchable Python exception (e.g., ValueError, TypeError).
     Exc(ExceptionRaise),
-    /// Uncatchable Python exception: a resource limit (MemoryError,
-    /// TimeoutError) or a host aborting a suspended feed.
+    /// Uncatchable Python exception from a resource limit or host abort.
     ///
-    /// These exceptions display with proper tracebacks like normal Python exceptions,
-    /// but cannot be caught by try/except blocks. This prevents untrusted code from
-    /// suppressing resource limit violations or a host's decision to end the feed.
+    /// Displays a normal traceback but bypasses `try`/`except` blocks.
     UncatchableExc(ExceptionRaise),
 }
 
@@ -2494,21 +2491,14 @@ impl From<fmt::Error> for RunError {
 }
 
 impl RunError {
-    /// Whether this is a catchable `StopIteration`, i.e. a `__next__` reporting
-    /// exhaustion.
+    /// Whether this is a catchable `StopIteration` from `__next__`.
     ///
-    /// Excluding `UncatchableExc` is defensive — it is only ever built from a
-    /// `ResourceError` or a host abort — but spelled out so a future uncatchable
-    /// variant cannot read as "the iterator finished", letting sandboxed code
-    /// absorb its own limit breach.
+    /// Matching only `Exc` prevents uncatchable errors being mistaken for exhaustion.
     pub(crate) fn is_stop_iteration(&self) -> bool {
         matches!(self, Self::Exc(raise) if matches!(raise.exc.exc_type(), ExcType::StopIteration))
     }
 
-    /// Wraps a host-supplied exception so that, raised into the sandbox, it
-    /// unwinds every frame for its traceback and no `except` can catch it —
-    /// how a host ends a suspended feed for its own reasons (a suspension
-    /// budget, a policy decision) without the sandbox retrying.
+    /// Wraps a host exception so it builds a traceback but bypasses `except`.
     pub(crate) fn uncatchable(exc: MontyException) -> Self {
         Self::UncatchableExc(exc.into())
     }

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -614,8 +614,7 @@ impl ReplFunctionCall {
         self.snapshot.run(ExtFunctionResult::Future(self.call_id), print)
     }
 
-    /// Ends the snippet by raising `exc` uncatchably at the suspended call;
-    /// see [`ReplOsCall::abort`].
+    /// Aborts the snippet with an uncatchable exception; see [`ReplOsCall::abort`].
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
         self.snapshot.abort(exc, print)
     }
@@ -668,9 +667,9 @@ impl ReplOsCall {
         self.snapshot.run(result, print)
     }
 
-    /// REPL mirror of [`crate::OsCall::abort`]: raises `exc` uncatchably at
-    /// the suspended call. Always `Err`, with the session inside it ready for
-    /// further feeds.
+    /// Raises `exc` uncatchably at the suspended call.
+    ///
+    /// Always returns `Err` with a reusable session; see [`crate::OsCall::abort`].
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
         self.snapshot.abort(exc, print)
     }
@@ -714,8 +713,7 @@ impl ReplNameLookup {
         self.scope.object_id()
     }
 
-    /// Ends the snippet by raising `exc` uncatchably at the suspended lookup;
-    /// see [`ReplOsCall::abort`].
+    /// Aborts the snippet with an uncatchable exception; see [`ReplOsCall::abort`].
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
         self.snapshot.abort(exc, print)
     }
@@ -807,8 +805,7 @@ impl ReplResolveFutures {
         &self.pending_call_ids
     }
 
-    /// Ends the snippet by raising `exc` uncatchably in the blocked task; see
-    /// [`ReplOsCall::abort`]. Pending futures are abandoned with the snippet.
+    /// Aborts with an uncatchable exception and abandons pending futures.
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
         let Self {
             repl,
@@ -966,11 +963,9 @@ fn starts_with_triple_quote(source: &str) -> bool {
 // ReplSnapshot — internal execution state for suspend/resume
 // ---------------------------------------------------------------------------
 
-/// REPL execution state that can be resumed after an external call.
+/// Restores the REPL VM and aborts uncatchably, preserving its globals.
 ///
-/// REPL counterpart of `run_progress::abort_restored`: restores the suspended
-/// VM, raises `exc` uncatchably where it stopped (rolling back any armed OS
-/// effect), and hands the globals back to the session.
+/// Any armed OS effect is rolled back.
 fn abort_restored(
     mut repl: MontyRepl,
     executor: Executor,
@@ -989,15 +984,16 @@ fn abort_restored(
         );
         let vm_result = vm.resume_with_exception(RunError::uncatchable(exc));
         let converted = convert_frame_exit(vm_result, &mut vm);
-        // an uncatchable exception never suspends, so no snapshot is needed
+        // Uncatchable exceptions cannot suspend, so no snapshot is needed.
         repl.globals = vm.take_globals();
         converted
     });
     build_repl_progress(converted, None, executor, repl)
 }
 
-/// This is the REPL-aware counterpart to `Snapshot`. It is `pub(crate)` —
-/// callers interact with the per-variant structs (`ReplFunctionCall`, etc.).
+/// REPL execution state that can resume after suspension.
+///
+/// This is the internal REPL-aware counterpart to `Snapshot`.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ReplSnapshot {
     /// Persistent REPL session state while this snippet is suspended.
@@ -1009,7 +1005,7 @@ pub(crate) struct ReplSnapshot {
 }
 
 impl ReplSnapshot {
-    /// Raises `exc` uncatchably at the suspension point instead of answering it.
+    /// Raises `exc` uncatchably at the suspension point.
     fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
         let Self {
             repl,

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -982,7 +982,7 @@ fn abort_restored(
             print.reborrow(),
             executor.assert_repr_max_bytes,
         );
-        let vm_result = vm.resume_with_exception(RunError::uncatchable(exc));
+        let vm_result = vm.abort(exc);
         let converted = convert_frame_exit(vm_result, &mut vm);
         // Uncatchable exceptions cannot suspend, so no snapshot is needed.
         repl.globals = vm.take_globals();

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -613,6 +613,12 @@ impl ReplFunctionCall {
     pub fn resume_pending(self, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
         self.snapshot.run(ExtFunctionResult::Future(self.call_id), print)
     }
+
+    /// Ends the snippet by raising `exc` uncatchably at the suspended call;
+    /// see [`ReplOsCall::abort`].
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
+        self.snapshot.abort(exc, print)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -661,6 +667,13 @@ impl ReplOsCall {
         let result = handler(self.function_call);
         self.snapshot.run(result, print)
     }
+
+    /// REPL mirror of [`crate::OsCall::abort`]: raises `exc` uncatchably at
+    /// the suspended call. Always `Err`, with the session inside it ready for
+    /// further feeds.
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
+        self.snapshot.abort(exc, print)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -699,6 +712,12 @@ impl ReplNameLookup {
     #[must_use]
     pub fn object_id(&self) -> Option<MontyUuid> {
         self.scope.object_id()
+    }
+
+    /// Ends the snippet by raising `exc` uncatchably at the suspended lookup;
+    /// see [`ReplOsCall::abort`].
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
+        self.snapshot.abort(exc, print)
     }
 
     /// Resumes execution after name resolution.
@@ -786,6 +805,18 @@ impl ReplResolveFutures {
     #[must_use]
     pub fn pending_call_ids(&self) -> &[u32] {
         &self.pending_call_ids
+    }
+
+    /// Ends the snippet by raising `exc` uncatchably in the blocked task; see
+    /// [`ReplOsCall::abort`]. Pending futures are abandoned with the snippet.
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
+        let Self {
+            repl,
+            executor,
+            vm_state,
+            ..
+        } = self;
+        abort_restored(repl, executor, vm_state, exc, print)
     }
 
     /// Resumes snippet execution with zero or more resolved futures.
@@ -937,6 +968,34 @@ fn starts_with_triple_quote(source: &str) -> bool {
 
 /// REPL execution state that can be resumed after an external call.
 ///
+/// REPL counterpart of `run_progress::abort_restored`: restores the suspended
+/// VM, raises `exc` uncatchably where it stopped (rolling back any armed OS
+/// effect), and hands the globals back to the session.
+fn abort_restored(
+    mut repl: MontyRepl,
+    executor: Executor,
+    vm_state: VMSnapshot,
+    exc: MontyException,
+    print: PrintWriter<'_>,
+) -> Result<ReplProgress, Box<ReplStartError>> {
+    let converted = HeapReader::with(&mut repl.heap, &mut (&executor, print), |reader, (executor, print)| {
+        let mut vm = VM::restore(
+            vm_state,
+            &executor.module_code,
+            reader,
+            &executor.interns,
+            print.reborrow(),
+            executor.assert_repr_max_bytes,
+        );
+        let vm_result = vm.resume_with_exception(RunError::uncatchable(exc));
+        let converted = convert_frame_exit(vm_result, &mut vm);
+        // an uncatchable exception never suspends, so no snapshot is needed
+        repl.globals = vm.take_globals();
+        converted
+    });
+    build_repl_progress(converted, None, executor, repl)
+}
+
 /// This is the REPL-aware counterpart to `Snapshot`. It is `pub(crate)` —
 /// callers interact with the per-variant structs (`ReplFunctionCall`, etc.).
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -950,6 +1009,16 @@ pub(crate) struct ReplSnapshot {
 }
 
 impl ReplSnapshot {
+    /// Raises `exc` uncatchably at the suspension point instead of answering it.
+    fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<ReplProgress, Box<ReplStartError>> {
+        let Self {
+            repl,
+            executor,
+            vm_state,
+        } = self;
+        abort_restored(repl, executor, vm_state, exc, print)
+    }
+
     /// Extracts the REPL session, restoring globals from the VM snapshot.
     ///
     /// When a snapshot is taken, globals live inside the `VMSnapshot`; the rest

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -192,8 +192,7 @@ impl FunctionCall {
         self.snapshot.run(ExtFunctionResult::Future(self.call_id), print)
     }
 
-    /// Ends the feed by raising `exc` uncatchably at the suspended call; see
-    /// [`OsCall::abort`].
+    /// Aborts the feed with an uncatchable exception; see [`OsCall::abort`].
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
         self.snapshot.abort(exc, print)
     }
@@ -264,11 +263,8 @@ impl OsCall {
 
     /// Ends the feed by raising `exc` uncatchably at the suspended call.
     ///
-    /// The host's alternative to answering: the exception unwinds every
-    /// frame for its traceback and no `except` in the sandbox can catch it,
-    /// so a snippet retrying refused calls stops here. Any pending file effect
-    /// is rolled back. The heap stays consistent — a REPL session remains
-    /// usable afterwards. Always returns `Err`, carrying the traceback.
+    /// The exception builds a traceback but bypasses sandbox handlers. Pending
+    /// file effects roll back. Always returns `Err`.
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
         self.snapshot.abort(exc, print)
     }
@@ -364,8 +360,7 @@ impl NameLookup {
         &self.snapshot.heap.tracker
     }
 
-    /// Ends the feed by raising `exc` uncatchably at the suspended lookup; see
-    /// [`OsCall::abort`].
+    /// Aborts the feed with an uncatchable exception; see [`OsCall::abort`].
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
         self.snapshot.abort(exc, print)
     }
@@ -613,8 +608,7 @@ impl ResolveFutures {
         &self.heap.tracker
     }
 
-    /// Ends the feed by raising `exc` uncatchably in the blocked task; see
-    /// [`OsCall::abort`]. Pending futures are abandoned with the run.
+    /// Aborts with an uncatchable exception and abandons pending futures.
     pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
         let Self {
             executor,
@@ -799,7 +793,7 @@ impl Snapshot {
         build_run_progress(converted, vm_state, executor, heap)
     }
 
-    /// Raises `exc` uncatchably at the suspension point instead of answering it.
+    /// Raises `exc` uncatchably at the suspension point.
     pub(crate) fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
         let Self {
             executor,
@@ -810,9 +804,7 @@ impl Snapshot {
     }
 }
 
-/// Restores the suspended VM and raises `exc` as an uncatchable exception
-/// where it stopped: every frame unwinds into the traceback, no handler runs,
-/// and an armed OS effect is rolled back. Shared by every suspension kind.
+/// Restores the VM and aborts uncatchably, rolling back any armed OS effect.
 fn abort_restored(
     executor: Executor,
     vm_state: VMSnapshot,

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -191,6 +191,12 @@ impl FunctionCall {
     pub fn resume_pending(self, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
         self.snapshot.run(ExtFunctionResult::Future(self.call_id), print)
     }
+
+    /// Ends the feed by raising `exc` uncatchably at the suspended call; see
+    /// [`OsCall::abort`].
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
+        self.snapshot.abort(exc, print)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -254,6 +260,17 @@ impl OsCall {
     ) -> Result<RunProgress, MontyException> {
         let result = handler(self.function_call);
         self.snapshot.run(result, print)
+    }
+
+    /// Ends the feed by raising `exc` uncatchably at the suspended call.
+    ///
+    /// The host's alternative to answering: the exception unwinds every
+    /// frame for its traceback and no `except` in the sandbox can catch it,
+    /// so a snippet retrying refused calls stops here. Any pending file effect
+    /// is rolled back. The heap stays consistent — a REPL session remains
+    /// usable afterwards. Always returns `Err`, carrying the traceback.
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
+        self.snapshot.abort(exc, print)
     }
 
     /// Returns the resource tracker while execution is suspended.
@@ -345,6 +362,12 @@ impl NameLookup {
     #[must_use]
     pub fn tracker(&self) -> &ResourceTracker {
         &self.snapshot.heap.tracker
+    }
+
+    /// Ends the feed by raising `exc` uncatchably at the suspended lookup; see
+    /// [`OsCall::abort`].
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
+        self.snapshot.abort(exc, print)
     }
 
     /// Resumes execution after name resolution.
@@ -590,6 +613,18 @@ impl ResolveFutures {
         &self.heap.tracker
     }
 
+    /// Ends the feed by raising `exc` uncatchably in the blocked task; see
+    /// [`OsCall::abort`]. Pending futures are abandoned with the run.
+    pub fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
+        let Self {
+            executor,
+            vm_state,
+            heap,
+            ..
+        } = self;
+        abort_restored(executor, vm_state, heap, exc, print)
+    }
+
     /// Forces a GC cycle against the exact root walk used by the live VM.
     ///
     /// This is test-only support for reproducing GC bugs while execution is
@@ -763,6 +798,43 @@ impl Snapshot {
             });
         build_run_progress(converted, vm_state, executor, heap)
     }
+
+    /// Raises `exc` uncatchably at the suspension point instead of answering it.
+    pub(crate) fn abort(self, exc: MontyException, print: PrintWriter<'_>) -> Result<RunProgress, MontyException> {
+        let Self {
+            executor,
+            vm_state,
+            heap,
+        } = self;
+        abort_restored(executor, vm_state, heap, exc, print)
+    }
+}
+
+/// Restores the suspended VM and raises `exc` as an uncatchable exception
+/// where it stopped: every frame unwinds into the traceback, no handler runs,
+/// and an armed OS effect is rolled back. Shared by every suspension kind.
+fn abort_restored(
+    executor: Executor,
+    vm_state: VMSnapshot,
+    mut heap: Heap,
+    exc: MontyException,
+    print: PrintWriter<'_>,
+) -> Result<RunProgress, MontyException> {
+    let (converted, vm_state) = HeapReader::with(&mut heap, &mut (&executor, print), |reader, (executor, print)| {
+        let mut vm = VM::restore(
+            vm_state,
+            &executor.module_code,
+            reader,
+            &executor.interns,
+            print.reborrow(),
+            executor.assert_repr_max_bytes,
+        );
+        let vm_result = vm.resume_with_exception(RunError::uncatchable(exc));
+        let converted = convert_frame_exit(vm_result, &mut vm);
+        let vm_state = check_snapshot_from_converted(&converted, vm);
+        (converted, vm_state)
+    });
+    build_run_progress(converted, vm_state, executor, heap)
 }
 
 pub use monty_types::{ExtFunctionResult, NameLookupResult};

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -821,7 +821,7 @@ fn abort_restored(
             print.reborrow(),
             executor.assert_repr_max_bytes,
         );
-        let vm_result = vm.resume_with_exception(RunError::uncatchable(exc));
+        let vm_result = vm.abort(exc);
         let converted = convert_frame_exit(vm_result, &mut vm);
         let vm_state = check_snapshot_from_converted(&converted, vm);
         (converted, vm_state)

--- a/crates/monty/tests/abort.rs
+++ b/crates/monty/tests/abort.rs
@@ -9,10 +9,7 @@ use monty_types::{
 
 /// The exception the pool aborts with once `max_suspensions` is spent.
 fn limit_exceeded() -> MontyException {
-    MontyException::new(
-        ExcType::RuntimeError,
-        Some("suspension limit exceeded: 4 > 3".to_owned()),
-    )
+    MontyException::new(ExcType::RuntimeError, Some("suspension limit 3 exceeded".to_owned()))
 }
 
 /// Starts `code` and resolves every leading name lookup to a function.
@@ -49,7 +46,7 @@ retry()
     let call = start(code).into_function_call().expect("external call");
     let exc = call.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
     assert_eq!(exc.exc_type(), ExcType::RuntimeError);
-    assert_eq!(exc.message(), Some("suspension limit exceeded: 4 > 3"));
+    assert_eq!(exc.message(), Some("suspension limit 3 exceeded"));
     assert_snapshot!(exc.to_string(), @r#"
     Traceback (most recent call last):
       File "test.py", line 8, in <module>
@@ -58,7 +55,7 @@ retry()
       File "test.py", line 4, in retry
         return fetch('x')
                ~~~~~~~~~~
-    RuntimeError: suspension limit exceeded: 4 > 3
+    RuntimeError: suspension limit 3 exceeded
     "#);
 }
 

--- a/crates/monty/tests/abort.rs
+++ b/crates/monty/tests/abort.rs
@@ -1,6 +1,4 @@
-//! Tests for aborting a suspended feed: the host raises an exception at the
-//! suspension point instead of answering it, uncatchably, so a snippet that
-//! retries refused calls cannot continue — how `max_suspensions` is enforced.
+//! Tests that hosts can abort suspended feeds uncatchably to enforce limits.
 
 use insta::assert_snapshot;
 use monty::{MontyRepl, MontyRun, RunProgress};
@@ -35,9 +33,7 @@ fn start(code: &str) -> RunProgress {
     progress
 }
 
-/// The issue's shape: every refused call is caught and retried. Aborting the
-/// external call ends the run even though the call sits inside `except
-/// Exception`, and the traceback points at the call.
+/// Aborting bypasses broad `Exception` handlers and records the call in the traceback.
 #[test]
 fn abort_external_call_is_uncatchable() {
     let code = "\
@@ -66,8 +62,7 @@ retry()
     "#);
 }
 
-/// OS calls abort the same way; the read's pending buffer-store effect is
-/// rolled back (checked by the refcount harness) rather than applied to nothing.
+/// Aborting an OS call rolls back its pending buffer-store effect.
 #[test]
 fn abort_os_call_after_open() {
     let code = "\
@@ -95,7 +90,7 @@ except Exception:
     assert_eq!(exc.traceback().len(), 1);
 }
 
-/// A name lookup can be aborted before it is ever resolved.
+/// Covers suspension before the host provides a lookup value.
 #[test]
 fn abort_name_lookup() {
     let run = MontyRun::new(
@@ -116,8 +111,7 @@ fn abort_name_lookup() {
     assert_eq!(exc.traceback()[0].start.line, 1);
 }
 
-/// Aborting while blocked on external futures — after a partial resolution,
-/// the re-suspension that a host would count as one more round trip.
+/// Covers a second suspension after partial future resolution.
 #[test]
 fn abort_resolve_futures_after_partial_resolution() {
     let code = "\
@@ -156,13 +150,11 @@ await main()
     assert_eq!(exc.exc_type(), ExcType::RuntimeError);
 }
 
-/// A REPL abort hands the session back usable: globals set before the
-/// aborted snippet survive, and nothing after the suspension ran.
+/// A REPL abort preserves earlier globals and skips code after the suspension.
 #[test]
 fn repl_abort_keeps_the_session_usable() {
     let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
     repl.feed_run("x = 41", vec![], PrintWriter::Stdout).unwrap();
-    // calling an unknown name suspends at FunctionCall directly
     let call = repl
         .feed_start("fetch('x')\nx = 0", vec![], PrintWriter::Stdout)
         .unwrap()

--- a/crates/monty/tests/abort.rs
+++ b/crates/monty/tests/abort.rs
@@ -1,0 +1,178 @@
+//! Tests for aborting a suspended feed: the host raises an exception at the
+//! suspension point instead of answering it, uncatchably, so a snippet that
+//! retries refused calls cannot continue — how `max_suspensions` is enforced.
+
+use insta::assert_snapshot;
+use monty::{MontyRepl, MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult, PrintWriter,
+    ResourceTracker,
+};
+
+/// The exception the pool aborts with once `max_suspensions` is spent.
+fn limit_exceeded() -> MontyException {
+    MontyException::new(
+        ExcType::RuntimeError,
+        Some("suspension limit exceeded: 4 > 3".to_owned()),
+    )
+}
+
+/// Starts `code` and resolves every leading name lookup to a function.
+fn start(code: &str) -> RunProgress {
+    let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let mut progress = run
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    while let RunProgress::NameLookup(lookup) = progress {
+        let name = lookup.name.clone();
+        progress = lookup
+            .resume(
+                NameLookupResult::Value(MontyObject::Function { name, docstring: None }),
+                PrintWriter::Stdout,
+            )
+            .unwrap();
+    }
+    progress
+}
+
+/// The issue's shape: every refused call is caught and retried. Aborting the
+/// external call ends the run even though the call sits inside `except
+/// Exception`, and the traceback points at the call.
+#[test]
+fn abort_external_call_is_uncatchable() {
+    let code = "\
+def retry():
+    while True:
+        try:
+            return fetch('x')
+        except Exception:
+            pass
+
+retry()
+";
+    let call = start(code).into_function_call().expect("external call");
+    let exc = call.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_eq!(exc.message(), Some("suspension limit exceeded: 4 > 3"));
+    assert_snapshot!(exc.to_string(), @r#"
+    Traceback (most recent call last):
+      File "test.py", line 8, in <module>
+        retry()
+        ~~~~~~~
+      File "test.py", line 4, in retry
+        return fetch('x')
+               ~~~~~~~~~~
+    RuntimeError: suspension limit exceeded: 4 > 3
+    "#);
+}
+
+/// OS calls abort the same way; the read's pending buffer-store effect is
+/// rolled back (checked by the refcount harness) rather than applied to nothing.
+#[test]
+fn abort_os_call_after_open() {
+    let code = "\
+f = open('/data/x.txt')
+try:
+    f.read()
+except Exception:
+    pass
+";
+    let call = start(code).into_os_call().expect("open");
+    assert_eq!(call.function_call.name(), "open");
+    let handle = MontyObject::FileHandle(monty_types::MontyFileHandle {
+        path: "/data/x.txt".to_owned(),
+        mode: "r".parse().unwrap(),
+        position: 0,
+    });
+    let read = call
+        .resume(ExtFunctionResult::Return(handle), PrintWriter::Stdout)
+        .unwrap()
+        .into_os_call()
+        .expect("read");
+    assert_eq!(read.function_call.name(), "Path.read_text");
+    let exc = read.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_eq!(exc.traceback().len(), 1);
+}
+
+/// A name lookup can be aborted before it is ever resolved.
+#[test]
+fn abort_name_lookup() {
+    let run = MontyRun::new(
+        "x = unknown_name\n".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let progress = run
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let RunProgress::NameLookup(lookup) = progress else {
+        panic!("expected a name lookup");
+    };
+    let exc = lookup.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_eq!(exc.traceback()[0].start.line, 1);
+}
+
+/// Aborting while blocked on external futures — after a partial resolution,
+/// the re-suspension that a host would count as one more round trip.
+#[test]
+fn abort_resolve_futures_after_partial_resolution() {
+    let code = "\
+import asyncio
+
+async def main():
+    try:
+        a, b = await asyncio.gather(foo(), bar())
+    except Exception:
+        return -1
+    return a + b
+
+await main()
+";
+    let mut progress = start(code);
+    let mut call_ids = vec![];
+    let state = loop {
+        match progress {
+            RunProgress::FunctionCall(call) => {
+                call_ids.push(call.call_id);
+                progress = call.resume_pending(PrintWriter::Stdout).unwrap();
+            }
+            RunProgress::ResolveFutures(state) => break state,
+            other => panic!("unexpected progress {other:?}"),
+        }
+    };
+    let state = state
+        .resume(
+            vec![(call_ids[0], ExtFunctionResult::Return(MontyObject::Int(1)))],
+            PrintWriter::Stdout,
+        )
+        .unwrap()
+        .into_resolve_futures()
+        .expect("still waiting on bar");
+    let exc = state.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+}
+
+/// A REPL abort hands the session back usable: globals set before the
+/// aborted snippet survive, and nothing after the suspension ran.
+#[test]
+fn repl_abort_keeps_the_session_usable() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("x = 41", vec![], PrintWriter::Stdout).unwrap();
+    // calling an unknown name suspends at FunctionCall directly
+    let call = repl
+        .feed_start("fetch('x')\nx = 0", vec![], PrintWriter::Stdout)
+        .unwrap()
+        .into_function_call()
+        .expect("fetch call");
+    let err = call.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_eq!(err.error.exc_type(), ExcType::RuntimeError);
+    let mut repl = err.repl;
+    assert_eq!(
+        repl.feed_run("x + 1", vec![], PrintWriter::Stdout).unwrap(),
+        MontyObject::Int(42)
+    );
+}

--- a/crates/monty/tests/abort.rs
+++ b/crates/monty/tests/abort.rs
@@ -1,7 +1,7 @@
 //! Tests that hosts can abort suspended feeds uncatchably to enforce limits.
 
 use insta::assert_snapshot;
-use monty::{MontyRepl, MontyRun, RunProgress};
+use monty::{MontyRepl, MontyRun, ReplProgress, RunProgress};
 use monty_types::{
     CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult, PrintWriter,
     ResourceTracker,
@@ -145,6 +145,106 @@ await main()
         .expect("still waiting on bar");
     let exc = state.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
     assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_snapshot!(exc.to_string(), @r#"
+    Traceback (most recent call last):
+      File "test.py", line 10, in <module>
+        await main()
+        ~~~~~~~~~~~~
+      File "test.py", line 5, in main
+        a, b = await asyncio.gather(foo(), bar())
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RuntimeError: suspension limit 3 exceeded
+    "#);
+}
+
+/// The last runnable task finishing parks the VM with every real frame held
+/// by the scheduler; the abort still reports the main task's `await`.
+#[test]
+fn abort_resolve_futures_while_parked() {
+    let code = "\
+import asyncio
+
+async def slow():
+    return await foo()
+
+async def quick():
+    return 2
+
+async def main():
+    a, b = await asyncio.gather(slow(), quick())
+    return a + b
+
+await main()
+";
+    let call = start(code).into_function_call().expect("foo call");
+    let state = call
+        .resume_pending(PrintWriter::Stdout)
+        .unwrap()
+        .into_resolve_futures()
+        .expect("waiting on foo");
+    let exc = state.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::RuntimeError);
+    assert_snapshot!(exc.to_string(), @r#"
+    Traceback (most recent call last):
+      File "test.py", line 13, in <module>
+        await main()
+        ~~~~~~~~~~~~
+      File "test.py", line 10, in main
+        a, b = await asyncio.gather(slow(), quick())
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RuntimeError: suspension limit 3 exceeded
+    "#);
+}
+
+/// The REPL abort path reloads the parked main task the same way.
+#[test]
+fn repl_abort_resolve_futures_while_parked() {
+    let code = "\
+import asyncio
+
+async def quick():
+    return 2
+
+async def main():
+    return await asyncio.gather(foo(), quick())
+
+await main()
+";
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run("x = 41", vec![], PrintWriter::Stdout).unwrap();
+    let mut progress = repl.feed_start(code, vec![], PrintWriter::Stdout).unwrap();
+    let state = loop {
+        progress = match progress {
+            ReplProgress::NameLookup(lookup) => {
+                let name = lookup.name.clone();
+                lookup
+                    .resume(
+                        NameLookupResult::Value(MontyObject::Function { name, docstring: None }),
+                        PrintWriter::Stdout,
+                    )
+                    .unwrap()
+            }
+            ReplProgress::FunctionCall(call) => call.resume_pending(PrintWriter::Stdout).unwrap(),
+            ReplProgress::ResolveFutures(state) => break state,
+            other => panic!("unexpected progress {other:?}"),
+        };
+    };
+    let err = state.abort(limit_exceeded(), PrintWriter::Stdout).unwrap_err();
+    assert_snapshot!(err.error.to_string(), @r#"
+    Traceback (most recent call last):
+      File "<python-input-1>", line 9, in <module>
+        await main()
+        ~~~~~~~~~~~~
+      File "<python-input-1>", line 7, in main
+        return await asyncio.gather(foo(), quick())
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RuntimeError: suspension limit 3 exceeded
+    "#);
+    let mut repl = err.repl;
+    assert_eq!(
+        repl.feed_run("x + 1", vec![], PrintWriter::Stdout).unwrap(),
+        MontyObject::Int(42)
+    );
 }
 
 /// A REPL abort preserves earlier globals and skips code after the suspension.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ hello world
 | `--max-memory` | Maximum heap memory, e.g. `1024`, `512KB`, `10MB`, `1GB` |
 | `--max-recursion-depth` | Maximum call-stack depth; defaults to 1000 when any limit is set |
 | `--gc-interval` | Run garbage collection every N allocations |
-| `--max-suspensions` | Maximum suspensions (OS calls, name lookups) serviced per run |
+| `--max-suspensions` | Maximum suspensions (OS calls, name lookups) serviced per run (default 1000) |
 | `--version` | Print the version |
 
 See [resource limits](resource-limits.md) for what the limits actually bound.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ hello world
 | `--max-memory` | Maximum heap memory, e.g. `1024`, `512KB`, `10MB`, `1GB` |
 | `--max-recursion-depth` | Maximum call-stack depth; defaults to 1000 when any limit is set |
 | `--gc-interval` | Run garbage collection every N allocations |
-| `--max-suspensions` | Maximum suspensions (OS calls, name lookups) serviced, per run or across a whole interactive session (default 1000) |
+| `--max-suspensions` | Maximum suspensions serviced, per run or across a whole interactive session (default 1000); [what counts](resource-limits.md#suspensions) |
 | `--version` | Print the version |
 
 See [resource limits](resource-limits.md) for what the limits actually bound.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,7 @@ hello world
 | `--max-memory` | Maximum heap memory, e.g. `1024`, `512KB`, `10MB`, `1GB` |
 | `--max-recursion-depth` | Maximum call-stack depth; defaults to 1000 when any limit is set |
 | `--gc-interval` | Run garbage collection every N allocations |
+| `--max-suspensions` | Maximum suspensions (OS calls, name lookups) serviced per run |
 | `--version` | Print the version |
 
 See [resource limits](resource-limits.md) for what the limits actually bound.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ hello world
 | `--max-memory` | Maximum heap memory, e.g. `1024`, `512KB`, `10MB`, `1GB` |
 | `--max-recursion-depth` | Maximum call-stack depth; defaults to 1000 when any limit is set |
 | `--gc-interval` | Run garbage collection every N allocations |
-| `--max-suspensions` | Maximum suspensions (OS calls, name lookups) serviced per run (default 1000) |
+| `--max-suspensions` | Maximum suspensions (OS calls, name lookups) serviced, per run or across a whole interactive session (default 1000) |
 | `--version` | Print the version |
 
 See [resource limits](resource-limits.md) for what the limits actually bound.

--- a/docs/host-objects.md
+++ b/docs/host-objects.md
@@ -139,8 +139,8 @@ print(result)
 Every wrapper the hook creates is kept by the session's instance store until the session ends.
 A method that returns a fresh object per call grows host memory by one entry per call, and
 [`max_memory`](resource-limits.md#what-is-not-covered) does not count it.
-Every such call is a suspension, so [`max_suspensions`](resource-limits.md#suspensions) bounds how many entries a
-session can create; set it for untrusted code, and recycle long-lived sessions.
+Each call suspends, so [`max_suspensions`](resource-limits.md#suspensions) bounds instance-store growth.
+Set it for untrusted code, and recycle long-lived sessions.
 
 ## Sandbox instances
 

--- a/docs/host-objects.md
+++ b/docs/host-objects.md
@@ -139,7 +139,8 @@ print(result)
 Every wrapper the hook creates is kept by the session's instance store until the session ends.
 A method that returns a fresh object per call grows host memory by one entry per call, and
 [`max_memory`](resource-limits.md#what-is-not-covered) does not count it.
-Bound what a long-lived session hands out, or recycle sessions periodically.
+Every such call is a suspension, so [`max_suspensions`](resource-limits.md#suspensions) bounds how many entries a
+session can create; set it for untrusted code, and recycle long-lived sessions.
 
 ## Sandbox instances
 

--- a/docs/quickstart/javascript.md
+++ b/docs/quickstart/javascript.md
@@ -160,8 +160,8 @@ await using session = await pool.checkout({
 })
 ```
 
-Omitted `maxMemory` / `maxDurationSecs` / `maxSuspensions` means unlimited.
-`maxRecursionDepth` defaults to 1000 and cannot be disabled.
+Omitted `maxMemory` / `maxDurationSecs` means unlimited.
+`maxRecursionDepth` and `maxSuspensions` default to 1000 and cannot be disabled.
 `gcInterval` defaults to every 100,000 allocations.
 The pool enforces `maxSuspensions`: the first suspension over the budget ends the feed with an uncatchable
 `RuntimeError`.

--- a/docs/quickstart/javascript.md
+++ b/docs/quickstart/javascript.md
@@ -163,7 +163,7 @@ await using session = await pool.checkout({
 Omitted `maxMemory` / `maxDurationSecs` / `maxSuspensions` means unlimited.
 `maxRecursionDepth` defaults to 1000 and cannot be disabled.
 `gcInterval` defaults to every 100,000 allocations.
-`maxSuspensions` is enforced by the pool itself: the host round trip past the budget ends the feed with an uncatchable
+The pool enforces `maxSuspensions`: the first suspension over the budget ends the feed with an uncatchable
 `RuntimeError`.
 See [resource limits](../resource-limits.md) and [type checking](../type-checking.md).
 

--- a/docs/quickstart/javascript.md
+++ b/docs/quickstart/javascript.md
@@ -160,9 +160,11 @@ await using session = await pool.checkout({
 })
 ```
 
-Omitted `maxMemory` / `maxDurationSecs` means unlimited.
+Omitted `maxMemory` / `maxDurationSecs` / `maxSuspensions` means unlimited.
 `maxRecursionDepth` defaults to 1000 and cannot be disabled.
 `gcInterval` defaults to every 100,000 allocations.
+`maxSuspensions` is enforced by the pool itself: the host round trip past the budget ends the feed with an uncatchable
+`RuntimeError`.
 See [resource limits](../resource-limits.md) and [type checking](../type-checking.md).
 
 ## Filesystem mounts

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -203,6 +203,8 @@ The pool leaves the checkout open, but the heap behind it is no longer trustwort
 again.
 A spent `max_duration_secs` budget is cumulative, so later feeds re-raise `TimeoutError` anyway; after a `max_memory`
 trip they may quietly succeed.
+A `RuntimeError` reading `suspension limit exceeded` is the pool's own `max_suspensions` limit on host round trips;
+that one leaves the session consistent, and only further suspending feeds fail.
 
 The print-collector cap is not one of these, though it looks identical from the outside: same `MontyRuntimeError`, same
 `MemoryError`, same `memory limit exceeded: ...` message.

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -203,7 +203,7 @@ The pool leaves the checkout open, but the heap behind it is no longer trustwort
 again.
 A spent `max_duration_secs` budget is cumulative, so later feeds re-raise `TimeoutError` anyway; after a `max_memory`
 trip they may quietly succeed.
-`max_suspensions` limits host calls and raises a pool-generated `RuntimeError` containing `suspension limit exceeded`.
+`max_suspensions` limits host calls and raises a pool-generated `RuntimeError` such as `suspension limit 1000 exceeded`.
 The feed ends cleanly; later code runs until it suspends again.
 
 The print-collector cap is not one of these, though it looks identical from the outside: same `MontyRuntimeError`, same

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -203,8 +203,8 @@ The pool leaves the checkout open, but the heap behind it is no longer trustwort
 again.
 A spent `max_duration_secs` budget is cumulative, so later feeds re-raise `TimeoutError` anyway; after a `max_memory`
 trip they may quietly succeed.
-A `RuntimeError` reading `suspension limit exceeded` is the pool's own `max_suspensions` limit on host round trips;
-that one leaves the session consistent, and only further suspending feeds fail.
+`max_suspensions` limits host calls and raises a pool-generated `RuntimeError` containing `suspension limit exceeded`.
+The feed ends cleanly; later code runs until it suspends again.
 
 The print-collector cap is not one of these, though it looks identical from the outside: same `MontyRuntimeError`, same
 `MemoryError`, same `memory limit exceeded: ...` message.

--- a/docs/quickstart/rust.md
+++ b/docs/quickstart/rust.md
@@ -82,17 +82,23 @@ trusted back into the pool.
   With a `max_duration` budget the deadline also enforces that from outside the child, plus `duration_limit_grace`.
   `PoolConfig::subprocess` sets neither `request_timeout` nor `checkout_timeout` by default; set `request_timeout`
   yourself for untrusted code.
+- **Suspension limits** — the pool counts external calls, OS calls, name lookups and future-resolution turns against
+  `ResourceLimits::max_suspensions`.
+  The suspension past the limit ends the feed with an uncatchable `RuntimeError`.
 - **Untrusted children** — every frame from a possibly compromised worker is validated; wire decoding never panics, and
   a protocol violation discards the worker.
 - **Worker recycling** — `max_checkouts_per_worker` bounds the impact of a slow leak.
 
 Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its session stay alive and
 usable.
-Resource-limit failures are the exception.
-They arrive as `PoolError::Runtime` too, carrying a `MemoryError` or `TimeoutError`, but [no guarantees hold about heap
-state afterwards](../resource-limits.md#after-a-limit-fires) — and because `max_duration` is a cumulative budget, once
-it is spent every later `feed` fails immediately.
+Memory and time limit failures are the exception.
+They carry a `MemoryError` or `TimeoutError`, but [no guarantees hold about heap
+state afterwards](../resource-limits.md#after-a-limit-fires).
+Because `max_duration` is cumulative, every later `feed` fails immediately once it is spent.
 Finish the checkout and take a fresh one.
+
+A suspension-limit failure also arrives as `PoolError::Runtime`, but aborting the feed leaves the session consistent.
+Feeds that do not suspend still work; later suspensions fail because the checkout's count remains spent.
 
 ### Transports
 
@@ -183,6 +189,11 @@ assert_eq!(result, MontyObject::Int(42));
 
 Async host functions work the same way: `FunctionCall::resume_pending` continues with a pending future the sandboxed
 code can `await`, and when every task is blocked the run yields `RunProgress::ResolveFutures` for the host to settle.
+
+`FunctionCall`, `OsCall`, `NameLookup` and `ResolveFutures` each have an `abort` method.
+It raises a host-supplied `MontyException` uncatchably at the suspension point and unwinds the run with a traceback.
+A host driving the interpreter directly must count suspensions and call `abort` to enforce `max_suspensions`;
+`ResourceTracker` stores that limit but does not enforce it.
 
 ### Serialization
 

--- a/docs/quickstart/rust.md
+++ b/docs/quickstart/rust.md
@@ -84,21 +84,20 @@ trusted back into the pool.
   yourself for untrusted code.
 - **Suspension limits** — the pool counts external calls, OS calls, name lookups and future-resolution turns against
   `ResourceLimits::max_suspensions`.
-  The suspension past the limit ends the feed with an uncatchable `RuntimeError`.
+  The first suspension over the limit ends the feed with an uncatchable `RuntimeError`.
 - **Untrusted children** — every frame from a possibly compromised worker is validated; wire decoding never panics, and
   a protocol violation discards the worker.
 - **Worker recycling** — `max_checkouts_per_worker` bounds the impact of a slow leak.
 
 Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its session stay alive and
 usable.
-Memory and time limit failures are the exception.
-They carry a `MemoryError` or `TimeoutError`, but [no guarantees hold about heap
-state afterwards](../resource-limits.md#after-a-limit-fires).
-Because `max_duration` is cumulative, every later `feed` fails immediately once it is spent.
+Memory and time limits return `PoolError::Runtime` with a `MemoryError` or `TimeoutError`, but
+[no guarantees hold about heap state afterwards](../resource-limits.md#after-a-limit-fires).
+A spent `max_duration` rejects every later `feed`.
 Finish the checkout and take a fresh one.
 
-A suspension-limit failure also arrives as `PoolError::Runtime`, but aborting the feed leaves the session consistent.
-Feeds that do not suspend still work; later suspensions fail because the checkout's count remains spent.
+`max_suspensions` also returns `PoolError::Runtime`, but leaves the session consistent.
+Later feeds run until they suspend; the count remains spent.
 
 ### Transports
 
@@ -190,8 +189,8 @@ assert_eq!(result, MontyObject::Int(42));
 Async host functions work the same way: `FunctionCall::resume_pending` continues with a pending future the sandboxed
 code can `await`, and when every task is blocked the run yields `RunProgress::ResolveFutures` for the host to settle.
 
-`FunctionCall`, `OsCall`, `NameLookup` and `ResolveFutures` each have an `abort` method.
-It raises a host-supplied `MontyException` uncatchably at the suspension point and unwinds the run with a traceback.
+`FunctionCall`, `OsCall`, `NameLookup` and `ResolveFutures` expose `abort`, which raises a host-supplied
+`MontyException` uncatchably at the suspension point and unwinds the run with a traceback.
 A host driving the interpreter directly must count suspensions and call `abort` to enforce `max_suspensions`;
 `ResourceTracker` stores that limit but does not enforce it.
 

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -29,11 +29,12 @@ with Monty() as pool:
 | `max_duration_secs` | Maximum cumulative execution time in seconds |
 | `max_recursion_depth` | Maximum function call stack depth (default 1000) |
 | `gc_interval` | Run garbage collection every N allocations |
-| `max_suspensions` | Maximum host round trips (external calls, `os` callbacks, name lookups, future resolution) per session |
+| `max_suspensions` | Maximum host round trips (external calls, `os` callbacks, name lookups, future resolution) per session (default 1000) |
 
 Every key is optional.
-Omit `max_memory`, `max_duration_secs` or `max_suspensions`, or set them to `None`, to disable that limit.
-`max_recursion_depth` cannot be disabled: omitting it, or passing `None`, leaves the 1000-frame default.
+Omit `max_memory` or `max_duration_secs`, or set them to `None`, to disable that limit.
+`max_recursion_depth` and `max_suspensions` cannot be disabled: omitting either, or passing `None`, leaves its 1000
+default.
 `gc_interval` omitted or `None` uses the built-in schedule of every 100,000 allocations; collection cannot be turned
 off.
 
@@ -110,7 +111,7 @@ These host round trips are outside `max_memory`; each [`ClassType`](host-objects
 adds an instance-store entry.
 Because `max_duration_secs` pauses during suspensions, a snippet could otherwise retry rejected calls indefinitely.
 
-The pool enforces the limit per checkout.
+The pool enforces the limit per checkout; the default is 1000, and a host that needs more sets a larger number.
 A host driving the interpreter directly counts suspensions and calls `abort` itself; the limit only travels in the
 `ResourceTracker`, see the [Rust quickstart](quickstart/rust.md).
 The first suspension over the budget aborts the feed with an uncatchable

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -116,7 +116,8 @@ A host driving the interpreter directly counts suspensions and calls `abort` its
 The first suspension over the budget aborts the feed with an uncatchable
 `RuntimeError: suspension limit exceeded: 4 > 3` at the call site.
 The session stays consistent and can be dumped; later feeds run until they suspend.
-Restoring a dump preserves the limit but resets the count to zero.
+Restoring a dump preserves the limit but resets the count to zero; a `max_suspensions` set on the restoring checkout
+caps the dump's, so a worker cannot report a looser one.
 
 ## What is not covered
 

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -21,7 +21,7 @@ with Monty() as pool:
             #> MemoryError
 ```
 
-## The four settings
+## The five settings
 
 | Key | Meaning |
 | --- | --- |
@@ -29,15 +29,16 @@ with Monty() as pool:
 | `max_duration_secs` | Maximum cumulative execution time in seconds |
 | `max_recursion_depth` | Maximum function call stack depth (default 1000) |
 | `gc_interval` | Run garbage collection every N allocations |
+| `max_suspensions` | Maximum host round trips (external calls, `os` callbacks, name lookups) per session |
 
 Every key is optional.
-Omit `max_memory` or `max_duration_secs`, or set them to `None`, to disable that limit.
+Omit `max_memory`, `max_duration_secs` or `max_suspensions`, or set them to `None`, to disable that limit.
 `max_recursion_depth` cannot be disabled: omitting it, or passing `None`, leaves the 1000-frame default.
 `gc_interval` omitted or `None` uses the built-in schedule of every 100,000 allocations; collection cannot be turned
 off.
 
-In JavaScript the same fields are `maxMemory`, `maxDurationSecs`, `maxRecursionDepth` and `gcInterval`, passed as
-`limits` to `pool.checkout()`.
+In JavaScript the same fields are `maxMemory`, `maxDurationSecs`, `maxRecursionDepth`, `gcInterval` and
+`maxSuspensions`, passed as `limits` to `pool.checkout()`.
 In Rust they are the fields of `monty_types::ResourceLimits`, where the duration is a `Duration` named `max_duration`.
 
 ## Memory
@@ -101,6 +102,22 @@ recursive `__repr__`/`__str__` — re-enter on the native Rust stack rather than
 Those are capped independently at a lower fixed depth, so Monty raises `RecursionError` before a native stack overflow
 could abort the process.
 
+## Suspensions
+
+`max_suspensions` bounds how many times a session may suspend to your process: every external function call,
+host-object method call or construction, lazy attribute lookup, `os` callback, name lookup and future resolution.
+Each is a round trip that costs the host memory the sandbox limits cannot see, most visibly a
+[`ClassType`](host-objects.md) with `init=True`, where every construction adds an entry to the host's instance store.
+A snippet that catches each refused call and retries forever would otherwise produce an unbounded stream of them while
+`max_duration_secs` sits paused and `max_memory` sees nothing.
+
+It is enforced by the pool, not the sandbox: the pool counts the suspensions it answers, and on the one past the budget
+it ends the feed with `RuntimeError: suspension limit exceeded: 4 > 3`, raised uncatchably at the suspending call with a
+full traceback.
+The count is per checkout and is never reset, so every later feed that suspends fails on its first suspension.
+Feeds that do not suspend keep working, the session stays consistent, and it can still be dumped.
+A restored dump keeps the limit but starts counting from zero.
+
 ## What is not covered
 
 - **Compilation time.** Parsing and bytecode compilation happen before the VM exists and are not charged to the duration
@@ -124,6 +141,8 @@ A memory or time limit is **terminal**.
 Sandboxed code cannot catch it, and once it fires **no guarantees are made about heap state or reference counts** — the
 heap may hold orphaned objects with wrong refcounts.
 Discard the session rather than continuing to run code in it.
+A suspension limit is also uncatchable, but the feed ends cleanly, so reading results out of the session afterwards is
+fine; only further suspending code is refused.
 
 The pool does **not** do this for you.
 The checkout stays open and accepts further `feed_run` calls.

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -104,19 +104,17 @@ could abort the process.
 
 ## Suspensions
 
-`max_suspensions` bounds how many times a session may suspend to your process: every external function call,
-host-object method call or construction, lazy attribute lookup, `os` callback, name lookup and future resolution.
-Each is a round trip that costs the host memory the sandbox limits cannot see, most visibly a
-[`ClassType`](host-objects.md) with `init=True`, where every construction adds an entry to the host's instance store.
-A snippet that catches each refused call and retries forever would otherwise produce an unbounded stream of them while
-`max_duration_secs` sits paused and `max_memory` sees nothing.
+`max_suspensions` counts external calls, host-object method calls and construction, lazy attribute lookups, `os`
+callbacks, name lookups and future-resolution events.
+These host round trips are outside `max_memory`; each [`ClassType`](host-objects.md) construction with `init=True` also
+adds an instance-store entry.
+Because `max_duration_secs` pauses during suspensions, a snippet could otherwise retry rejected calls indefinitely.
 
-It is enforced by the pool, not the sandbox: the pool counts the suspensions it answers, and on the one past the budget
-it ends the feed with `RuntimeError: suspension limit exceeded: 4 > 3`, raised uncatchably at the suspending call with a
-full traceback.
-The count is per checkout and is never reset, so every later feed that suspends fails on its first suspension.
-Feeds that do not suspend keep working, the session stays consistent, and it can still be dumped.
-A restored dump keeps the limit but starts counting from zero.
+The pool enforces the limit per checkout.
+The first suspension over the budget aborts the feed with an uncatchable
+`RuntimeError: suspension limit exceeded: 4 > 3` at the call site.
+The session stays consistent and can be dumped; later feeds run until they suspend.
+Restoring a dump preserves the limit but resets the count to zero.
 
 ## What is not covered
 
@@ -141,8 +139,8 @@ A memory or time limit is **terminal**.
 Sandboxed code cannot catch it, and once it fires **no guarantees are made about heap state or reference counts** — the
 heap may hold orphaned objects with wrong refcounts.
 Discard the session rather than continuing to run code in it.
-A suspension limit is also uncatchable, but the feed ends cleanly, so reading results out of the session afterwards is
-fine; only further suspending code is refused.
+`max_suspensions` also raises uncatchably, but ends the feed cleanly.
+The session remains usable until code suspends again.
 
 The pool does **not** do this for you.
 The checkout stays open and accepts further `feed_run` calls.

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -115,7 +115,7 @@ The pool enforces the limit per checkout; the default is 1000, and a host that n
 A host driving the interpreter directly counts suspensions and calls `abort` itself; the limit only travels in the
 `ResourceTracker`, see the [Rust quickstart](quickstart/rust.md).
 The first suspension over the budget aborts the feed with an uncatchable
-`RuntimeError: suspension limit exceeded: 4 > 3` at the call site.
+`RuntimeError: suspension limit 3 exceeded` at the call site.
 The session stays consistent and can be dumped; later feeds run until they suspend.
 Restoring a dump preserves the limit but resets the count to zero; a `max_suspensions` set on the restoring checkout
 caps the dump's, so a worker cannot report a looser one.

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -29,7 +29,7 @@ with Monty() as pool:
 | `max_duration_secs` | Maximum cumulative execution time in seconds |
 | `max_recursion_depth` | Maximum function call stack depth (default 1000) |
 | `gc_interval` | Run garbage collection every N allocations |
-| `max_suspensions` | Maximum host round trips (external calls, `os` callbacks, name lookups) per session |
+| `max_suspensions` | Maximum host round trips (external calls, `os` callbacks, name lookups, future resolution) per session |
 
 Every key is optional.
 Omit `max_memory`, `max_duration_secs` or `max_suspensions`, or set them to `None`, to disable that limit.
@@ -111,6 +111,8 @@ adds an instance-store entry.
 Because `max_duration_secs` pauses during suspensions, a snippet could otherwise retry rejected calls indefinitely.
 
 The pool enforces the limit per checkout.
+A host driving the interpreter directly counts suspensions and calls `abort` itself; the limit only travels in the
+`ResourceTracker`, see the [Rust quickstart](quickstart/rust.md).
 The first suspension over the budget aborts the feed with an uncatchable
 `RuntimeError: suspension limit exceeded: 4 > 3` at the call site.
 The session stays consistent and can be dumped; later feeds run until they suspend.

--- a/docs/security.md
+++ b/docs/security.md
@@ -129,6 +129,10 @@ See [resource limits](resource-limits.md) for the full picture; the security-rel
   cumulative, so every later feed fails with the same `TimeoutError`, while after a `max_memory` trip a later feed may
   quietly succeed against a corrupted heap.
 - Compilation is not charged against the duration budget.
+- `max_suspensions` bounds the host round trips a session may make.
+  A snippet that retries a refused host call forever costs the sandbox nothing the other limits can see, but costs
+  your process memory per round trip — and with an `init=True` host class, an instance-store entry per construction.
+  The pool enforces it by ending the feed with an uncatchable `RuntimeError`; the count is per checkout.
   It has its own structural caps (AST nesting, bytecode operand sizes, comprehension nesting, `finally` expansion), but
   a host accepting untrusted source should still isolate compilation — as the subprocess and WebAssembly runtimes do.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -129,12 +129,12 @@ See [resource limits](resource-limits.md) for the full picture; the security-rel
   cumulative, so every later feed fails with the same `TimeoutError`, while after a `max_memory` trip a later feed may
   quietly succeed against a corrupted heap.
 - Compilation is not charged against the duration budget.
-- `max_suspensions` bounds the host round trips a session may make.
-  A snippet that retries a refused host call forever costs the sandbox nothing the other limits can see, but costs
-  your process memory per round trip — and with an `init=True` host class, an instance-store entry per construction.
-  The pool enforces it by ending the feed with an uncatchable `RuntimeError`; the count is per checkout.
   It has its own structural caps (AST nesting, bytecode operand sizes, comprehension nesting, `finally` expansion), but
   a host accepting untrusted source should still isolate compilation — as the subprocess and WebAssembly runtimes do.
+- `max_suspensions` bounds suspension events per checkout.
+  A snippet can otherwise retry a rejected host call while `max_duration_secs` is paused.
+  Each allowed `ClassType(init=True)` construction adds an instance-store entry outside `max_memory`.
+  The pool aborts the first suspension over the limit with an uncatchable `RuntimeError`.
 
 ## Where the guarantees weaken
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -137,6 +137,8 @@ with Monty() as pool:
   See [`limitations/pool-architecture.md`](https://github.com/pydantic/monty/blob/main/limitations/pool-architecture.md#host-api-behaviour-notes).
 - **The accumulated time budget travels with the dump**, so a restored session resumes where it left off rather than
   getting a fresh budget.
+- **The suspension count does not.** A restored session keeps the dump's `max_suspensions` but the pool counts from
+  zero again, because the count is kept by the pool rather than the sandbox.
 - **Mounts do not travel.** Host paths are never part of a dump.
   Pass the same `mount=` to `load_snapshot`, or the restored feed's filesystem calls degrade into unhandled OS calls.
   Any `'overlay'` writes made before the dump are gone — the restored overlay starts empty.

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -138,7 +138,7 @@ with Monty() as pool:
 - **The accumulated time budget travels with the dump**, so a restored session resumes where it left off rather than
   getting a fresh budget.
 - **Only the suspension limit travels.** A restored session keeps `max_suspensions`, but the pool resets its count to
-  zero.
+  zero, and a `max_suspensions` set on the restoring `checkout()` caps the dump's.
 - **Mounts do not travel.** Host paths are never part of a dump.
   Pass the same `mount=` to `load_snapshot`, or the restored feed's filesystem calls degrade into unhandled OS calls.
   Any `'overlay'` writes made before the dump are gone — the restored overlay starts empty.

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -137,8 +137,8 @@ with Monty() as pool:
   See [`limitations/pool-architecture.md`](https://github.com/pydantic/monty/blob/main/limitations/pool-architecture.md#host-api-behaviour-notes).
 - **The accumulated time budget travels with the dump**, so a restored session resumes where it left off rather than
   getting a fresh budget.
-- **The suspension count does not.** A restored session keeps the dump's `max_suspensions` but the pool counts from
-  zero again, because the count is kept by the pool rather than the sandbox.
+- **Only the suspension limit travels.** A restored session keeps `max_suspensions`, but the pool resets its count to
+  zero.
 - **Mounts do not travel.** Host paths are never part of a dump.
   Pass the same `mount=` to `load_snapshot`, or the restored feed's filesystem calls degrade into unhandled OS calls.
   Any `'overlay'` writes made before the dump are gone — the restored overlay starts empty.

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -74,7 +74,9 @@ properties that real CPython does not provide, per the caveat above.
   divergences below).
 - Resource exhaustion (e.g. `max_duration_secs`) is terminal for the
   *session*: later feeds keep failing with the same resource error. The
-  worker process is reused for the next checkout.
+  worker process is reused for the next checkout. `max_suspensions` is the
+  exception: only feeds that suspend keep failing, since the pool ends each
+  of them on its first suspension.
 - Asyncio cancellation of an in-flight call (`feed_run`, `dump`, ...)
   **loses the session**: the protocol turn was abandoned mid-flight, so its
   worker can no longer be trusted. It is killed immediately, or, when the
@@ -104,6 +106,12 @@ properties that real CPython does not provide, per the caveat above.
   host (external functions, OS callbacks) or between feeds, accumulates
   across feeds, and travels inside dumps. The worker reports its total on
   every protocol turn; the host never keeps a second clock.
+- **`max_suspensions` is enforced by the host alone.** The pool counts the
+  suspensions it services per checkout and answers the one past the budget
+  with an `AbortFeed` request instead of a value, which the worker raises
+  as an uncatchable `RuntimeError` at the suspension point. The worker only
+  stores the limit (so it travels in dumps and is re-adopted on restore) and
+  never counts; a restored session starts from zero.
 - **`max_duration` is backstopped by the host.** From the reported total the
   host bounds each execution turn by the remaining budget plus
   `duration_limit_grace` (default 1s) and kills the worker when it expires.

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -109,7 +109,9 @@ properties that real CPython does not provide, per the caveat above.
   events per checkout and answers the first one over budget with `AbortFeed`.
   The worker raises its `RuntimeError` uncatchably at the suspension point.
   The worker stores the limit for dumps but does not count, so restoring a
-  session resets the count.
+  session resets the count. The limit a restore re-adopts from the worker's
+  reply is capped by the checkout's own configured `max_suspensions`, since
+  the reply is untrusted.
 - **`max_duration` is backstopped by the host.** From the reported total the
   host bounds each execution turn by the remaining budget plus
   `duration_limit_grace` (default 1s) and kills the worker when it expires.

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -74,9 +74,8 @@ properties that real CPython does not provide, per the caveat above.
   divergences below).
 - Resource exhaustion (e.g. `max_duration_secs`) is terminal for the
   *session*: later feeds keep failing with the same resource error. The
-  worker process is reused for the next checkout. `max_suspensions` is the
-  exception: only feeds that suspend keep failing, since the pool ends each
-  of them on its first suspension.
+  worker process is reused for the next checkout. `max_suspensions` differs:
+  later feeds run until they suspend, when the pool ends the feed.
 - Asyncio cancellation of an in-flight call (`feed_run`, `dump`, ...)
   **loses the session**: the protocol turn was abandoned mid-flight, so its
   worker can no longer be trusted. It is killed immediately, or, when the
@@ -106,12 +105,11 @@ properties that real CPython does not provide, per the caveat above.
   host (external functions, OS callbacks) or between feeds, accumulates
   across feeds, and travels inside dumps. The worker reports its total on
   every protocol turn; the host never keeps a second clock.
-- **`max_suspensions` is enforced by the host alone.** The pool counts the
-  suspensions it services per checkout and answers the one past the budget
-  with an `AbortFeed` request instead of a value, which the worker raises
-  as an uncatchable `RuntimeError` at the suspension point. The worker only
-  stores the limit (so it travels in dumps and is re-adopted on restore) and
-  never counts; a restored session starts from zero.
+- **`max_suspensions` is enforced by the host.** The pool counts suspension
+  events per checkout and answers the first one over budget with `AbortFeed`.
+  The worker raises its `RuntimeError` uncatchably at the suspension point.
+  The worker stores the limit for dumps but does not count, so restoring a
+  session resets the count.
 - **`max_duration` is backstopped by the host.** From the reported total the
   host bounds each execution turn by the remaining budget plus
   `duration_limit_grace` (default 1s) and kills the worker when it expires.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -146,6 +146,9 @@ indistinguishable from a stack overflow.
   external function calls, host-object method calls, attribute lookups and
   construction, OS calls, name lookups, and each `ResolveFutures` round trip
   (a partial future resolution that re-suspends counts again).
+- It defaults to 1000 and cannot be disabled (like `max_recursion_depth`):
+  omitting it, or passing `None`, keeps the default; set a larger number
+  for sessions that legitimately make more host calls.
 - `monty-pool` enforces it for `pydantic_monty`, the JavaScript napi pool and
   monty-server. The wasm worker pool and CLI also enforce it. A direct host
   must count suspensions and call `abort` itself.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -1,10 +1,9 @@
 # Resource limits
 
-Monty enforces limits on memory, time, and recursion to keep untrusted code
-bounded, and the host that services its suspensions enforces a suspension
-count. Memory limits surface to the host as `MemoryError`s, time limits as
-`TimeoutError`s and the suspension limit as a `RuntimeError`; sandboxed code
-cannot catch any of these. `RecursionError` is catchable, as in CPython.
+Monty limits memory, time, and recursion, while the host limits suspension
+events. Exceeding the memory, time, or suspension limit returns `MemoryError`,
+`TimeoutError`, or `RuntimeError`, respectively; sandboxed code cannot catch
+these exceptions. `RecursionError` is catchable, as in CPython.
 
 ## Compilation
 
@@ -147,21 +146,18 @@ indistinguishable from a stack overflow.
   external function calls, host-object method calls, attribute lookups and
   construction, OS calls, name lookups, and each `ResolveFutures` round trip
   (a partial future resolution that re-suspends counts again).
-- It is enforced by the host that answers suspensions — `monty-pool` (so
-  `pydantic_monty`, the JavaScript napi pool and monty-server), the wasm
-  worker pool and the CLI — not by the interpreter. A host driving `monty`
-  directly must count for itself and end the feed with `abort`.
-- The suspension past the budget is never handed to the caller: the host
-  ends the feed with `RuntimeError: suspension limit exceeded: N+1 > N`,
-  raised uncatchably at the suspension point with a traceback, at the cost of
-  one more round trip to the worker.
-- The count is per checkout and is never reset, so once spent every later
-  feed is ended on its first suspension. Feeds that do not suspend still run,
-  the heap stays consistent (the abort unwinds like any unhandled exception)
-  and the session can still be dumped.
-- The count does not travel in dumps; only the limit does. A session
-  restored from a dump keeps the dump's `max_suspensions` but starts
-  counting from zero.
+- `monty-pool` enforces it for `pydantic_monty`, the JavaScript napi pool and
+  monty-server. The wasm worker pool and CLI also enforce it. A direct host
+  must count suspensions and call `abort` itself.
+- The first suspension over budget is not returned to the caller. The host
+  uses one extra worker round trip to raise
+  `RuntimeError: suspension limit exceeded: N+1 > N` uncatchably at the
+  suspension point with a traceback.
+- The count persists for the checkout. Once spent, every later feed ends on
+  its first suspension. Non-suspending feeds still run, the heap stays
+  consistent, and the session can still be dumped.
+- Only the limit travels in dumps. A restored session keeps
+  `max_suspensions` but resets the count to zero.
 - There is no in-sandbox way to observe the budget or remaining count.
 
 ## Time

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -157,7 +157,9 @@ indistinguishable from a stack overflow.
   its first suspension. Non-suspending feeds still run, the heap stays
   consistent, and the session can still be dumped.
 - Only the limit travels in dumps. A restored session keeps
-  `max_suspensions` but resets the count to zero.
+  `max_suspensions` but resets the count to zero; a limit configured on the
+  restoring checkout caps the dump's (the smaller of the two applies, and
+  the configured one alone if the worker's reply omits it).
 - There is no in-sandbox way to observe the budget or remaining count.
 
 ## Time

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -1,9 +1,10 @@
 # Resource limits
 
 Monty enforces limits on memory, time, and recursion to keep untrusted code
-bounded. Memory limits surface to the host as `MemoryError`s and time limits as
-`TimeoutError`s; sandboxed code cannot catch either resource error.
-`RecursionError` is catchable, as in CPython.
+bounded, and the host that services its suspensions enforces a suspension
+count. Memory limits surface to the host as `MemoryError`s, time limits as
+`TimeoutError`s and the suspension limit as a `RuntimeError`; sandboxed code
+cannot catch any of these. `RecursionError` is catchable, as in CPython.
 
 ## Compilation
 
@@ -139,6 +140,29 @@ indistinguishable from a stack overflow.
   limit, so Monty raises `RecursionError` before a native stack overflow would
   abort the process. See the `__repr__`/`__str__` entry in ./classes.md for
   the main user-visible divergence this causes.
+
+## Suspensions
+
+- `max_suspensions` bounds how many times a session may suspend to the host:
+  external function calls, host-object method calls, attribute lookups and
+  construction, OS calls, name lookups, and each `ResolveFutures` round trip
+  (a partial future resolution that re-suspends counts again).
+- It is enforced by the host that answers suspensions — `monty-pool` (so
+  `pydantic_monty`, the JavaScript napi pool and monty-server), the wasm
+  worker pool and the CLI — not by the interpreter. A host driving `monty`
+  directly must count for itself and end the feed with `abort`.
+- The suspension past the budget is never handed to the caller: the host
+  ends the feed with `RuntimeError: suspension limit exceeded: N+1 > N`,
+  raised uncatchably at the suspension point with a traceback, at the cost of
+  one more round trip to the worker.
+- The count is per checkout and is never reset, so once spent every later
+  feed is ended on its first suspension. Feeds that do not suspend still run,
+  the heap stays consistent (the abort unwinds like any unhandled exception)
+  and the session can still be dumped.
+- The count does not travel in dumps; only the limit does. A session
+  restored from a dump keeps the dump's `max_suspensions` but starts
+  counting from zero.
+- There is no in-sandbox way to observe the budget or remaining count.
 
 ## Time
 

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -154,7 +154,7 @@ indistinguishable from a stack overflow.
   must count suspensions and call `abort` itself.
 - The first suspension over budget is not returned to the caller. The host
   uses one extra worker round trip to raise
-  `RuntimeError: suspension limit exceeded: N+1 > N` uncatchably at the
+  `RuntimeError: suspension limit N exceeded` uncatchably at the
   suspension point with a traceback.
 - The count persists for the checkout. Once spent, every later feed ends on
   its first suspension. Non-suspending feeds still run, the heap stays

--- a/packages/pydantic-monty/README.md
+++ b/packages/pydantic-monty/README.md
@@ -260,9 +260,8 @@ protocol turn, and sessions with the limit are additionally killed
 `duration_limit_grace` (1s, not currently configurable from Python) after
 the remaining budget expires, covering hangs the in-sandbox limit cannot
 catch (its check only runs at interpreter checkpoints). `max_suspensions`
-is enforced by the pool itself: it counts the host round trips (external
-functions, `os` callbacks, name lookups) it services per checkout, and the
-one past the budget ends the feed with an uncatchable `RuntimeError`.
+limits the host round trips the pool services per checkout; exceeding it ends
+the feed with an uncatchable `RuntimeError`.
 
 ```python
 from pydantic_monty import Monty, MontyRuntimeError

--- a/packages/pydantic-monty/README.md
+++ b/packages/pydantic-monty/README.md
@@ -259,7 +259,10 @@ accumulates across feeds. The worker reports its execution time on every
 protocol turn, and sessions with the limit are additionally killed
 `duration_limit_grace` (1s, not currently configurable from Python) after
 the remaining budget expires, covering hangs the in-sandbox limit cannot
-catch (its check only runs at interpreter checkpoints).
+catch (its check only runs at interpreter checkpoints). `max_suspensions`
+is enforced by the pool itself: it counts the host round trips (external
+functions, `os` callbacks, name lookups) it services per checkout, and the
+one past the budget ends the feed with an uncatchable `RuntimeError`.
 
 ```python
 from pydantic_monty import Monty, MontyRuntimeError


### PR DESCRIPTION
Closes #736.

## What

`ResourceLimits.max_suspensions` bounds how many times a session may suspend to the host: external function calls, host-object method calls / lazy attributes / `init=True` construction, OS calls, name lookups and each `ResolveFutures` round trip. Nothing else bounds this shape — `max_duration` is paused while suspended and `max_memory` sees no sandbox allocation — yet each round trip costs the parent retained memory, and since #682 every host-class construction also adds an instance-store entry.

## How

The **host that services suspensions is the single source of truth** rather than the interpreter:

- **New `AbortFeed` parent request** (`monty-proto`): valid whenever the child is suspended, whatever the kind. The child raises the given exception *uncatchably* at the suspension point — every frame unwinds into the traceback, no `except` runs — and replies with the `Error` turn-ender. The session survives with a consistent heap, so `feed_run` and `dump` keep working. Exposed on the interpreter as `abort(exc, print)` on `FunctionCall` / `OsCall` / `NameLookup` / `ResolveFutures` and their REPL mirrors; a general host primitive, not only for this limit.
- **`monty-pool`** counts the suspensions it services per checkout (typed and `turn_raw` paths) and, on the one past the budget, sends `AbortFeed` with `RuntimeError: suspension limit exceeded: N+1 > N` and returns the resulting `PoolError::Runtime`. The budget state is grouped into `SessionBudget` alongside the duration backstop.
- **wasm `WorkerTransport`** and the **CLI** (`--max-suspensions`) count and abort the same way.
- The child only stores the limit (so it travels in dumps and is re-adopted on restore, like `max_duration`) and echoes it on `ChildEvent.max_suspensions`. The *count* is host state and restarts at zero on restore — documented.
- Python `limits={'max_suspensions': N}`, JS `maxSuspensions`; `DUMP_VERSION` bumped to 9.

The pool README, `docs/resource-limits.md` (now "five settings" plus a Suspensions section), `docs/security.md`, `docs/host-objects.md`, `docs/snapshots.md`, `limitations/resource_limits.md`, `limitations/pool-architecture.md`, the quickstarts and the crate/package READMEs are updated.

## Follow-up

monty-server (monty-private) needs `max_suspensions` on `LimitPolicy` / `RequestedLimits`, one `tighten` line in `apply`, a `--max-suspensions` flag and a `docs/server.md` row; enforcement itself comes from this PR's pool changes, so a client asking for unlimited is clamped to the operator's ceiling.

## Tests

- `crates/monty/tests/abort.rs`: abort on each suspension kind (incl. a `ResolveFutures` re-suspension and an armed file-read effect), uncatchability inside `except Exception`, a snapshotted traceback, REPL session reuse; also run under `memory-model-checks`.
- `monty-proto` dispatch/roundtrip, `monty-runtime` subprocess, `monty-pool` real-worker and mock-websocket tests (typed path, raw path, restore re-adoption), Python and JS (napi + wasm) limit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thww3RmyMrhsZj8CErWZXz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-disableable `ResourceLimits.max_suspensions` limit of 1000 to bound host round trips that were previously unbounded while `max_duration` paused and `max_memory` missed parent-side growth. Hosts abort the first excess suspension with an uncatchable `RuntimeError`; the session remains usable for later non-suspending feeds, but its budget stays spent. Closes #736.

**Enforcement**

- `monty-pool`, wasm, the CLI, and direct interpreter hosts count external calls, host-object calls and construction, OS calls, name lookups, and future-resolution turns.
- Protocol v3 adds `AbortFeed`, which preserves a traceback, bypasses sandbox handlers, and leaves the session consistent; parked `ResolveFutures` aborts now point to the main task.
- A non-Error reply to an abort discards the worker as a protocol violation; over-budget OsCalls are validated before the abort shortcut.
- Restoring a dump resets the count and adopts its limit, while a checkout limit can only tighten it; the dump format remains at 8.

**APIs**

- Adds `max_suspensions`, `maxSuspensions`, and `--max-suspensions`; omitted or `None` values retain the 1000 default, and interactive CLI sessions share one budget.
- `monty-server` still needs to plumb the setting through its private limit policy.

<sup>Written for commit 1d995b9b35d4ba3646feac6d821b18e072a68ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

