### PR TITLE
Debounce print output in the worker

### DIFF
--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -284,8 +284,13 @@ session, before any feed; using the wrong one for a dump's kind throws.
 ## Print Output
 
 `printCallback` accepts a function or a host collector (`PrintTargetInput` in
-TypeScript). Output is line-buffered; without a callback it goes to the host
-process stdout/stderr.
+TypeScript); without a callback output goes to the host process stdout/stderr.
+
+The worker batches output rather than sending an event per `print()`, so a
+callback can receive several prints in one chunk, or one print in several.
+`printFlushInterval` on `checkout()` sets how long (in seconds) output may be
+held — 0.005 by default, or `0` to restore line buffering. Output is always
+flushed before a host call and before a feed ends.
 
 ```ts
 // Function form

--- a/crates/monty-js/__test__/helpers.ts
+++ b/crates/monty-js/__test__/helpers.ts
@@ -43,6 +43,7 @@ export function setupPool(): PoolFixture {
       typeCheckFormat,
       typeCheckColor,
       assertMessageAnnotations,
+      printFlushInterval,
       ...feed
     } = options
     const session = await get().checkout({
@@ -53,6 +54,7 @@ export function setupPool(): PoolFixture {
       ...(typeCheckFormat !== undefined ? { typeCheckFormat } : {}),
       ...(typeCheckColor !== undefined ? { typeCheckColor } : {}),
       ...(assertMessageAnnotations !== undefined ? { assertMessageAnnotations } : {}),
+      ...(printFlushInterval !== undefined ? { printFlushInterval } : {}),
     })
     try {
       return await session.feedRun(code, feed)

--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -10,9 +10,9 @@ const { run, pool } = setupPool()
 // Print tests
 // =============================================================================
 
-// Collects printCallback invocations. Output is line-buffered: each callback
-// call receives one whole line including its trailing '\n' (or the unflushed
-// tail of the stream at the end of the turn).
+// Collects printCallback invocations. The worker batches output, so a call
+// receives whatever was buffered — not one line and not one print(). Tests
+// that care about the split pin `printFlushInterval: 0`.
 function makePrintCollector() {
   const output: string[] = []
 
@@ -33,7 +33,23 @@ test('basic', async () => {
 test('multiple', async () => {
   const { output, callback } = makePrintCollector()
   await run('print("hello")\nprint("world")', { printCallback: callback })
-  t.deepEqual(output, ['hello\n', 'world\n'])
+  t.is(output.join(''), 'hello\nworld\n')
+})
+
+test('batched into fewer callbacks than prints', async () => {
+  const { output, callback } = makePrintCollector()
+  await run('for i in range(500):\n    print(i)', { printCallback: callback })
+  t.is(output.join(''), Array.from({ length: 500 }, (_, i) => `${i}\n`).join(''))
+  t.true(output.length < 100, `expected far fewer callbacks than prints, got ${output.length}`)
+})
+
+test('a zero flush interval delivers one callback per line', async () => {
+  const { output, callback } = makePrintCollector()
+  await run('for i in range(20):\n    print(i)', { printCallback: callback, printFlushInterval: 0 })
+  t.deepEqual(
+    output,
+    Array.from({ length: 20 }, (_, i) => `${i}\n`),
+  )
 })
 
 test('with values', async () => {
@@ -55,7 +71,7 @@ test('with end', async () => {
   t.deepEqual(output, ['hello!'])
 })
 
-test('partial lines are buffered until a newline', async () => {
+test('a print with end="" joins the next print', async () => {
   const { output, callback } = makePrintCollector()
   await run('print("a", end="")\nprint("b")', { printCallback: callback })
   t.deepEqual(output, ['ab\n'])
@@ -92,7 +108,7 @@ for i in range(3):
 `
   const { output, callback } = makePrintCollector()
   await run(code, { printCallback: callback })
-  t.deepEqual(output, ['Count 0\n', 'Count 1\n', 'Count 2\n'])
+  t.is(output.join(''), 'Count 0\nCount 1\nCount 2\n')
 })
 
 test('print mixed types', async () => {
@@ -189,7 +205,9 @@ test('CollectString accumulates', async () => {
 
 test('CollectStreams accumulates with labels', async () => {
   const collector = new CollectStreams()
-  const result = await run('print("a"); print("b", 1); 123', { printCallback: collector })
+  // pinned to line buffering: entries follow chunk boundaries, and this test
+  // is about the labels on them, not about how the worker batched them
+  const result = await run('print("a"); print("b", 1); 123', { printCallback: collector, printFlushInterval: 0 })
   t.is(result, 123)
   t.deepEqual(collector.output, [
     { stream: 'stdout', text: 'a\n' },
@@ -225,9 +243,11 @@ test('CollectStreams maxBytes first write fails with overhead', async () => {
 
 test('CollectString partial success keeps prior buffer', async () => {
   // First print('a') → 'a\n' = 2 bytes; second print('x'*20) → 21 bytes; total 23 > 10.
+  // Line-buffered so the two writes reach the collector separately, which is
+  // what makes the first one's output survive the second one's failure.
   const collector = new CollectString(10)
   const thrown = await t.throwsAsync<MontyRuntimeError>(() =>
-    run("print('a'); print('x' * 20)", { printCallback: collector }),
+    run("print('a'); print('x' * 20)", { printCallback: collector, printFlushInterval: 0 }),
   )
   t.true(thrown instanceof MontyRuntimeError)
   t.is(thrown.exception.typeName, 'MemoryError')
@@ -237,9 +257,10 @@ test('CollectString partial success keeps prior buffer', async () => {
 
 test('CollectStreams partial success keeps prior entries', async () => {
   // First entry: 2 + 64 = 66; second: 21 + 64 = 85; total 151 > 100.
+  // Line-buffered for the same reason as the CollectString case above.
   const collector = new CollectStreams(100)
   const thrown = await t.throwsAsync<MontyRuntimeError>(() =>
-    run("print('a'); print('x' * 20)", { printCallback: collector }),
+    run("print('a'); print('x' * 20)", { printCallback: collector, printFlushInterval: 0 }),
   )
   t.true(thrown instanceof MontyRuntimeError)
   t.is(thrown.exception.typeName, 'MemoryError')

--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -52,6 +52,27 @@ test('a zero flush interval delivers one callback per line', async () => {
   )
 })
 
+test('a negative or non-finite flush interval is rejected', async () => {
+  // The wasm component encodes the interval as `val >>> 0`, which would wrap a
+  // negative into a ~50-day timer, so both backends reject it at checkout.
+  for (const bad of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    const thrown = await t.throwsAsync(() => run('print(1)', { printFlushInterval: bad }))
+    t.true(
+      thrown.message.startsWith('invalid printFlushInterval'),
+      `expected a named rejection for ${bad}, got ${thrown.message}`,
+    )
+  }
+})
+
+test('a sub-millisecond flush interval does not become line buffering', async () => {
+  // Zero is the line-buffering sentinel, so a positive interval must not round
+  // down into it: 100 prints would arrive as 100 callbacks if it had.
+  const { output, callback } = makePrintCollector()
+  await run('for i in range(100):\n    print(i)', { printCallback: callback, printFlushInterval: 0.0004 })
+  t.is(output.join(''), Array.from({ length: 100 }, (_, i) => `${i}\n`).join(''))
+  t.true(output.length < 100, `expected batching, got one callback per line (${output.length})`)
+})
+
 test('with values', async () => {
   const { output, callback } = makePrintCollector()
   await run('print("The answer is", 42)', { printCallback: callback })

--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -3,12 +3,22 @@ import { t } from './assertions.js'
 
 import { CollectString, CollectStreams, MontyRuntimeError } from '@pydantic/monty'
 import { setupPool } from './helpers.js'
+import { skipIfBrowser } from './env.js'
 
 const { run, pool } = setupPool()
 
 // =============================================================================
 // Print tests
 // =============================================================================
+
+/**
+ * Skips a test that pins `printFlushInterval: 0`. That is a subprocess-worker
+ * setting — the wasm worker's `configure` record has no such field and returns
+ * a whole turn's output at once, leaving no per-line chunks to assert on.
+ */
+function skipLineBuffered(ctx: { skip(): void }) {
+  skipIfBrowser(ctx)
+}
 
 // Collects printCallback invocations. The worker batches output, so a call
 // receives whatever was buffered — not one line and not one print(). Tests
@@ -43,7 +53,8 @@ test('batched into fewer callbacks than prints', async () => {
   t.true(output.length < 100, `expected far fewer callbacks than prints, got ${output.length}`)
 })
 
-test('a zero flush interval delivers one callback per line', async () => {
+test('a zero flush interval delivers one callback per line', async (ctx) => {
+  skipLineBuffered(ctx)
   const { output, callback } = makePrintCollector()
   await run('for i in range(20):\n    print(i)', { printCallback: callback, printFlushInterval: 0 })
   t.deepEqual(
@@ -203,7 +214,8 @@ test('CollectString accumulates', async () => {
   t.is(collector.output, 'a\nb 1\n')
 })
 
-test('CollectStreams accumulates with labels', async () => {
+test('CollectStreams accumulates with labels', async (ctx) => {
+  skipLineBuffered(ctx)
   const collector = new CollectStreams()
   // pinned to line buffering: entries follow chunk boundaries, and this test
   // is about the labels on them, not about how the worker batched them
@@ -241,7 +253,8 @@ test('CollectStreams maxBytes first write fails with overhead', async () => {
   t.deepEqual(collector.output, [])
 })
 
-test('CollectString partial success keeps prior buffer', async () => {
+test('CollectString partial success keeps prior buffer', async (ctx) => {
+  skipLineBuffered(ctx)
   // First print('a') → 'a\n' = 2 bytes; second print('x'*20) → 21 bytes; total 23 > 10.
   // Line-buffered so the two writes reach the collector separately, which is
   // what makes the first one's output survive the second one's failure.
@@ -255,7 +268,8 @@ test('CollectString partial success keeps prior buffer', async () => {
   t.is(collector.output, 'a\n')
 })
 
-test('CollectStreams partial success keeps prior entries', async () => {
+test('CollectStreams partial success keeps prior entries', async (ctx) => {
+  skipLineBuffered(ctx)
   // First entry: 2 + 64 = 66; second: 21 + 64 = 85; total 151 > 100.
   // Line-buffered for the same reason as the CollectString case above.
   const collector = new CollectStreams(100)

--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -3,22 +3,12 @@ import { t } from './assertions.js'
 
 import { CollectString, CollectStreams, MontyRuntimeError } from '@pydantic/monty'
 import { setupPool } from './helpers.js'
-import { skipIfBrowser } from './env.js'
 
 const { run, pool } = setupPool()
 
 // =============================================================================
 // Print tests
 // =============================================================================
-
-/**
- * Skips a test that pins `printFlushInterval: 0`. That is a subprocess-worker
- * setting — the wasm worker's `configure` record has no such field and returns
- * a whole turn's output at once, leaving no per-line chunks to assert on.
- */
-function skipLineBuffered(ctx: { skip(): void }) {
-  skipIfBrowser(ctx)
-}
 
 // Collects printCallback invocations. The worker batches output, so a call
 // receives whatever was buffered — not one line and not one print(). Tests
@@ -53,8 +43,7 @@ test('batched into fewer callbacks than prints', async () => {
   t.true(output.length < 100, `expected far fewer callbacks than prints, got ${output.length}`)
 })
 
-test('a zero flush interval delivers one callback per line', async (ctx) => {
-  skipLineBuffered(ctx)
+test('a zero flush interval delivers one callback per line', async () => {
   const { output, callback } = makePrintCollector()
   await run('for i in range(20):\n    print(i)', { printCallback: callback, printFlushInterval: 0 })
   t.deepEqual(
@@ -214,8 +203,7 @@ test('CollectString accumulates', async () => {
   t.is(collector.output, 'a\nb 1\n')
 })
 
-test('CollectStreams accumulates with labels', async (ctx) => {
-  skipLineBuffered(ctx)
+test('CollectStreams accumulates with labels', async () => {
   const collector = new CollectStreams()
   // pinned to line buffering: entries follow chunk boundaries, and this test
   // is about the labels on them, not about how the worker batched them
@@ -253,8 +241,7 @@ test('CollectStreams maxBytes first write fails with overhead', async () => {
   t.deepEqual(collector.output, [])
 })
 
-test('CollectString partial success keeps prior buffer', async (ctx) => {
-  skipLineBuffered(ctx)
+test('CollectString partial success keeps prior buffer', async () => {
   // First print('a') → 'a\n' = 2 bytes; second print('x'*20) → 21 bytes; total 23 > 10.
   // Line-buffered so the two writes reach the collector separately, which is
   // what makes the first one's output survive the second one's failure.
@@ -268,8 +255,7 @@ test('CollectString partial success keeps prior buffer', async (ctx) => {
   t.is(collector.output, 'a\n')
 })
 
-test('CollectStreams partial success keeps prior entries', async (ctx) => {
-  skipLineBuffered(ctx)
+test('CollectStreams partial success keeps prior entries', async () => {
   // First entry: 2 + 64 = 66; second: 21 + 64 = 85; total 151 > 100.
   // Line-buffered for the same reason as the CollectString case above.
   const collector = new CollectStreams(100)

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -132,6 +132,11 @@ pub struct NativeCheckoutOptions {
     /// operand reprs to `n` bytes. The TypeScript wrapper normalizes the
     /// public `boolean | number` option into this encoding.
     pub assert_message_annotations: Option<u32>,
+
+    /// How long the worker may hold buffered `print()` output before sending
+    /// it (ms). Absent: the worker's default. `0` restores line buffering,
+    /// delivering each completed line on its own.
+    pub print_flush_interval_ms: Option<f64>,
 }
 
 /// One mount entry for a feed, pre-validated by the TypeScript `MountDir`.
@@ -194,9 +199,18 @@ impl NativePool {
         let mut config = PoolConfig::subprocess(&options.binary_path);
         config.min_processes = options.min_processes as usize;
         config.max_processes = options.max_processes as usize;
-        config.checkout_timeout = options.checkout_timeout_ms.map(duration_from_ms).transpose()?;
-        config.request_timeout = options.request_timeout_ms.map(duration_from_ms).transpose()?;
-        config.duration_limit_grace = options.duration_limit_grace_ms.map(duration_from_ms).transpose()?;
+        config.checkout_timeout = options
+            .checkout_timeout_ms
+            .map(|ms| duration_from_ms("checkoutTimeout", ms))
+            .transpose()?;
+        config.request_timeout = options
+            .request_timeout_ms
+            .map(|ms| duration_from_ms("requestTimeout", ms))
+            .transpose()?;
+        config.duration_limit_grace = options
+            .duration_limit_grace_ms
+            .map(|ms| duration_from_ms("durationLimitGrace", ms))
+            .transpose()?;
         config.max_checkouts_per_worker = options.max_checkouts_per_worker;
         config.metrics = configured_adapter().map(TelemetryAdapterHandle::metrics);
         if config.max_processes < 1 {
@@ -245,6 +259,10 @@ impl NativePool {
                     AssertMessageAnnotations::default,
                     AssertMessageAnnotations::from_max_bytes,
                 ),
+                print_flush_interval: options
+                    .print_flush_interval_ms
+                    .map(|ms| duration_from_ms("printFlushInterval", ms))
+                    .transpose()?,
             },
             checkout: Arc::new(AsyncMutex::new(None)),
         })
@@ -1065,9 +1083,10 @@ fn bytes_limit(limit: f64, name: &str) -> Result<u64> {
     }
 }
 
-/// Converts a millisecond count from JS into a `Duration`.
-fn duration_from_ms(ms: f64) -> Result<Duration> {
-    Duration::try_from_secs_f64(ms / 1000.0).map_err(|err| invalid(&format!("invalid timeout: {err}")))
+/// Converts a millisecond count from JS into a `Duration`, naming the option
+/// in the error so a rejected value says which one it was.
+fn duration_from_ms(name: &str, ms: f64) -> Result<Duration> {
+    Duration::try_from_secs_f64(ms / 1000.0).map_err(|err| invalid(&format!("invalid {name}: {err}")))
 }
 
 /// Locks the shared *pool* slot, ignoring poisoning (a panic elsewhere must

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -76,6 +76,15 @@ export interface CheckoutOptions {
    * per-operand repr truncation length (default 120 bytes).
    */
   assertMessageAnnotations?: AssertMessageAnnotations
+  /**
+   * How long, in seconds, the worker may hold buffered `print()` output before
+   * sending it, so a burst of prints costs one `printCallback` call rather
+   * than one each (default 0.005). `0` restores line buffering, delivering
+   * each completed line on its own. Output is always flushed before a host
+   * call and before a feed ends, so this only sets how far live output may
+   * lag — never what arrives, or in what order.
+   */
+  printFlushInterval?: number
 }
 
 /**
@@ -147,6 +156,7 @@ export class Monty {
       ...(options.typeCheckFormat !== undefined ? { typeCheckFormat: options.typeCheckFormat } : {}),
       ...(options.typeCheckColor !== undefined ? { typeCheckColor: options.typeCheckColor } : {}),
       ...(assertAnnotations !== undefined ? { assertMessageAnnotations: assertAnnotations } : {}),
+      ...(options.printFlushInterval !== undefined ? { printFlushIntervalMs: options.printFlushInterval * 1000 } : {}),
     })
     const telemetryContext = captureTelemetryContext()
     await native.enter(telemetryContext)

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -51,7 +51,7 @@ export type ExternalFunction = (...args: never[]) => unknown
  */
 export type OsCallback = (name: string, args: unknown[], kwargs: Record<string, unknown>) => unknown
 
-/** Receives sandbox `print()` output (line-buffered). */
+/** Receives sandbox `print()` output in batched chunks. */
 export type PrintCallback = (stream: 'stdout' | 'stderr', text: string) => void
 
 /**

--- a/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
+++ b/crates/monty-js/ts/worker/component/interfaces/pydantic-monty-worker.d.ts
@@ -288,6 +288,7 @@ export interface ConfigureRequest {
   assertMessageAnnotations?: number
   typeCheckFormat: TypeCheckFormat
   typeCheckColor: boolean
+  printFlushIntervalMs?: number
 }
 export interface FeedRequest {
   code: string

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -50,6 +50,14 @@ export interface WorkerSessionConfig {
    * child's default, false disables them, and an integer customizes truncation.
    */
   assertMessageAnnotations?: AssertMessageAnnotations
+  /**
+   * How long, in seconds, the worker may hold buffered `print()` output before
+   * sending it (default 0.005). `0` restores line buffering, delivering each
+   * completed line on its own. A turn's frames all reach the host together
+   * here, but this still sets how they are split: one `printCallback` call per
+   * frame, and a print collector charges its `maxBytes` cap per frame.
+   */
+  printFlushInterval?: number
 }
 
 /** A session-shaped adapter over one semantic component dispatcher. */
@@ -87,6 +95,10 @@ export class WorkerTransport {
           ...(assertMessageAnnotations === undefined ? {} : { assertMessageAnnotations }),
           typeCheckFormat: componentTypeCheckFormat(config.typeCheckFormat ?? 'full'),
           typeCheckColor: config.typeCheckColor ?? false,
+          ...(config.printFlushInterval === undefined
+            ? {}
+            : // truncated, matching the subprocess path's `Duration::as_millis`
+              { printFlushIntervalMs: Math.floor(config.printFlushInterval * 1000) }),
         },
       },
       'ok',

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -26,6 +26,22 @@ import { decodeValue, encodeValue } from './value.js'
 
 type OnPrint = (stream: 'stdout' | 'stderr', text: string) => void
 
+/**
+ * Encodes a print flush interval (seconds) as whole milliseconds for the WIT
+ * `u32`, mirroring `monty-pool`'s `flush_interval_ms`.
+ *
+ * The component encodes a `u32` as `val >>> 0`, which would silently wrap a
+ * negative or non-finite value into a huge interval, so reject those here.
+ * Zero is the line-buffering sentinel, so a positive interval never rounds
+ * down into it.
+ */
+function flushIntervalMs(interval: number): number {
+  if (!Number.isFinite(interval) || interval < 0) {
+    throw new TypeError(`invalid printFlushInterval: expected a non-negative number of seconds, got ${interval}`)
+  }
+  return interval === 0 ? 0 : Math.min(Math.max(Math.floor(interval * 1000), 1), 0xffffffff)
+}
+
 /** Resource limits mirrored from the napi pool; the transport enforces `maxSuspensions`. */
 export interface ResourceLimits {
   maxDurationSecs?: number
@@ -97,8 +113,7 @@ export class WorkerTransport {
           typeCheckColor: config.typeCheckColor ?? false,
           ...(config.printFlushInterval === undefined
             ? {}
-            : // truncated, matching the subprocess path's `Duration::as_millis`
-              { printFlushIntervalMs: Math.floor(config.printFlushInterval * 1000) }),
+            : { printFlushIntervalMs: flushIntervalMs(config.printFlushInterval) }),
         },
       },
       'ok',

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -65,8 +65,10 @@ async fn main() -> Result<(), PoolError> {
 }
 ```
 
-`ReplConfig` also enables per-session sandbox `ResourceLimits` and type checking of every fed
-snippet; `Checkout::feed` accepts inputs (host values exposed as sandbox globals) and
+`ReplConfig` also enables per-session sandbox `ResourceLimits`, type checking of every fed
+snippet, and `print_flush_interval` — how long the worker may batch `print()` output before
+sending it, so a burst of prints costs one event rather than one each (`Duration::ZERO`
+restores line buffering, one event per completed line); `Checkout::feed` accepts inputs (host values exposed as sandbox globals) and
 per-feed filesystem mounts (`MountSpec`). Sessions can be snapshotted with `Checkout::dump`
 and restored later — including on a different worker or machine — with `Checkout::restore`.
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -50,6 +50,16 @@ pub struct ReplConfig {
     /// (see `limitations/assert.md`). On by default with a 120-byte
     /// operand-repr truncation; `MaxBytes` customizes the truncation.
     pub assert_message_annotations: AssertMessageAnnotations,
+    /// How long the worker may hold buffered `print()` output before sending
+    /// it, batching a burst of prints into one `Print` event instead of one
+    /// each. `None` takes the worker's default
+    /// ([`crate::DEFAULT_PRINT_FLUSH_INTERVAL`]); `Duration::ZERO` restores line
+    /// buffering, delivering each completed line on its own.
+    ///
+    /// Output is always flushed before a suspension or a turn ends, so this
+    /// only sets how long live output may lag — never what arrives, or in
+    /// what order. Sub-millisecond values round down to zero on the wire.
+    pub print_flush_interval: Option<Duration>,
 }
 
 impl Default for ReplConfig {
@@ -61,6 +71,7 @@ impl Default for ReplConfig {
             type_check_stubs: None,
             type_check_config: TypeCheckingConfig::default(),
             assert_message_annotations: AssertMessageAnnotations::default(),
+            print_flush_interval: None,
         }
     }
 }
@@ -449,6 +460,11 @@ impl Checkout {
             protocol_version: PROTOCOL_VERSION,
             // Diagnostic only, so a rejection can report both builds.
             monty_version: MONTY_VERSION.to_owned(),
+            // Saturating: an interval past `u32::MAX` milliseconds is absurd
+            // rather than meaningful, and the turn-end flush bounds it anyway.
+            print_flush_interval_ms: repl
+                .print_flush_interval
+                .map(|interval| u32::try_from(interval.as_millis()).unwrap_or(u32::MAX)),
         }));
         let mut this = Self {
             worker: Some(worker),

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -58,7 +58,9 @@ pub struct ReplConfig {
     ///
     /// Output is always flushed before a suspension or a turn ends, so this
     /// only sets how long live output may lag — never what arrives, or in
-    /// what order. Sub-millisecond values round down to zero on the wire.
+    /// what order. The wire carries whole milliseconds, so a positive interval
+    /// below 1 ms is sent as 1 ms rather than rounding down into the
+    /// line-buffering sentinel.
     pub print_flush_interval: Option<Duration>,
 }
 
@@ -460,11 +462,7 @@ impl Checkout {
             protocol_version: PROTOCOL_VERSION,
             // Diagnostic only, so a rejection can report both builds.
             monty_version: MONTY_VERSION.to_owned(),
-            // Saturating: an interval past `u32::MAX` milliseconds is absurd
-            // rather than meaningful, and the turn-end flush bounds it anyway.
-            print_flush_interval_ms: repl
-                .print_flush_interval
-                .map(|interval| u32::try_from(interval.as_millis()).unwrap_or(u32::MAX)),
+            print_flush_interval_ms: repl.print_flush_interval.map(flush_interval_ms),
         }));
         let mut this = Self {
             worker: Some(worker),
@@ -1547,6 +1545,20 @@ impl Drop for Checkout {
         }
         #[cfg(feature = "telemetry")]
         self.record_finish("abandoned");
+    }
+}
+
+/// Encodes a print flush interval as whole milliseconds for the wire.
+///
+/// Zero is the explicit line-buffering sentinel, so a *positive* interval must
+/// never round down into it — anything under a millisecond is sent as 1 ms.
+/// Saturates at the top: an interval past `u32::MAX` milliseconds is absurd
+/// rather than meaningful, and the turn-end flush bounds it anyway.
+fn flush_interval_ms(interval: Duration) -> u32 {
+    if interval.is_zero() {
+        0
+    } else {
+        u32::try_from(interval.as_millis()).unwrap_or(u32::MAX).max(1)
     }
 }
 

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -11,7 +11,7 @@ mod worker;
 
 use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
 
-pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
+pub use monty_proto::{DEFAULT_PRINT_FLUSH_INTERVAL, MAX_VALUE_DEPTH, exceeds_max_value_depth};
 use monty_types::MontyException;
 
 #[cfg(feature = "telemetry")]

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1070,6 +1070,32 @@ async fn zero_flush_interval_delivers_one_event_per_line() {
     session.finish().await.unwrap();
 }
 
+/// With the timer off the contract is one event per *completed line*, not one
+/// per write: a single `print()` carrying embedded newlines must still arrive
+/// as one event per line.
+#[tokio::test]
+async fn zero_flush_interval_splits_embedded_newlines() {
+    let pool = Pool::new(config()).await.unwrap();
+    let repl = ReplConfig {
+        print_flush_interval: Some(Duration::ZERO),
+        ..ReplConfig::default()
+    };
+    let mut session = pool.checkout(&repl).await.unwrap();
+    let mut events = Vec::new();
+    session
+        .feed(
+            r#"print("a\nb")"#,
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| events.push(text.to_owned())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(events, vec!["a\n".to_owned(), "b\n".to_owned()]);
+    session.finish().await.unwrap();
+}
+
 /// Output must not sit in the worker's buffer while the program computes in
 /// silence: the interpreter polls the writer at its dispatch checkpoints, so a
 /// line printed before a long stretch of quiet work is released on its own

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -2105,6 +2105,33 @@ async fn dump_survives_worker_death_and_loads_elsewhere() {
     restored.finish().await.unwrap();
 }
 
+/// Zero is the explicit line-buffering sentinel, so a positive interval must
+/// never round down into it. 100 prints would arrive as 100 events if the
+/// sub-millisecond interval had truncated to zero; any batching at all proves
+/// the timer is still on.
+#[tokio::test]
+async fn a_sub_millisecond_interval_does_not_become_line_buffering() {
+    let pool = Pool::new(config()).await.unwrap();
+    let repl = ReplConfig {
+        print_flush_interval: Some(Duration::from_micros(400)),
+        ..ReplConfig::default()
+    };
+    let mut session = pool.checkout(&repl).await.unwrap();
+    let mut events = 0usize;
+    session
+        .feed(
+            "for i in range(100):\n    print(i)",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, _: &str| events += 1),
+        )
+        .await
+        .unwrap();
+    assert!(events < 100, "expected batching, got one event per line ({events})");
+    session.finish().await.unwrap();
+}
+
 /// A `Load` restores the repl without materializing the checkout's stored
 /// `Configure`, so the print flush interval has to be adopted when that config
 /// arrives — otherwise a restored session silently falls back to the default

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -7,7 +7,9 @@ use std::os::unix::fs::{PermissionsExt, symlink};
 #[cfg(windows)]
 use std::os::windows::fs::symlink_dir;
 use std::{
-    env, fs,
+    env,
+    fmt::Write as _,
+    fs,
     future::ready,
     io,
     path::{Path, PathBuf},
@@ -964,6 +966,162 @@ async fn inputs_and_prints() {
         .unwrap();
     assert_eq!(expect_complete(event), MontyObject::Int(5));
     assert_eq!(output, "hello monty\n");
+    session.finish().await.unwrap();
+}
+
+/// A loop of small prints must not cost one `Print` event each: the worker
+/// batches them by size and elapsed time, which is what keeps the parent's
+/// per-event work (telemetry included) proportional to output rather than to
+/// how often the sandbox called `print()`.
+#[tokio::test]
+async fn prints_are_batched_into_few_events() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+    let mut output = String::new();
+    let mut events = 0;
+    let event = session
+        .feed(
+            "for i in range(2000):\n    print(i)",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| {
+                events += 1;
+                output.push_str(text);
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::None);
+    let mut expected = String::new();
+    for i in 0..2000 {
+        writeln!(expected, "{i}").unwrap();
+    }
+    assert_eq!(output, expected);
+    assert!(
+        events < 200,
+        "expected far fewer than one event per print, got {events}"
+    );
+    session.finish().await.unwrap();
+}
+
+/// The size threshold still bounds a chunk when the interval never expires:
+/// one huge write is split into ~8 KiB events rather than buffered whole. This
+/// is also what keeps the buffer below the threshold on entry to each write, so
+/// its remaining-room arithmetic cannot underflow.
+#[tokio::test]
+async fn one_huge_write_is_split_at_the_size_threshold() {
+    const FLUSH_BYTES: usize = 8 * 1024;
+    let pool = Pool::new(config()).await.unwrap();
+    // an interval nothing will reach, so only the size threshold can flush
+    let repl = ReplConfig {
+        print_flush_interval: Some(Duration::from_secs(600)),
+        ..ReplConfig::default()
+    };
+    let mut session = pool.checkout(&repl).await.unwrap();
+    let mut chunks: Vec<usize> = Vec::new();
+    let mut total = 0;
+    session
+        .feed(
+            "print('x' * 100_000, end='')",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| {
+                chunks.push(text.len());
+                total += text.len();
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(total, 100_000);
+    assert!(chunks.len() > 1, "expected the write to be split, got {chunks:?}");
+    assert!(
+        chunks.iter().all(|len| *len <= FLUSH_BYTES),
+        "every chunk must stay within the threshold, got {chunks:?}"
+    );
+    session.finish().await.unwrap();
+}
+
+/// A zero interval turns the timer off and restores line buffering, for a host
+/// that wants each completed line delivered on its own.
+#[tokio::test]
+async fn zero_flush_interval_delivers_one_event_per_line() {
+    let pool = Pool::new(config()).await.unwrap();
+    let repl = ReplConfig {
+        print_flush_interval: Some(Duration::ZERO),
+        ..ReplConfig::default()
+    };
+    let mut session = pool.checkout(&repl).await.unwrap();
+    let mut lines = Vec::new();
+    session
+        .feed(
+            "for i in range(20):\n    print(i)",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| lines.push(text.to_owned())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(lines.len(), 20);
+    assert_eq!(lines[0], "0\n");
+    assert_eq!(lines[19], "19\n");
+    session.finish().await.unwrap();
+}
+
+/// Output must not sit in the worker's buffer while the program computes in
+/// silence: the interpreter polls the writer at its dispatch checkpoints, so a
+/// line printed before a long stretch of quiet work is released on its own
+/// rather than waiting for the next print.
+#[tokio::test]
+async fn silence_releases_buffered_output() {
+    let pool = Pool::new(config()).await.unwrap();
+    let repl = ReplConfig {
+        print_flush_interval: Some(Duration::from_millis(1)),
+        ..ReplConfig::default()
+    };
+    let mut session = pool.checkout(&repl).await.unwrap();
+    let mut events: Vec<String> = Vec::new();
+    session
+        .feed(
+            // the loop is far longer than the 1ms interval in any build
+            "print('first')\nt = 0\nfor i in range(200_000):\n    t += i\nprint('second')",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| events.push(text.to_owned())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(events.first().map(String::as_str), Some("first\n"));
+    assert_eq!(events.concat(), "first\nsecond\n");
+    session.finish().await.unwrap();
+}
+
+/// Batching must never reorder output against the suspension that follows it:
+/// the worker drains its buffer before every turn-ending event, so a print
+/// made just before a host call still arrives before the call is announced.
+#[tokio::test]
+async fn buffered_output_is_flushed_before_a_suspension() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+    let mut output = String::new();
+    let event = session
+        .feed(
+            "print('before')\nask()",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| output.push_str(text)),
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(event, TurnEvent::FunctionCall { ref function_name, .. } if function_name == "ask"),
+        "expected a call suspension, got {event:?}"
+    );
+    assert_eq!(output, "before\n");
     session.finish().await.unwrap();
 }
 

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -2105,6 +2105,44 @@ async fn dump_survives_worker_death_and_loads_elsewhere() {
     restored.finish().await.unwrap();
 }
 
+/// A `Load` restores the repl without materializing the checkout's stored
+/// `Configure`, so the print flush interval has to be adopted when that config
+/// arrives — otherwise a restored session silently falls back to the default
+/// and ignores the line buffering its host asked for.
+#[tokio::test]
+async fn a_restored_session_honors_its_checkout_flush_interval() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+    session
+        .feed("base = 1", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap();
+    let state = session.dump().await.unwrap();
+    drop(session);
+
+    let repl = ReplConfig {
+        print_flush_interval: Some(Duration::ZERO),
+        ..ReplConfig::default()
+    };
+    let mut restored = pool.checkout(&repl).await.unwrap();
+    restored.restore(state, vec![], &mut no_print).await.unwrap();
+    let mut lines = Vec::new();
+    restored
+        .feed(
+            "for i in range(20):\n    print(base + i)",
+            vec![],
+            vec![],
+            false,
+            &mut on_print_sync(|_, text: &str| lines.push(text.to_owned())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(lines.len(), 20);
+    assert_eq!(lines[0], "1\n");
+    assert_eq!(lines[19], "20\n");
+    restored.finish().await.unwrap();
+}
+
 // =============================================================================
 // Environment isolation
 // =============================================================================

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -464,6 +464,15 @@ message Configure {
   // is not a monty parent — and is always rejected. The protocol has no
   // in-band negotiation, so an undeclared peer cannot be assumed compatible.
   uint32 protocol_version = 9;
+  // How long the child may hold buffered `print()` output before emitting it
+  // as a `Print` event, in milliseconds. Absent means the child's default
+  // (`DEFAULT_PRINT_FLUSH_INTERVAL`). 0 disables the timer and restores line
+  // buffering — one event per completed line, as before this field existed —
+  // for a host that wants each `print()` delivered on its own.
+  //
+  // Output is always flushed before a turn-ending event whatever this says, so
+  // the field trades streaming latency for event volume and nothing else.
+  optional uint32 print_flush_interval_ms = 10;
 }
 
 // Rendering of the typing diagnostics a `TypingError` carries; mirrors ty's

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -491,6 +491,16 @@ pub struct Configure {
     /// in-band negotiation, so an undeclared peer cannot be assumed compatible.
     #[prost(uint32, tag = "9")]
     pub protocol_version: u32,
+    /// How long the child may hold buffered `print()` output before emitting it
+    /// as a `Print` event, in milliseconds. Absent means the child's default
+    /// (`DEFAULT_PRINT_FLUSH_INTERVAL`). 0 disables the timer and restores line
+    /// buffering — one event per completed line, as before this field existed —
+    /// for a host that wants each `print()` delivered on its own.
+    ///
+    /// Output is always flushed before a turn-ending event whatever this says, so
+    /// the field trades streaming latency for event volume and nothing else.
+    #[prost(uint32, optional, tag = "10")]
+    pub print_flush_interval_ms: ::core::option::Option<u32>,
 }
 /// Executes one snippet against the session. Turn ends with `Complete`,
 /// `Error`, `TypingError`, or a suspension event.

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::ops::RangeInclusive;
+use std::{ops::RangeInclusive, time::Duration};
 
 mod convert;
 mod frame;
@@ -25,6 +25,14 @@ pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Oldest [`PROTOCOL_VERSION`] this build still serves.
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 2;
+
+/// How long the child holds buffered `print()` output before emitting it as a
+/// `Print` event, when [`pb::Configure::print_flush_interval_ms`] says nothing.
+///
+/// Short enough to read as live output, long enough that a printing loop emits
+/// events at a rate set by elapsed time rather than by how often the program
+/// called `print()`.
+pub const DEFAULT_PRINT_FLUSH_INTERVAL: Duration = Duration::from_millis(5);
 
 // The supported range must be non-empty, and must exclude zero
 const _: () = assert!(MIN_SUPPORTED_PROTOCOL_VERSION >= 1);

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -1112,9 +1112,31 @@ impl<'a> ProtoPrint<'a> {
             return Ok(());
         }
         self.buffered_since = None;
+        let text = mem::take(&mut self.buf);
+        self.send(text)
+    }
+
+    /// Emits one `Print` event per completed line, leaving any trailing
+    /// partial line buffered. With the timer off the contract is one event per
+    /// completed line, so a single write carrying embedded newlines has to be
+    /// split rather than shipped whole.
+    fn flush_lines(&mut self) -> Result<(), MontyException> {
+        while let Some(end) = self.buf.find('\n') {
+            let rest = self.buf.split_off(end + 1);
+            let line = mem::replace(&mut self.buf, rest);
+            self.send(line)?;
+        }
+        if self.buf.is_empty() {
+            self.buffered_since = None;
+        }
+        Ok(())
+    }
+
+    /// Sends `text` as one `Print` event.
+    fn send(&mut self, text: String) -> Result<(), MontyException> {
         let event = event(pb::child_event::Kind::Print(pb::Print {
             stream: pb::PrintStream::Stdout.into(),
-            text: mem::take(&mut self.buf),
+            text,
         }));
         self.sink.send(&event).map_err(|err| {
             MontyException::new(
@@ -1124,20 +1146,19 @@ impl<'a> ProtoPrint<'a> {
         })
     }
 
+    /// Flushes whatever the buffer has earned: complete lines when the timer
+    /// is off, then a frame if it has filled or its oldest byte has waited out
+    /// `interval`.
     fn maybe_flush(&mut self) -> Result<(), MontyException> {
-        if self.flush_due() { self.flush() } else { Ok(()) }
-    }
-
-    /// Whether the buffer has earned a frame: it has filled, or its oldest
-    /// byte has waited out `interval` — or, with the timer off, it holds a
-    /// complete line.
-    fn flush_due(&self) -> bool {
-        if self.buf.len() >= Self::FLUSH_BYTES {
-            true
-        } else if self.interval.is_zero() {
-            self.buf.ends_with('\n')
+        // Lines leave first so the size threshold below cannot merge a
+        // multi-line write back into one frame.
+        if self.interval.is_zero() {
+            self.flush_lines()?;
+        }
+        if self.buf.len() >= Self::FLUSH_BYTES || (!self.interval.is_zero() && self.interval_elapsed()) {
+            self.flush()
         } else {
-            self.interval_elapsed()
+            Ok(())
         }
     }
 

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -429,6 +429,14 @@ impl Child {
     /// not-yet-configured worker.
     fn handle_configure(&mut self, configure: pb::Configure) -> pb::ChildEvent {
         if matches!(self.state, SessionState::Configured(None)) {
+            // Applied on arrival rather than in `ensure_repl`, which a `Load`
+            // never reaches: a dump restores the repl directly, and print
+            // pacing is a delivery setting the dump does not carry.
+            // Absent means an older parent, or one with no opinion; both get
+            // the default rather than the line buffering that predates it.
+            self.print_flush_interval = configure
+                .print_flush_interval_ms
+                .map_or(DEFAULT_PRINT_FLUSH_INTERVAL, |ms| Duration::from_millis(u64::from(ms)));
             self.state = SessionState::Configured(Some(Box::new(configure)));
             ok_event()
         } else {
@@ -466,14 +474,11 @@ impl Child {
             protocol_version: _,
             // informational only — never checked
             monty_version: _,
-            print_flush_interval_ms,
+            // applied when the `Configure` arrived, so a `Load` honors it too
+            print_flush_interval_ms: _,
         } = *config;
         let limits = limits.unwrap_or_default().into();
         self.script_name = script_name;
-        // Absent means an older parent, or one with no opinion; both get the
-        // default rather than the line buffering that predates the field.
-        self.print_flush_interval =
-            print_flush_interval_ms.map_or(DEFAULT_PRINT_FLUSH_INTERVAL, |ms| Duration::from_millis(u64::from(ms)));
         self.type_check = type_check.then(|| TypeCheckState {
             committed_stubs: type_check_stubs.unwrap_or_default(),
             pending_snippet: None,

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -16,7 +16,11 @@
 //! the host transport surfaces that; it only ensures every *graceful* turn ends
 //! with exactly one turn-ending event.
 
-use std::{borrow::Cow, mem};
+use std::{
+    borrow::Cow,
+    mem,
+    time::{Duration, Instant},
+};
 
 use monty::{Dump, MontyRepl, ReplProgress, ReplStartError, Session, SessionRef, dump};
 use monty_type_checking::{SourceFile, TypeChecker};
@@ -26,8 +30,8 @@ use monty_types::{
 };
 
 use super::{
-    FrameError, FrameReader, MAX_FRAME_LEN, ProtoConvertError, WireFunctionCall, check_protocol_version,
-    exceeds_max_frame_len, exceeds_max_value_depth, future_results_from_proto, pb, write_frame,
+    DEFAULT_PRINT_FLUSH_INTERVAL, FrameError, FrameReader, MAX_FRAME_LEN, ProtoConvertError, WireFunctionCall,
+    check_protocol_version, exceeds_max_frame_len, exceeds_max_value_depth, future_results_from_proto, pb, write_frame,
 };
 use crate::wire::uuid_to_pb;
 
@@ -199,6 +203,10 @@ pub struct Child {
     type_checker: TypeChecker,
     /// `Some` when the session was created with `type_check: true`.
     type_check: Option<TypeCheckState>,
+    /// How long [`ProtoPrint`] may hold buffered output, from the session's
+    /// `Configure`. `Duration::ZERO` means line buffering (see the field's
+    /// documentation in the schema).
+    print_flush_interval: Duration,
 }
 
 impl Default for Child {
@@ -208,6 +216,7 @@ impl Default for Child {
             script_name: String::new(),
             type_checker: TypeChecker::default(),
             type_check: None,
+            print_flush_interval: DEFAULT_PRINT_FLUSH_INTERVAL,
         }
     }
 }
@@ -457,9 +466,14 @@ impl Child {
             protocol_version: _,
             // informational only — never checked
             monty_version: _,
+            print_flush_interval_ms,
         } = *config;
         let limits = limits.unwrap_or_default().into();
         self.script_name = script_name;
+        // Absent means an older parent, or one with no opinion; both get the
+        // default rather than the line buffering that predates the field.
+        self.print_flush_interval =
+            print_flush_interval_ms.map_or(DEFAULT_PRINT_FLUSH_INTERVAL, |ms| Duration::from_millis(u64::from(ms)));
         self.type_check = type_check.then(|| TypeCheckState {
             committed_stubs: type_check_stubs.unwrap_or_default(),
             pending_snippet: None,
@@ -510,7 +524,7 @@ impl Child {
         {
             state.pending_snippet = Some(feed.code.clone());
         }
-        let mut print = ProtoPrint::new(sink);
+        let mut print = ProtoPrint::new(sink, self.print_flush_interval);
         let result = repl.feed_start(&feed.code, inputs, PrintWriter::Callback(&mut print));
         let event = self.drive(result, &mut print);
         print.drain();
@@ -561,7 +575,7 @@ impl Child {
         let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
             unreachable!("checked above");
         };
-        let mut print = ProtoPrint::new(sink);
+        let mut print = ProtoPrint::new(sink, self.print_flush_interval);
         let outcome = match *progress {
             ReplProgress::FunctionCall(call) => call.resume(result, PrintWriter::Callback(&mut print)),
             ReplProgress::OsCall(call) => call.resume(result, PrintWriter::Callback(&mut print)),
@@ -591,7 +605,7 @@ impl Child {
         let ReplProgress::NameLookup(lookup) = *progress else {
             unreachable!("checked above");
         };
-        let mut print = ProtoPrint::new(sink);
+        let mut print = ProtoPrint::new(sink, self.print_flush_interval);
         let outcome = lookup.resume(result, PrintWriter::Callback(&mut print));
         let event = self.drive(outcome, &mut print);
         print.drain();
@@ -617,7 +631,7 @@ impl Child {
         let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
             unreachable!("checked above");
         };
-        let mut print = ProtoPrint::new(sink);
+        let mut print = ProtoPrint::new(sink, self.print_flush_interval);
         let outcome = match *progress {
             ReplProgress::FunctionCall(call) => call.abort(exc, PrintWriter::Callback(&mut print)),
             ReplProgress::OsCall(call) => call.abort(exc, PrintWriter::Callback(&mut print)),
@@ -649,7 +663,7 @@ impl Child {
         let ReplProgress::ResolveFutures(state) = *progress else {
             unreachable!("checked above");
         };
-        let mut print = ProtoPrint::new(sink);
+        let mut print = ProtoPrint::new(sink, self.print_flush_interval);
         let outcome = state.resume(results, PrintWriter::Callback(&mut print));
         let event = self.drive(outcome, &mut print);
         print.drain();
@@ -866,6 +880,7 @@ impl Child {
         self.state = SessionState::Configured(None);
         self.type_check = None;
         self.script_name = String::new();
+        self.print_flush_interval = DEFAULT_PRINT_FLUSH_INTERVAL;
         self.type_checker.reset()
     }
 }
@@ -1054,22 +1069,35 @@ fn named_inputs(inputs: Vec<pb::NamedValue>) -> Result<Vec<(String, MontyObject)
 /// Streams sandbox `print()` output as `Print` events through an
 /// [`EventSink`].
 ///
-/// Line-buffered: a frame is written when the buffer ends with a newline or
-/// exceeds [`Self::FLUSH_BYTES`], and [`Self::drain`] flushes any partial
-/// line before the turn-ending event so ordering is exact.
+/// Debounced: a frame is written once the buffer reaches
+/// [`Self::FLUSH_BYTES`] or its oldest byte has waited out `interval`, so the
+/// number of events a turn produces follows elapsed time and output volume
+/// rather than how many times the program called `print()` — which is what
+/// makes a loop of tiny prints cost the parent (and its telemetry) roughly
+/// what one large print costs. [`Self::drain`] empties the buffer before every
+/// turn-ending event, so ordering against suspensions stays exact.
+///
+/// A zero `interval` disables the timer and restores line buffering, one event
+/// per completed line.
 struct ProtoPrint<'a> {
     buf: String,
     sink: &'a mut dyn EventSink,
+    /// How long the oldest buffered byte may wait; zero means line buffering.
+    interval: Duration,
+    /// When the buffer stopped being empty; `None` while it is empty.
+    buffered_since: Option<Instant>,
 }
 
 impl<'a> ProtoPrint<'a> {
-    /// Flush threshold for output that never produces a newline.
+    /// Flush threshold for output that never reaches the interval.
     const FLUSH_BYTES: usize = 8 * 1024;
 
-    fn new(sink: &'a mut dyn EventSink) -> Self {
+    fn new(sink: &'a mut dyn EventSink, interval: Duration) -> Self {
         Self {
             buf: String::new(),
             sink,
+            interval,
+            buffered_since: None,
         }
     }
 
@@ -1078,6 +1106,7 @@ impl<'a> ProtoPrint<'a> {
         if self.buf.is_empty() {
             return Ok(());
         }
+        self.buffered_since = None;
         let event = event(pb::child_event::Kind::Print(pb::Print {
             stream: pb::PrintStream::Stdout.into(),
             text: mem::take(&mut self.buf),
@@ -1091,16 +1120,39 @@ impl<'a> ProtoPrint<'a> {
     }
 
     fn maybe_flush(&mut self) -> Result<(), MontyException> {
-        if self.buf.ends_with('\n') || self.buf.len() >= Self::FLUSH_BYTES {
-            self.flush()
+        if self.flush_due() { self.flush() } else { Ok(()) }
+    }
+
+    /// Whether the buffer has earned a frame: it has filled, or its oldest
+    /// byte has waited out `interval` — or, with the timer off, it holds a
+    /// complete line.
+    fn flush_due(&self) -> bool {
+        if self.buf.len() >= Self::FLUSH_BYTES {
+            true
+        } else if self.interval.is_zero() {
+            self.buf.ends_with('\n')
         } else {
-            Ok(())
+            self.interval_elapsed()
         }
     }
 
-    /// Flushes any trailing partial line; called before every turn-ending
-    /// event. Errors are ignored — if the sink is broken the turn-ending write
-    /// fails anyway.
+    /// Whether buffered output has waited out `interval`. False when the
+    /// buffer is empty, so an idle writer never reads the clock twice.
+    fn interval_elapsed(&self) -> bool {
+        self.buffered_since
+            .is_some_and(|since| since.elapsed() >= self.interval)
+    }
+
+    /// Starts the interval clock when the buffer leaves the empty state.
+    fn mark_buffered(&mut self) {
+        if self.buffered_since.is_none() {
+            self.buffered_since = Some(Instant::now());
+        }
+    }
+
+    /// Flushes whatever is buffered; called before every turn-ending event.
+    /// Errors are ignored — if the sink is broken the turn-ending write fails
+    /// anyway.
     fn drain(&mut self) {
         let _ = self.flush();
     }
@@ -1121,6 +1173,7 @@ impl PrintWriterCallback for ProtoPrint<'_> {
                 self.flush()?;
                 continue;
             }
+            self.mark_buffered();
             self.buf.push_str(&rest[..take]);
             rest = &rest[take..];
             self.maybe_flush()?;
@@ -1129,8 +1182,21 @@ impl PrintWriterCallback for ProtoPrint<'_> {
     }
 
     fn stdout_push(&mut self, end: char) -> Result<(), MontyException> {
+        self.mark_buffered();
         self.buf.push(end);
         self.maybe_flush()
+    }
+
+    /// Releases output the program stopped writing to: without this a script
+    /// that prints and then computes in silence would hold that line until its
+    /// next print or the end of the turn. A zero `interval` has no timer to
+    /// expire, so line buffering is left to decide flushes on its own.
+    fn poll_flush(&mut self) -> Result<(), MontyException> {
+        if !self.interval.is_zero() && self.interval_elapsed() {
+            self.flush()
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -589,6 +589,16 @@ pub struct Configure {
     /// in-band negotiation, so an undeclared peer cannot be assumed compatible.
     #[prost(uint32, tag = "9")]
     pub protocol_version: u32,
+    /// How long the child may hold buffered `print()` output before emitting it
+    /// as a `Print` event, in milliseconds. Absent means the child's default
+    /// (`DEFAULT_PRINT_FLUSH_INTERVAL`). 0 disables the timer and restores line
+    /// buffering — one event per completed line, as before this field existed —
+    /// for a host that wants each `print()` delivered on its own.
+    ///
+    /// Output is always flushed before a turn-ending event whatever this says, so
+    /// the field trades streaming latency for event volume and nothing else.
+    #[prost(uint32, optional, tag = "10")]
+    pub print_flush_interval_ms: ::core::option::Option<u32>,
 }
 /// Executes one snippet against the session. Turn ends with `Complete`,
 /// `Error`, `TypingError`, or a suspension event.

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -537,6 +537,7 @@ class Monty:
         type_check_format: TypeCheckFormat | None = None,
         type_check_color: bool = False,
         assert_message_annotations: bool | int = ...,
+        print_flush_interval: float | None = None,
     ) -> MontySession:
         """
         Prepare a REPL session served by a dedicated worker.
@@ -564,6 +565,14 @@ class Monty:
                 CPython's empty `AssertionError`. On by default; set to `False`
                 to restore CPython's behavior, or to an int >= 1 to customize
                 the per-operand repr truncation length (default 120 bytes).
+            print_flush_interval: How long, in seconds, the worker may hold
+                buffered `print()` output before sending it, so that a burst
+                of prints costs one callback rather than one each. `None` (the
+                default) means 0.005; `0` restores line buffering, delivering
+                each completed line on its own. Output is always flushed
+                before a host call and before a run ends, so this only sets
+                how far live output may lag — never what arrives, or in what
+                order.
         """
 
 @final
@@ -815,6 +824,7 @@ class AsyncMonty:
         type_check_format: TypeCheckFormat | None = None,
         type_check_color: bool = False,
         assert_message_annotations: bool | int = ...,
+        print_flush_interval: float | None = None,
     ) -> AsyncMontySession:
         """
         Prepare a REPL session served by a dedicated worker.
@@ -896,6 +906,7 @@ class AsyncMontyWebsocket:
         type_check_format: TypeCheckFormat | None = None,
         type_check_color: bool = False,
         assert_message_annotations: bool | int = ...,
+        print_flush_interval: float | None = None,
     ) -> AsyncMontySession:
         """
         Prepare a REPL session served by a dedicated remote connection.

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -172,6 +172,7 @@ impl PyMonty {
         type_check_format = None,
         type_check_color = false,
         assert_message_annotations = AssertAnnotationsArg::default(),
+        print_flush_interval = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn checkout(
@@ -184,6 +185,7 @@ impl PyMonty {
         type_check_format: Option<TypeCheckFormatArg>,
         type_check_color: bool,
         assert_message_annotations: AssertAnnotationsArg,
+        print_flush_interval: Option<f64>,
     ) -> PyResult<PyMontySession> {
         Ok(PyMontySession {
             pool: Arc::clone(&self.pool),
@@ -198,6 +200,7 @@ impl PyMonty {
                     color: type_check_color,
                 },
                 assert_message_annotations,
+                print_flush_interval,
             )?,
             instances: InstanceStore::new(py),
             checkout: Arc::new(AsyncMutex::new(None)),
@@ -549,6 +552,7 @@ impl PyAsyncMonty {
         type_check_format = None,
         type_check_color = false,
         assert_message_annotations = AssertAnnotationsArg::default(),
+        print_flush_interval = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn checkout(
@@ -561,6 +565,7 @@ impl PyAsyncMonty {
         type_check_format: Option<TypeCheckFormatArg>,
         type_check_color: bool,
         assert_message_annotations: AssertAnnotationsArg,
+        print_flush_interval: Option<f64>,
     ) -> PyResult<PyAsyncMontySession> {
         Ok(PyAsyncMontySession {
             pool: Arc::clone(&self.pool),
@@ -575,6 +580,7 @@ impl PyAsyncMonty {
                     color: type_check_color,
                 },
                 assert_message_annotations,
+                print_flush_interval,
             )?,
             instances: InstanceStore::new(py),
             checkout: Arc::new(AsyncMutex::new(None)),
@@ -668,6 +674,7 @@ impl PyAsyncMontyWebsocket {
         type_check_format = None,
         type_check_color = false,
         assert_message_annotations = AssertAnnotationsArg::default(),
+        print_flush_interval = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn checkout(
@@ -680,6 +687,7 @@ impl PyAsyncMontyWebsocket {
         type_check_format: Option<TypeCheckFormatArg>,
         type_check_color: bool,
         assert_message_annotations: AssertAnnotationsArg,
+        print_flush_interval: Option<f64>,
     ) -> PyResult<PyAsyncMontySession> {
         Ok(PyAsyncMontySession {
             pool: Arc::clone(&self.pool),
@@ -694,6 +702,7 @@ impl PyAsyncMontyWebsocket {
                     color: type_check_color,
                 },
                 assert_message_annotations,
+                print_flush_interval,
             )?,
             instances: InstanceStore::new(py),
             checkout: Arc::new(AsyncMutex::new(None)),
@@ -966,8 +975,12 @@ fn parse_pool_config(
     if let Some(max) = max_processes {
         config.max_processes = max;
     }
-    config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
-    config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
+    config.checkout_timeout = checkout_timeout
+        .map(|secs| duration_from_secs("checkout_timeout", secs))
+        .transpose()?;
+    config.request_timeout = request_timeout
+        .map(|secs| duration_from_secs("request_timeout", secs))
+        .transpose()?;
     config.max_checkouts_per_worker = max_checkouts_per_worker;
     config.metrics = pool_metrics();
     Ok(config)
@@ -1082,14 +1095,19 @@ fn parse_websocket_config(
     if let Some(max) = max_processes {
         config.max_processes = max;
     }
-    config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
-    config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
+    config.checkout_timeout = checkout_timeout
+        .map(|secs| duration_from_secs("checkout_timeout", secs))
+        .transpose()?;
+    config.request_timeout = request_timeout
+        .map(|secs| duration_from_secs("request_timeout", secs))
+        .transpose()?;
     config.metrics = pool_metrics();
     Ok(config)
 }
 
 /// Builds the worker-side REPL session config from the (shared) `checkout`
 /// arguments.
+#[expect(clippy::too_many_arguments, reason = "one parameter per checkout argument")]
 pub(crate) fn parse_repl_config(
     py: Python<'_>,
     script_name: &str,
@@ -1098,6 +1116,7 @@ pub(crate) fn parse_repl_config(
     type_check_stubs: Option<&Bound<'_, PyString>>,
     type_check_config: TypeCheckingConfig,
     assert_message_annotations: AssertAnnotationsArg,
+    print_flush_interval: Option<f64>,
 ) -> PyResult<ReplConfig> {
     Ok(ReplConfig {
         script_name: script_name.to_owned(),
@@ -1106,6 +1125,9 @@ pub(crate) fn parse_repl_config(
         type_check_stubs: extract_type_check_stubs(py, type_check_stubs)?,
         type_check_config,
         assert_message_annotations: assert_message_annotations.0,
+        print_flush_interval: print_flush_interval
+            .map(|secs| duration_from_secs("print_flush_interval", secs))
+            .transpose()?,
     })
 }
 
@@ -1785,8 +1807,10 @@ pub(crate) fn pool_err_to_py(py: Python<'_>, err: PoolError) -> PyErr {
     }
 }
 
-fn duration_from_secs(secs: f64) -> PyResult<Duration> {
-    Duration::try_from_secs_f64(secs).map_err(|err| PyValueError::new_err(format!("invalid timeout: {err}")))
+/// Converts a seconds argument to a `Duration`, naming the argument in the
+/// error so a rejected value says which one it was.
+fn duration_from_secs(name: &str, secs: f64) -> PyResult<Duration> {
+    Duration::try_from_secs_f64(secs).map_err(|err| PyValueError::new_err(format!("invalid {name}: {err}")))
 }
 
 /// Locks the shared *pool* slot, ignoring poisoning (a panic elsewhere must

--- a/crates/monty-python/tests/test_print.py
+++ b/crates/monty-python/tests/test_print.py
@@ -1,4 +1,4 @@
-"""print_callback tests: line-buffered chunk delivery, error propagation, collectors."""
+"""print_callback tests: chunk delivery, error propagation, collectors."""
 
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ PrintCallback = Callable[[Literal['stdout', 'stderr'], str], None]
 def make_print_collector() -> tuple[list[str], PrintCallback]:
     """Create a print callback that collects output into a list.
 
-    The callback receives line-buffered chunks (one call per completed line,
-    or 8KiB), so assertions join the chunks rather than checking fragments.
+    The worker batches output, so a chunk is not a line or a `print()` call —
+    assertions join the chunks rather than checking fragments.
     """
     output: list[str] = []
 
@@ -95,6 +95,31 @@ for i in range(3):
     output, callback = make_print_collector()
     monty_run(code, print_callback=callback)
     assert ''.join(output) == snapshot('0\n1\n2\n')
+
+
+def test_print_flush_interval_batches_chunks(pool: Monty) -> None:
+    """A loop of prints costs a handful of callbacks, not one per print."""
+    output, callback = make_print_collector()
+    with pool.checkout() as s:
+        s.feed_run('for i in range(500):\n    print(i)', print_callback=callback)
+    assert ''.join(output) == ''.join(f'{i}\n' for i in range(500))
+    assert len(output) < 100
+
+
+def test_print_flush_interval_zero_is_line_buffered(pool: Monty) -> None:
+    """`0` turns the timer off, restoring one chunk per completed line."""
+    output, callback = make_print_collector()
+    with pool.checkout(print_flush_interval=0) as s:
+        s.feed_run('for i in range(20):\n    print(i)', print_callback=callback)
+    assert output == [f'{i}\n' for i in range(20)]
+
+
+def test_print_flush_interval_rejects_negative(pool: Monty) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        pool.checkout(print_flush_interval=-1)
+    assert exc_info.value.args[0] == snapshot(
+        'invalid print_flush_interval: cannot convert float seconds to Duration: value is negative'
+    )
 
 
 def test_print_mixed_types(monty_run: RunMonty) -> None:
@@ -193,10 +218,11 @@ fetch()
     assert str(exc_info2.value) == snapshot('this checkout has already been finished')
 
 
-def test_print_callback_raises_in_loop(monty_run: RunMonty) -> None:
+def test_print_callback_raises_in_loop(pool: Monty) -> None:
     """Test exception from callback when print is called in a loop.
 
-    Chunks are line-buffered, so each `print(i)` delivers exactly one chunk.
+    Pinned to line buffering so the failing chunk is the third `print(i)`
+    rather than whichever batch the worker happened to send.
     """
     code = """
 for i in range(5):
@@ -210,8 +236,8 @@ for i in range(5):
         if call_count >= 3:
             raise ValueError('stopped at 3')
 
-    with pytest.raises(MontyRuntimeError) as exc_info:
-        monty_run(code, print_callback=callback)
+    with pytest.raises(MontyRuntimeError) as exc_info, pool.checkout(print_flush_interval=0) as s:
+        s.feed_run(code, print_callback=callback)
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert inner.args[0] == snapshot('stopped at 3')
@@ -237,7 +263,8 @@ def test_collect_streams_run_returns_raw_output(monty_run: RunMonty) -> None:
     result = monty_run('print("a"); print("b", 1); 123', print_callback=collector)
 
     assert result == snapshot(123)
-    assert collector.output == snapshot([('stdout', 'a\n'), ('stdout', 'b 1\n')])
+    # both prints land in one chunk, so the collector sees one entry
+    assert collector.output == snapshot([('stdout', 'a\nb 1\n')])
 
 
 def test_collect_streams_repr(monty_run: RunMonty) -> None:

--- a/crates/monty-python/tests/test_print.py
+++ b/crates/monty-python/tests/test_print.py
@@ -98,12 +98,26 @@ for i in range(3):
 
 
 def test_print_flush_interval_batches_chunks(pool: Monty) -> None:
-    """A loop of prints costs a handful of callbacks, not one per print."""
+    """A loop of prints costs a handful of callbacks, not one per print.
+
+    Pinned to an interval nothing will reach, so only the 8 KiB threshold and
+    the turn-end drain can flush. 500 short lines stay well under 8 KiB, making
+    the count exactly one rather than a function of how fast the loop ran.
+    """
+    expected = ''.join(f'{i}\n' for i in range(500))
+    output, callback = make_print_collector()
+    with pool.checkout(print_flush_interval=60) as s:
+        s.feed_run('for i in range(500):\n    print(i)', print_callback=callback)
+    assert ''.join(output) == expected
+    assert len(output) == 1
+
+    # At the default interval the count depends on machine speed, so assert
+    # only what batching guarantees: fewer callbacks than prints.
     output, callback = make_print_collector()
     with pool.checkout() as s:
         s.feed_run('for i in range(500):\n    print(i)', print_callback=callback)
-    assert ''.join(output) == ''.join(f'{i}\n' for i in range(500))
-    assert len(output) < 100
+    assert ''.join(output) == expected
+    assert len(output) < 500
 
 
 def test_print_flush_interval_zero_is_line_buffered(pool: Monty) -> None:

--- a/crates/monty-types/src/io.rs
+++ b/crates/monty-types/src/io.rs
@@ -145,6 +145,24 @@ impl PrintWriter<'_> {
             Self::Callback(cb) => cb.stdout_push(end),
         }
     }
+
+    /// Whether this writer wants [`poll_flush`](Self::poll_flush) called at all.
+    ///
+    /// Only `Callback` can buffer, so the VM hoists this out of its dispatch
+    /// loop and skips the poll (and its clock read) entirely for every other
+    /// variant.
+    #[must_use]
+    pub fn wants_poll(&self) -> bool {
+        matches!(self, Self::Callback(_))
+    }
+
+    /// Forwards the VM's periodic checkpoint to a buffering callback.
+    pub fn poll_flush(&mut self) -> Result<(), MontyException> {
+        match self {
+            Self::Callback(cb) => cb.poll_flush(),
+            _ => Ok(()),
+        }
+    }
 }
 
 /// Rejects a collect-buffer growth that would exceed `max_bytes`.
@@ -230,4 +248,14 @@ pub trait PrintWriterCallback {
     /// # Arguments
     /// * `end` - The character to print after the formatted output.
     fn stdout_push(&mut self, end: char) -> Result<(), MontyException>;
+
+    /// Gives a buffering implementation a chance to release what it holds.
+    ///
+    /// The VM calls this from its periodic dispatch checkpoint, so a callback
+    /// that batches writes can bound how long output sits unsent while the
+    /// program computes without printing. Implementations that write straight
+    /// through do nothing here.
+    fn poll_flush(&mut self) -> Result<(), MontyException> {
+        Ok(())
+    }
 }

--- a/crates/monty-wasm-runtime/src/lib.rs
+++ b/crates/monty-wasm-runtime/src/lib.rs
@@ -313,10 +313,10 @@ fn configure_from_component(request: ConfigureRequest) -> pb::Configure {
         type_check_format: i32::from(type_check_format_from_component(request.type_check_format)),
         type_check_color: request.type_check_color,
         protocol_version: PROTOCOL_VERSION,
-        // Not exposed by the WIT interface: this transport hands the host a
-        // whole turn's frames at once, so how the child paced them changed
-        // nothing observable. The child's default keeps the event count down.
-        print_flush_interval_ms: None,
+        // Frames arrive as one batch at the end of a turn, but their
+        // boundaries survive it: the host gets one print callback per frame,
+        // and a print collector charges its cap per frame.
+        print_flush_interval_ms: request.print_flush_interval_ms,
     }
 }
 

--- a/crates/monty-wasm-runtime/src/lib.rs
+++ b/crates/monty-wasm-runtime/src/lib.rs
@@ -313,6 +313,10 @@ fn configure_from_component(request: ConfigureRequest) -> pb::Configure {
         type_check_format: i32::from(type_check_format_from_component(request.type_check_format)),
         type_check_color: request.type_check_color,
         protocol_version: PROTOCOL_VERSION,
+        // Not exposed by the WIT interface: this transport hands the host a
+        // whole turn's frames at once, so how the child paced them changed
+        // nothing observable. The child's default keeps the event count down.
+        print_flush_interval_ms: None,
     }
 }
 

--- a/crates/monty-wasm-runtime/wit/runtime.wit
+++ b/crates/monty-wasm-runtime/wit/runtime.wit
@@ -208,6 +208,9 @@ interface worker {
         assert-message-annotations: option<u32>,
         type-check-format: type-check-format,
         type-check-color: bool,
+        /// How long the child may hold buffered print output. Absent takes its
+        /// default; zero restores line buffering, one event per completed line.
+        print-flush-interval-ms: option<u32>,
     }
 
     /// One Python snippet and its host inputs.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1090,15 +1090,21 @@ impl<'h> VM<'h> {
     /// Periodic dispatch-loop work, outlined (`#[inline(never)]`) so the hot
     /// loop stays small: the amortized memory + time check — where a timeout
     /// swallowed by a truncating caller re-detects (elapsed time is
-    /// monotonic), backstopped by the `run_external` exit check — and the
-    /// GC-scheduling probe.
+    /// monotonic), backstopped by the `run_external` exit check — the
+    /// GC-scheduling probe, and the print writer's flush poll.
     #[inline(never)]
-    fn dispatch_checkpoint(&mut self, check_limits: bool) -> Result<(), RunError> {
+    fn dispatch_checkpoint(&mut self, check_limits: bool, poll_print: bool) -> Result<(), RunError> {
         if check_limits {
             self.heap.tracker.check_memory_time()?;
         }
         if self.heap.should_gc() {
             self.run_gc();
+        }
+        // A buffering writer only flushes when written to, so code that prints
+        // and then computes in silence would hold that output until its next
+        // print. This is what bounds that wait.
+        if poll_print {
+            self.print_writer.poll_flush()?;
         }
         Ok(())
     }
@@ -1133,6 +1139,9 @@ impl<'h> VM<'h> {
         // host boundary), so with none configured the whole checkpoint reduces
         // to this one hoisted, well-predicted branch per instruction.
         let check_limits = self.heap.tracker.has_memory_time_limit();
+        // Likewise hoisted: only a `Callback` writer can buffer, so every other
+        // variant skips the poll — and the clock read behind it — entirely.
+        let poll_print = self.print_writer.wants_poll();
 
         let mut countdown = CHECK_INTERVAL;
 
@@ -1146,7 +1155,7 @@ impl<'h> VM<'h> {
                 countdown = c;
             } else {
                 countdown = CHECK_INTERVAL;
-                self.dispatch_checkpoint(check_limits)?;
+                self.dispatch_checkpoint(check_limits, poll_print)?;
             }
 
             // Track instruction IP for exception table lookup

--- a/docs/quickstart/javascript.md
+++ b/docs/quickstart/javascript.md
@@ -121,6 +121,10 @@ A plain `(stream, text) => void` callback works too.
 Both collectors default to a 10 MiB cap (`DEFAULT_MAX_PRINT_COLLECT_BYTES`); pass `null` to disable it.
 The cap is host-side and separate from [`maxMemory`](../resource-limits.md).
 
+Output arrives in batched chunks, not one per `print()`.
+`printFlushInterval` on `checkout()` sets how long (in seconds) the worker may hold it — 0.005 by default, `0` for one
+chunk per line — and output is always flushed before a host call and before a feed ends.
+
 ## Errors
 
 ```ts

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -178,7 +178,10 @@ with Monty() as pool:
         #> [('stdout', 'hello\n')]
 ```
 
-Output arrives in chunks flushed at newline boundaries or once roughly 8 KiB accumulates, not one call per `print()`.
+Output arrives in chunks, not one call per `print()`.
+The worker batches it, sending a chunk once about 8 KiB accumulates or the oldest byte has waited out
+`print_flush_interval` — 0.005 seconds by default, settable on `checkout()`, and `0` to restore one chunk per line.
+Whatever the interval, output is flushed before a host call and before a feed ends, so it never arrives out of order.
 
 ## Errors
 

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -238,11 +238,11 @@ properties that real CPython does not provide, per the caveat above.
   against the checker's database and so never cross the wire. Formats are
   ty's: `full` (default), `concise`, `azure`, `json`, `jsonlines`, `rdjson`,
   `pylint`, `gitlab`, `github`; only `full` and `concise` carry colour.
-- **Print callbacks** receive buffered chunks flushed at newline boundaries
-  or once ~8 KiB accumulates, not per-fragment writes. A chunk may contain
-  more than one line, and output larger than the threshold is split into
-  ~8 KiB pieces, so a chunk is bounded but not guaranteed to be exactly
-  one line. A callback that raises aborts the feed after the current
+- **Print callbacks** receive buffered chunks flushed once ~8 KiB accumulates
+  or the flush interval expires (see ./print.md), not per-fragment writes. A
+  chunk may hold several `print()` calls, and output larger than the threshold
+  is split into ~8 KiB pieces, so a chunk is bounded but corresponds to nothing
+  in the source. A callback that raises aborts the feed after the current
   protocol turn, not mid-`print`; if that turn had suspended (an external
   function, OS call, or name lookup), the binding resets/discards the
   suspension before surfacing the print error so later feeds can continue.

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -39,8 +39,15 @@ out the flush interval (5 ms by default), so:
   argument.
 - Output that is printed and then followed by silence is released by the
   interpreter's periodic checkpoint, so it does not wait for the next
-  `print()`. Native code that runs for a long time without reaching a
-  checkpoint can still delay it.
+  `print()`.
+- That checkpoint sits in the bytecode dispatch loop, so it only fires between
+  instructions. One long native operation — a large `sort`, a regex scan,
+  `json.dumps` over a big structure — holds whatever was buffered for as long
+  as it runs, however short the interval. This is the one case where the
+  interval does not bound the wait. The output is late, never dropped: the
+  buffer is still drained before the next host call and at the end of the
+  turn, so a host that needs liveness here can set the interval to 0 and get a
+  callback as each line is written.
 - Ordering is exact, and the buffer is always drained before a host call or the
   end of a run, so output cannot arrive after the event it preceded.
 - Buffered output is lost if the worker dies *hard*: the pool killing it on

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -17,19 +17,46 @@ host decides where it ends up; there is no real `sys.stdout` underneath (see
   supported"`. Code that does `print(..., file=sys.stderr)` will not work;
   `sys.stderr` is an opaque marker (see ./sys.md).
 - `flush=...` — accepted and ignored. Output is delivered to the host through
-  the subprocess protocol, which line-buffers and also flushes large partial
-  lines.
+  the subprocess protocol on its own schedule (see "Chunk boundaries" below);
+  a `print()` cannot make it arrive sooner.
 - Any other keyword raises `TypeError: ... unexpected keyword argument`.
 
 ## Behaviour
 
 - Each positional argument is converted via `py_str` (equivalent to `str(x)`)
   before being written.
-- The host callback receives formatted chunks. In subprocess execution, chunks
-  are flushed on newline or after an internal buffer reaches roughly 8 KiB, so
-  a single `print()` call can arrive in more than one callback. There is no
-  atomicity guarantee across multiple `print()` calls if the host interleaves
-  with other output.
+- The host callback receives formatted chunks. There is no atomicity guarantee
+  across multiple `print()` calls if the host interleaves with other output.
+
+## Chunk boundaries
+
+Chunk boundaries carry no meaning. The worker holds output in a buffer and
+sends it when the buffer reaches roughly 8 KiB or its oldest byte has waited
+out the flush interval (5 ms by default), so:
+
+- One `print()` can arrive in several callbacks, and several `print()` calls
+  can arrive in one. A chunk does not correspond to a call, a line, or an
+  argument.
+- Output that is printed and then followed by silence is released by the
+  interpreter's periodic checkpoint, so it does not wait for the next
+  `print()`. Native code that runs for a long time without reaching a
+  checkpoint can still delay it.
+- Ordering is exact, and the buffer is always drained before a host call or the
+  end of a run, so output cannot arrive after the event it preceded.
+- Buffered output is lost if the worker dies *hard*: the pool killing it on
+  `request_timeout`, the allocator ending the process at its hard memory
+  ceiling, or a crash. A graceful turn drains first, so this only affects a
+  worker that never finished — but the window is up to 8 KiB or one flush
+  interval of already-complete lines, where line buffering would have sent
+  them. A host that would rather have that output than the batching (to see
+  what a snippet printed before it hung, say) can set the interval to 0.
+
+Hosts can set the interval per session: `print_flush_interval` (seconds) in
+`pydantic_monty`, `printFlushInterval` (seconds) in `@pydantic/monty`, and
+`ReplConfig::print_flush_interval` in Rust. `0` turns the timer off and
+restores line buffering, one callback per completed line. The wasm worker does
+not expose the setting: it returns a whole turn's output at once, so there is
+no streaming schedule to tune.
 
 ## CollectString / CollectStreams caps
 
@@ -58,6 +85,9 @@ buffers. That growth is **not** covered by `ResourceLimits.max_memory`
   cap, since many tiny fragments would otherwise OOM the host before payload
   bytes hit the limit. Rust `PrintWriter::CollectStreams` merges consecutive
   same-stream fragments, so entry count stays small for normal `print()`.
+- Entries follow the chunk boundaries above, not `print()` calls: several
+  prints usually collect into one entry. Set `print_flush_interval=0` to get
+  one entry per completed line.
 - JS (`@pydantic/monty`): `CollectString` / `CollectStreams` accept `maxBytes`
   (camelCase), same 10 MiB default and message; `CollectStreams` charges the
   same **64-byte** per-entry overhead as the Python host path and does **not**

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -54,9 +54,13 @@ out the flush interval (5 ms by default), so:
 Hosts can set the interval per session: `print_flush_interval` (seconds) in
 `pydantic_monty`, `printFlushInterval` (seconds) in `@pydantic/monty`, and
 `ReplConfig::print_flush_interval` in Rust. `0` turns the timer off and
-restores line buffering, one callback per completed line. The wasm worker does
-not expose the setting: it returns a whole turn's output at once, so there is
-no streaming schedule to tune.
+restores line buffering, one callback per completed line.
+
+The wasm worker takes the same setting, but it does not stream: a turn's
+frames all reach the host together when the turn ends, whatever the interval.
+What the setting still decides there is how that output is *split* — one print
+callback per frame, and a collector charges its cap per frame — so a snippet
+that hangs or is killed yields nothing either way.
 
 ## CollectString / CollectStreams caps
 

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -61,7 +61,10 @@ out the flush interval (5 ms by default), so:
 Hosts can set the interval per session: `print_flush_interval` (seconds) in
 `pydantic_monty`, `printFlushInterval` (seconds) in `@pydantic/monty`, and
 `ReplConfig::print_flush_interval` in Rust. `0` turns the timer off and
-restores line buffering, one callback per completed line.
+restores line buffering, one callback per completed line. The wire carries
+whole milliseconds, so a positive interval under 1 ms is sent as 1 ms rather
+than rounding down into that sentinel, and a negative or non-finite value is
+rejected at checkout.
 
 The wasm worker takes the same setting, but it does not stream: a turn's
 frames all reach the host together when the turn ends, whatever the interval.


### PR DESCRIPTION
Closes #734.

Letting untrusted sandbox code log could be very expensive for telemetry. Before every print() became its own Print frame. Now we debounce and flush logs in batches. ProtoPrint flushes on byte size and interval instead of on newline.

**Buffer flush interval** is configurable and defaults to 5ms.
If set to `0` it turns the timer off to restore line buffering — one event per completed line, for a host that wants each print() delivered on its own.

| Environment | Parameter | Units | Default |
| --- | --- | --- | --- |
| Python (`pydantic_monty`) | `print_flush_interval` on `checkout()` | seconds | `None` → 0.005 |
| JavaScript (`@pydantic/monty`) | `printFlushInterval` on `checkout()` | seconds | `undefined` → 0.005 |
| Rust (`monty-pool`) | `ReplConfig::print_flush_interval` | `Option<Duration>` | `None` → 5 ms |
| Any parent (wire protocol) | `Configure.print_flush_interval_ms` (tag 10) | milliseconds | absent → 5 ms |
| wasm worker (`@pydantic/monty/wasm`) | `printFlushInterval` on `checkout()` | seconds | `undefined` → 0.005 |

The wasm worker takes the setting but does not stream: a turn's frames all reach the host together when the turn ends. What the interval still decides there is how that output is *split* — one `printCallback` call per frame, and a print collector charges its `maxBytes` cap per frame.

**Buffer flush size** is currently hardcoded to 8 KiB (`ProtoPrint::FLUSH_BYTES`).
Note - discussing with Claude there are some bounds if we were to make it configurable:
- 64 KiB max: past it, telemetry truncates the text, so you'd trade records for lost output.
- 4B min: under 4 bytes the write loop can't advance a multi-byte char.

**Change** - hard-kill means output loss as the buffer is lost, previously we could only lose a partial line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wcvnwRhLcyjh3fP2Rotqb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounces sandbox `print()` output in the worker. Previously every completed line sent its own `Print` event; now bursts are batched to reduce per-frame telemetry overhead, with changes to delivery latency and hard-kill output loss.

**Configuration**

- Set `print_flush_interval` in `pydantic_monty`, `printFlushInterval` in `@pydantic/monty`, or `ReplConfig::print_flush_interval` in Rust; the wire field is `Configure.print_flush_interval_ms`.
- Output flushes at 8 KiB or after 5 ms by default; `0` restores one event per completed line, splitting embedded newlines within a single `print()`.
- Negative or non-finite intervals are rejected at checkout; positive values are clamped to at least 1 ms so they never round down into the zero sentinel.
- The wasm worker now honors the setting. It still returns a turn's frames together, but the interval controls frame boundaries and collector limits.
- Restored sessions keep the checkout's interval instead of falling back to the default.

**Side effects**

- Output flushes before host calls and feed ends, preserving ordering.
- Dispatch checkpoints release buffered output during silent Python computation, but a single long native operation holds it until it finishes.
- A hard kill can lose up to 8 KiB or one flush interval of complete output; use `0` to avoid this buffering window.

<sup>Written for commit d5aa00f724c958d8b7669099055a21fa39857994. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

