### PR TITLE
match CPython for some float rounding behaviour

### DIFF
--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -101,17 +101,7 @@ pub fn builtin_round(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
                 // Round to `d` decimal places using banker's rounding.
                 Ok(Value::Float(round_float_to_digits(*f, d)))
             } else {
-                // No digits: round to nearest integer and return int (banker's rounding)
-                if f.is_nan() {
-                    Err(SimpleException::new_msg(ExcType::ValueError, "cannot convert float NaN to integer").into())
-                } else if f.is_infinite() {
-                    Err(
-                        SimpleException::new_msg(ExcType::OverflowError, "cannot convert float infinity to integer")
-                            .into(),
-                    )
-                } else {
-                    Ok(Value::Int(f64_to_i64(bankers_round(*f))))
-                }
+                LongInt::value_from_f64(bankers_round(*f), vm.heap)
             }
         }
         _ => {
@@ -137,9 +127,10 @@ fn bankers_round(value: f64) -> f64 {
         floor
     } else if frac > 0.5 {
         floor + 1.0
+    } else if floor % 2.0 == 0.0 {
+        floor
     } else {
-        // Exactly 0.5 - round to even
-        if f64_to_i64(floor) % 2 == 0 { floor } else { floor + 1.0 }
+        floor + 1.0
     }
 }
 
@@ -185,21 +176,4 @@ fn round_float_to_digits(value: f64, digits: i64) -> f64 {
     } else {
         rounded
     }
-}
-
-/// Converts `f64` to `i64` using saturating float-to-int casting.
-///
-/// Monty uses `i64` for integer values, so float-to-int conversion must pick a
-/// bounded representation:
-/// - Values outside the `i64` range saturate to `i64::MIN`/`i64::MAX`
-/// - `NaN` converts to `0`
-///
-/// This behavior is provided by Rust's `as` casting rules for float-to-int.
-fn f64_to_i64(value: f64) -> i64 {
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "intentional truncation; float-to-int casts saturate and map NaN to 0"
-    )]
-    let result = value as i64;
-    result
 }

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1534,6 +1534,18 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::OverflowError, "int too large to convert to float").into()
     }
 
+    /// Creates the OverflowError raised when converting an infinite float to an integer.
+    #[must_use]
+    fn overflow_float_infinity_to_integer() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "cannot convert float infinity to integer").into()
+    }
+
+    /// Creates the ValueError raised when converting NaN to an integer.
+    #[must_use]
+    fn value_error_float_nan_to_integer() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "cannot convert float NaN to integer").into()
+    }
+
     /// Creates a ValueError for a zero modulus passed to `pow`.
     #[must_use]
     fn value_error_pow_modulus_zero() -> RunError {

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -342,7 +342,7 @@ fn math_floor(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(value, vm);
 
     match value {
-        Value::Float(f) => float_to_int_checked(f.floor(), *f, vm.heap),
+        Value::Float(f) => LongInt::value_from_f64(f.floor(), vm.heap),
         Value::Int(n) => Ok(Value::Int(*n)),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
         _ => Err(ExcType::type_error(format!(
@@ -361,7 +361,7 @@ fn math_ceil(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(value, vm);
 
     match value {
-        Value::Float(f) => float_to_int_checked(f.ceil(), *f, vm.heap),
+        Value::Float(f) => LongInt::value_from_f64(f.ceil(), vm.heap),
         Value::Int(n) => Ok(Value::Int(*n)),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
         _ => Err(ExcType::type_error(format!(
@@ -379,7 +379,7 @@ fn math_trunc(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(value, vm);
 
     match value {
-        Value::Float(f) => float_to_int_checked(f.trunc(), *f, vm.heap),
+        Value::Float(f) => LongInt::value_from_f64(f.trunc(), vm.heap),
         Value::Int(n) => Ok(Value::Int(*n)),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
         _ => Err(ExcType::type_error(format!(
@@ -1304,40 +1304,6 @@ fn math_erfc(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 // ==========================
 // Helper functions
 // ==========================
-
-/// Converts a rounded float to an integer `Value`, checking for infinity/NaN.
-///
-/// `rounded` is the already-rounded float value (e.g., from `floor()`, `ceil()`, `trunc()`).
-/// `original` is the original input float, used only to determine the error type:
-/// infinity produces `OverflowError`, NaN produces `ValueError`.
-///
-/// For finite values outside the i64 range, promotes to `LongInt` to match CPython's
-/// behavior of returning arbitrary-precision integers from `math.floor`/`ceil`/`trunc`.
-fn float_to_int_checked(rounded: f64, original: f64, heap: &mut Heap) -> RunResult<Value> {
-    if original.is_infinite() {
-        Err(SimpleException::new_msg(ExcType::OverflowError, "cannot convert float infinity to integer").into())
-    } else if original.is_nan() {
-        Err(SimpleException::new_msg(ExcType::ValueError, "cannot convert float NaN to integer").into())
-    } else if rounded >= i64::MIN as f64 && rounded < i64::MAX as f64 {
-        // Note: `i64::MAX as f64` rounds up to 2^63 (9223372036854775808.0), so we use
-        // strict less-than to exclude that value. `i64::MIN as f64` is exact (-2^63).
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "intentional: value is within i64 range after bounds check"
-        )]
-        let result = rounded as i64;
-        Ok(Value::Int(result))
-    } else {
-        // Value exceeds i64 range — promote to LongInt.
-        // Format with no decimal places and parse as BigInt. This is correct because
-        // `rounded` is already an integer-valued float from floor/ceil/trunc.
-        let s = format!("{rounded:.0}");
-        let bi = s
-            .parse::<BigInt>()
-            .map_err(|_| SimpleException::new_msg(ExcType::ValueError, "float too large to convert to integer"))?;
-        Ok(LongInt::new(bi).into_value(heap))
-    }
-}
 
 /// Converts a `Value` to `f64`, raising `TypeError` if the value is not numeric.
 ///

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -84,6 +84,25 @@ impl LongInt {
         }
     }
 
+    /// Truncates a float into its most compact Python integer representation.
+    ///
+    /// Finite values outside the immediate range become arbitrary-precision integers;
+    /// infinity and NaN raise the exceptions required by Python.
+    pub(crate) fn value_from_f64(value: f64, heap: &Heap) -> RunResult<Value> {
+        if value.is_infinite() {
+            Err(ExcType::overflow_float_infinity_to_integer())
+        } else if value.is_nan() {
+            Err(ExcType::value_error_float_nan_to_integer())
+        } else if value >= i64::MIN as f64 && value < i64::MAX as f64 {
+            // `i64::MAX as f64` rounds up to 2**63, so the upper bound is strict.
+            #[expect(clippy::cast_possible_truncation, reason = "finite value is within the i64 range")]
+            Ok(Value::Int(value as i64))
+        } else {
+            let value = BigInt::from_f64(value).expect("finite f64 converts to BigInt");
+            Ok(Self::new(value).into_value(heap))
+        }
+    }
+
     /// Converts to a `Value`, demoting to i64 if it fits.
     ///
     /// For performance, we want to keep values as `Value::Int(i64)` whenever possible.

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -588,27 +588,6 @@ impl Type {
     }
 }
 
-/// Truncates f64 to i64 with clamping for out-of-range values.
-///
-/// Python's `int(float)` truncates toward zero. For values outside i64 range,
-/// we clamp to i64::MAX/MIN (Python would use arbitrary precision ints, which
-/// we don't support).
-fn f64_to_i64_truncate(value: f64) -> i64 {
-    // trunc() rounds toward zero, matching Python's int(float) behavior
-    let truncated = value.trunc();
-    if truncated >= i64::MAX as f64 {
-        i64::MAX
-    } else if truncated <= i64::MIN as f64 {
-        i64::MIN
-    } else {
-        // SAFETY for clippy: truncated is guaranteed to be in (i64::MIN, i64::MAX)
-        // after the bounds checks above, so truncation cannot overflow
-        #[expect(clippy::cast_possible_truncation, reason = "bounds checked above")]
-        let result = truncated as i64;
-        result
-    }
-}
-
 /// Parses a Python `float()` string argument into an `f64`.
 ///
 /// This supports:
@@ -699,7 +678,7 @@ fn int_convert(x: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
     let interns = vm.interns;
     match x {
         Value::Int(i) => Ok(Value::Int(*i)),
-        Value::Float(f) => Ok(Value::Int(f64_to_i64_truncate(*f))),
+        Value::Float(f) => LongInt::value_from_f64(*f, vm.heap),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
         Value::InternString(string_id) => parse_int_from_str(interns.get_str(*string_id), 10, vm.heap),
         Value::InternBytes(bytes_id) => parse_int_from_bytes(interns.get_bytes(*bytes_id), 10, vm.heap),

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -82,6 +82,10 @@ if is_monty:
 # round edge cases with extreme values
 assert isinstance(round(1e15), int)
 assert isinstance(round(-1e15), int)
+assert round(9.223372036854776e18) == 9223372036854775808
+assert round(1e20) == 100000000000000000000
+assert round(-1e20) == -100000000000000000000
+assert round(1.7976931348623157e308) == (2**53 - 1) * 2**971
 assert round(0.0) == 0
 assert round(-0.0) == 0
 

--- a/crates/monty/test_cases/collections__counter.py
+++ b/crates/monty/test_cases/collections__counter.py
@@ -242,6 +242,8 @@ assert repr(Counter({'a': True})) == "Counter({'a': True})", 'a bool count is no
 # === total() sums the real values ===
 assert Counter({'a': 1.5, 'b': 2}).total() == 3.5, 'total() adds floats as floats'
 assert Counter({'a': 2**70}).total() == 1180591620717411303424, 'total() preserves big ints'
+assert Counter({'a': 3.5, 'b': 2**70}).total() == 1.1805916207174113e21
+assert Counter({'a': 2**70, 'b': 3.5}).total() == 1.1805916207174113e21
 assert Counter().total() == 0, 'total() of an empty Counter is 0'
 # A count that cannot be added raises part-way through the fold, so the running
 # total and the counts after the bad one must not leak.
@@ -253,6 +255,8 @@ except TypeError as e:
 
 # === Arithmetic uses real numeric addition ===
 assert dict(Counter({'a': 1.5}) + Counter({'a': 1.5})) == {'a': 3.0}, '+ adds floats'
+assert dict(Counter({'a': 3.5}) + Counter({'a': 2**70})) == {'a': 1.1805916207174113e21}
+assert dict(Counter({'a': 2**70}) + Counter({'a': 3.5})) == {'a': 1.1805916207174113e21}
 assert dict(Counter({'a': 3.5}) - Counter({'a': 1.0})) == {'a': 2.5}, '- subtracts floats'
 assert dict(Counter({'a': 3.5}) & Counter({'a': 1.5})) == {'a': 1.5}, '& takes the float minimum'
 assert dict(Counter({'a': 3.5}) | Counter({'a': 1.5})) == {'a': 3.5}, '| takes the float maximum'

--- a/crates/monty/test_cases/type__ops.py
+++ b/crates/monty/test_cases/type__ops.py
@@ -113,14 +113,30 @@ assert int(False) == 0
 x = 12345678901234567890
 assert int(x) is x
 
-# int() with extreme float values (should clamp to i64 range in Monty)
-# Note: Python uses arbitrary precision; Monty clamps to i64
+# Float conversion truncates toward zero and promotes beyond the immediate i64 range.
 assert isinstance(int(1e18), int)
 assert isinstance(int(-1e18), int)
+assert int(9.223372036854776e18) == 9223372036854775808
+assert int(1e20) == 100000000000000000000
+assert int(-1e20) == -100000000000000000000
+assert int(1.7976931348623157e308) == (2**53 - 1) * 2**971
 assert int(0.0) == 0
 assert int(-0.0) == 0
 assert int(0.9) == 0
 assert int(-0.9) == 0
+
+for infinity in (float('inf'), float('-inf')):
+    try:
+        int(infinity)
+        assert False, 'expected int(infinity) to fail'
+    except OverflowError as exc:
+        assert str(exc) == 'cannot convert float infinity to integer'
+
+try:
+    int(float('nan'))
+    assert False, 'expected int(NaN) to fail'
+except ValueError as exc:
+    assert str(exc) == 'cannot convert float NaN to integer'
 
 # === float() constructor ===
 assert float() == 0.0

--- a/limitations/collections.md
+++ b/limitations/collections.md
@@ -71,9 +71,6 @@ divergences. `repr(Point)` is `<class 'Point'>` where CPython gives
   order match, but the whole sequence is built up front, so a very large count
   can hit the memory limit where CPython would stream.
 - **Crosses the host boundary as a plain `dict`.**
-- **Mixing `float` and big-int counts raises `TypeError`** (`Counter({'a': 3.5})
-  + Counter({'a': 2**70})`, and `total()` over such a mix). This is Monty's
-  general arithmetic limitation: `3.5 + 2**70` raises identically.
 - **In-place `c &= [list]`** (a non-mapping) subscripts `other[elem]` like
   CPython and raises `TypeError`, but with Monty's list-index wording (`list
   indices must be integers, not 'str'` vs CPython's `... or slices, not str`).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes float-to-integer conversion to match CPython for `round()`, `math.floor()`, `math.ceil()`, `math.trunc()`, and `int()`.

- Replaces i64 clamping with arbitrary-precision promotion for out-of-range floats.
- Adds exact OverflowError/ValueError messages for infinity and NaN.
- Consolidates conversion logic into `LongInt::value_from_f64`.
- Updates `bankers_round` to use the new conversion, fixing `round()` for large floats.
- Removes limitation on mixing float and big-int counts in `Counter`; those operations now produce the correct float result.

<sup>Written for commit 277978fcc9d1833b1da803878156b593f90f3cd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

