### PR TITLE
Answer `date.today()` / `datetime.now()` in standard execution

### DIFF
--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -41,6 +41,10 @@ monty --help
 - `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
   `--gc-interval`, `--max-suspensions` — sandbox resource limits
 
+`date.today()` and `datetime.now()` read this machine's clock and local
+timezone, as they do for any in-process run. `MontyRun::with_host_clock` is how
+an embedder chooses otherwise; the CLI has no flag for it.
+
 ## Worker mode
 
 `monty subprocess` runs the binary as a wire-protocol child: framed protobuf

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -23,14 +23,23 @@ use monty::{MontyRepl, MontyRun, ReplContinuationMode, ReplProgress, RunProgress
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
-    CompileOptions, DEFAULT_MAX_SUSPENSIONS, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult,
-    OsFunctionCall, PrintWriter, ResourceLimits, ResourceTracker, TypeCheckingConfig,
+    CompileOptions, DEFAULT_MAX_SUSPENSIONS, ExcType, ExtFunctionResult, HostClock, MontyException, MontyObject,
+    NameLookupResult, OsFunctionCall, PrintWriter, ResourceLimits, ResourceTracker, TypeCheckingConfig,
 };
 use rustyline::{DefaultEditor, error::ReadlineError};
 #[cfg(feature = "telemetry")]
 use tracing::field::Empty;
 
 use crate::Cli;
+
+/// The clock the CLI lends to sandboxed code for `date.today()` and
+/// `datetime.now()`.
+///
+/// The same clock a fresh [`MontyRun`] already has, set explicitly so the CLI's
+/// choice does not quietly follow a change to that default — and so
+/// [`handle_os_call`] can answer the suspended calls the mounted REPL path
+/// produces from the same source.
+const CLI_CLOCK: HostClock = HostClock::System;
 
 /// Dim/gray text (timings). `{DIM}` opens the style, `{DIM:#}` closes it.
 const DIM: Style = Style::new().dimmed();
@@ -199,7 +208,7 @@ fn run_script(
     let inputs = vec![];
 
     let runner = match MontyRun::new(code, file_path, input_names, CompileOptions::default()) {
-        Ok(ex) => ex,
+        Ok(ex) => ex.with_host_clock(CLI_CLOCK),
         Err(err) => {
             eprintln!("{BOLD_RED}error{BOLD_RED:#}:\n{err}");
             return ExitCode::FAILURE;
@@ -275,7 +284,7 @@ fn run_script(
 /// initialization or I/O errors.
 fn run_repl(file_path: &str, code: &str, tracker: ResourceTracker, mut mount_table: Option<MountTable>) -> ExitCode {
     let mut suspensions = SuspensionBudget::new(&tracker);
-    let mut repl = Some(MontyRepl::new(file_path, tracker, CompileOptions::default()));
+    let mut repl = Some(MontyRepl::new(file_path, tracker, CompileOptions::default()).with_host_clock(CLI_CLOCK));
 
     if !code.is_empty() {
         execute_repl_snippet(&mut repl, code, &mut mount_table, &mut suspensions);
@@ -582,6 +591,12 @@ impl SuspensionBudget {
 /// successful `MontyObject` or an exception for errors / unsupported
 /// operations.
 fn handle_os_call(call: OsFunctionCall, mount_table: &mut Option<MountTable>) -> ExtFunctionResult {
+    // The clock answers `date.today()` / `datetime.now()` here for the same
+    // reason it is granted to the non-suspending path: the CLI is the host, and
+    // a local script expecting CPython's clock should get one either way.
+    if let Some(now) = CLI_CLOCK.resolve(&call) {
+        return now.into();
+    }
     match mount_table.as_mut() {
         Some(mounts) => match mounts.handle_os_call(call) {
             MountCallOutcome::Handled(Ok(obj)) => obj.into(),

--- a/crates/monty-runtime/src/run.rs
+++ b/crates/monty-runtime/src/run.rs
@@ -35,10 +35,10 @@ use crate::Cli;
 /// The clock the CLI lends to sandboxed code for `date.today()` and
 /// `datetime.now()`.
 ///
-/// The same clock a fresh [`MontyRun`] already has, set explicitly so the CLI's
-/// choice does not quietly follow a change to that default — and so
-/// [`handle_os_call`] can answer the suspended calls the mounted REPL path
-/// produces from the same source.
+/// The same clock a fresh [`MontyRun`] already has, named here so the CLI's
+/// choice does not quietly follow a change to that default.
+/// [`handle_os_call`] reads it too, so the mounted REPL path answers the
+/// suspended calls from the same source.
 const CLI_CLOCK: HostClock = HostClock::System;
 
 /// Dim/gray text (timings). `{DIM}` opens the style, `{DIM:#}` closes it.

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -15,7 +15,7 @@ use monty_proto::{
     FrameError, FrameReader, MAX_FRAME_LEN, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, WireFunctionCall,
     WireObject, exceeds_max_frame_len, pb, write_frame,
 };
-use monty_types::{MontyDate, MontyObject};
+use monty_types::{MontyDate, MontyDateTime, MontyObject};
 
 /// How long a death-expecting helper waits for the child to exit. Generous:
 /// the regression it guards is "the child never dies", so the only cost of a
@@ -509,28 +509,48 @@ fn external_function_not_found_raises_name_error() {
 fn clock_calls_bubble_to_parent() {
     let mut child = ChildProc::spawn();
     child.create_repl();
+
+    let today = MontyDate {
+        year: 2024,
+        month: 1,
+        day: 15,
+    };
     let (_, event) = child.feed("from datetime import date\ndate.today()");
     let pb::child_event::Kind::OsCall(call) = event else {
         panic!("expected OsCall, got {event:?}");
     };
     assert_eq!(call.call, Some(pb::os_call::Call::DateToday(pb::Unit {})));
-
     let (_, event) = child.resume_call(
         call.call_id,
-        pb::ext_function_result::Kind::ReturnValue(WireObject::new(MontyObject::Date(MontyDate {
-            year: 2024,
-            month: 1,
-            day: 15,
-        }))),
+        pb::ext_function_result::Kind::ReturnValue(WireObject::new(MontyObject::Date(today.clone()))),
     );
+    assert_eq!(expect_complete(event), MontyObject::Date(today));
+
+    let now = MontyDateTime {
+        year: 2024,
+        month: 1,
+        day: 15,
+        hour: 9,
+        minute: 30,
+        second: 0,
+        microsecond: 0,
+        offset_seconds: None,
+        timezone_name: None,
+    };
+    let (_, event) = child.feed("from datetime import datetime\ndatetime.now()");
+    let pb::child_event::Kind::OsCall(call) = event else {
+        panic!("expected OsCall, got {event:?}");
+    };
     assert_eq!(
-        expect_complete(event),
-        MontyObject::Date(MontyDate {
-            year: 2024,
-            month: 1,
-            day: 15,
-        })
+        call.call,
+        Some(pb::os_call::Call::DateTimeNow(pb::os_call::DateTimeNow { tz: None }))
     );
+    let (_, event) = child.resume_call(
+        call.call_id,
+        pb::ext_function_result::Kind::ReturnValue(WireObject::new(MontyObject::DateTime(now.clone()))),
+    );
+    assert_eq!(expect_complete(event), MontyObject::DateTime(now));
+
     child.shutdown();
 }
 

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -15,7 +15,7 @@ use monty_proto::{
     FrameError, FrameReader, MAX_FRAME_LEN, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, WireFunctionCall,
     WireObject, exceeds_max_frame_len, pb, write_frame,
 };
-use monty_types::MontyObject;
+use monty_types::{MontyDate, MontyObject};
 
 /// How long a death-expecting helper waits for the child to exit. Generous:
 /// the regression it guards is "the child never dies", so the only cost of a
@@ -496,6 +496,41 @@ fn external_function_not_found_raises_name_error() {
     let error = expect_error(event);
     assert_eq!(error.exc_type, "NameError");
     assert_eq!(error.message.as_deref(), Some("name 'undefined_fn' is not defined"));
+    child.shutdown();
+}
+
+/// The worker's `MontyRepl` carries a `HostClock` — `System` since #330 — that
+/// only the non-suspending paths read, and it drives `feed_start`, which does
+/// not. Nothing in the type system holds that apart: routing a worker feed
+/// through `feed_run` would silently start answering the clock inside the
+/// sandbox instead of asking the parent, so this pins that the two clock calls
+/// still arrive here.
+#[test]
+fn clock_calls_bubble_to_parent() {
+    let mut child = ChildProc::spawn();
+    child.create_repl();
+    let (_, event) = child.feed("from datetime import date\ndate.today()");
+    let pb::child_event::Kind::OsCall(call) = event else {
+        panic!("expected OsCall, got {event:?}");
+    };
+    assert_eq!(call.call, Some(pb::os_call::Call::DateToday(pb::Unit {})));
+
+    let (_, event) = child.resume_call(
+        call.call_id,
+        pb::ext_function_result::Kind::ReturnValue(WireObject::new(MontyObject::Date(MontyDate {
+            year: 2024,
+            month: 1,
+            day: 15,
+        }))),
+    );
+    assert_eq!(
+        expect_complete(event),
+        MontyObject::Date(MontyDate {
+            year: 2024,
+            month: 1,
+            day: 15,
+        })
+    );
     child.shutdown();
 }
 

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -499,12 +499,10 @@ fn external_function_not_found_raises_name_error() {
     child.shutdown();
 }
 
-/// The worker's `MontyRepl` carries a `HostClock` — `System` since #330 — that
-/// only the non-suspending paths read, and it drives `feed_start`, which does
-/// not. Nothing in the type system holds that apart: routing a worker feed
-/// through `feed_run` would silently start answering the clock inside the
-/// sandbox instead of asking the parent, so this pins that the two clock calls
-/// still arrive here.
+/// The worker's `MontyRepl` carries a `HostClock`, but drives `feed_start`,
+/// which never reads it. Only this test holds the two apart: routing a worker
+/// feed through `feed_run` would answer the clock inside the sandbox instead
+/// of asking the parent.
 #[test]
 fn clock_calls_bubble_to_parent() {
     let mut child = ChildProc::spawn();

--- a/crates/monty-types/src/clock.rs
+++ b/crates/monty-types/src/clock.rs
@@ -4,24 +4,19 @@
 use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeDelta, Timelike};
 
 use crate::{
-    object::{MontyDate, MontyDateTime, MontyObject, MontyTimeZone},
+    object::{MontyDate, MontyDateTime, MontyObject},
     os::OsFunctionCall,
 };
 
 /// Where `date.today()` and `datetime.now()` read the time under standard
-/// (non-suspending) execution.
+/// (non-suspending) execution, which has no host to deliver their
+/// [`OsFunctionCall`] to.
 ///
-/// Both calls reach the host as an [`OsFunctionCall`], which standard execution
-/// has no way to deliver — so it answers them from this clock instead, which is
-/// what makes ordinary date-handling scripts run on the plain `run` path.
-///
-/// Only standard execution consults it. Under the suspend/resume path the call
-/// reaches the host like any other OS call and a clock set here is ignored, so
-/// this type is absent from the wire protocol. It does travel inside a session
-/// dump, though, which is why adding it bumped `DUMP_VERSION`.
-/// Deliberately not [`Default`]: a fresh runner gets [`System`](Self::System)
-/// (see `monty`'s `default_clock`), and a type-level default of
-/// [`Denied`](Self::Denied) would quietly disagree with that.
+/// Only standard execution consults it — under suspend/resume the host answers
+/// both calls and a clock set here is ignored, so this is absent from the wire
+/// protocol. Deliberately not [`Default`]: a fresh runner gets
+/// [`System`](Self::System) (see `monty`'s `default_clock`), which a type-level
+/// [`Denied`](Self::Denied) would quietly contradict.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum HostClock {
     /// No clock: both calls raise `NotImplementedError`, as every other OS
@@ -82,7 +77,7 @@ impl HostClock {
                     second: u8::try_from(local.second()).ok()?,
                     microsecond: local.nanosecond() / 1_000,
                     offset_seconds: tz.as_ref().map(|tz| tz.offset_seconds),
-                    timezone_name: tz.as_ref().and_then(|tz: &MontyTimeZone| tz.name.clone()),
+                    timezone_name: tz.as_ref().and_then(|tz| tz.name.clone()),
                 }))
             }
             _ => None,
@@ -118,7 +113,7 @@ impl HostClock {
     }
 }
 
-/// Reads a UTC wall clock at `offset_seconds` from UTC, rejecting anything
+/// Shifts a UTC wall clock by `offset_seconds`, rejecting anything
 /// outside the 1..=9999 years Python's `datetime` can hold.
 fn shift(utc: NaiveDateTime, offset_seconds: i32) -> Option<NaiveDateTime> {
     let shifted = utc.checked_add_signed(TimeDelta::seconds(i64::from(offset_seconds)))?;

--- a/crates/monty-types/src/clock.rs
+++ b/crates/monty-types/src/clock.rs
@@ -51,11 +51,15 @@ impl HostClock {
     /// `None` means the caller should treat the call as unserviced — the clock
     /// is [`Denied`](Self::Denied), the call is not a clock call, or the
     /// instant is unrepresentable as a Python `datetime`.
+    ///
+    /// The clock is read per arm rather than up front so that a host passing
+    /// every OS call through here — as the CLI does — pays nothing for the
+    /// filesystem calls, which are the overwhelming majority.
     #[must_use]
     pub fn resolve(self, call: &OsFunctionCall) -> Option<MontyObject> {
-        let (utc, local_offset_seconds) = self.instant()?;
         match call {
             OsFunctionCall::DateToday => {
+                let (utc, local_offset_seconds) = self.instant()?;
                 let local = shift(utc, local_offset_seconds)?;
                 Some(MontyObject::Date(MontyDate {
                     year: local.year(),
@@ -66,6 +70,7 @@ impl HostClock {
             // Naive `now()` is local wall clock; `now(tz)` is the same instant
             // read in `tz`, both matching CPython.
             OsFunctionCall::DateTimeNow(tz) => {
+                let (utc, local_offset_seconds) = self.instant()?;
                 let offset_seconds = tz.as_ref().map_or(local_offset_seconds, |tz| tz.offset_seconds);
                 let local = shift(utc, offset_seconds)?;
                 Some(MontyObject::DateTime(MontyDateTime {

--- a/crates/monty-types/src/clock.rs
+++ b/crates/monty-types/src/clock.rs
@@ -1,0 +1,116 @@
+//! The host clock capability: [`HostClock`], which answers `date.today()` and
+//! `datetime.now()` in-process instead of suspending to the host for them.
+
+use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeDelta, Timelike};
+
+use crate::{
+    object::{MontyDate, MontyDateTime, MontyObject, MontyTimeZone},
+    os::OsFunctionCall,
+};
+
+/// Where `date.today()` and `datetime.now()` read the time under standard
+/// (non-suspending) execution.
+///
+/// Both calls reach the host as an [`OsFunctionCall`], which standard execution
+/// has no way to deliver — so it answers them from this clock instead, which is
+/// what makes ordinary date-handling scripts run on the plain `run` path.
+///
+/// Only standard execution consults it. Under the suspend/resume path the call
+/// reaches the host like any other OS call and a clock set here is ignored, so
+/// this type is absent from the wire protocol. It does travel inside a session
+/// dump, though, which is why adding it bumped `DUMP_VERSION`.
+/// Deliberately not [`Default`]: a fresh runner gets [`System`](Self::System)
+/// (see `monty`'s `default_clock`), and a type-level default of
+/// [`Denied`](Self::Denied) would quietly disagree with that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum HostClock {
+    /// No clock: both calls raise `NotImplementedError`, as every other OS
+    /// call does under standard execution.
+    Denied,
+    /// The process's own clock, in its local timezone.
+    System,
+    /// A frozen instant, for runs that have to be reproducible.
+    ///
+    /// An instant outside `datetime`'s 1..=9999 year range reads as
+    /// [`Denied`](Self::Denied) rather than failing some other way.
+    Fixed {
+        /// Seconds since the Unix epoch, UTC.
+        unix_seconds: i64,
+        /// Sub-second component, 0..=999_999. Anything larger reads as
+        /// [`Denied`](Self::Denied).
+        microsecond: u32,
+        /// Offset of the clock's local timezone from UTC, in seconds. Naive
+        /// `datetime.now()` and `date.today()` are read in this zone.
+        local_offset_seconds: i32,
+    },
+}
+
+impl HostClock {
+    /// Answers `call` if it is a clock call this clock can serve.
+    ///
+    /// `None` means the caller should treat the call as unserviced — the clock
+    /// is [`Denied`](Self::Denied), the call is not a clock call, or the
+    /// instant is unrepresentable as a Python `datetime`.
+    #[must_use]
+    pub fn resolve(self, call: &OsFunctionCall) -> Option<MontyObject> {
+        let (utc, local_offset_seconds) = self.instant()?;
+        match call {
+            OsFunctionCall::DateToday => {
+                let local = shift(utc, local_offset_seconds)?;
+                Some(MontyObject::Date(MontyDate {
+                    year: local.year(),
+                    month: u8::try_from(local.month()).ok()?,
+                    day: u8::try_from(local.day()).ok()?,
+                }))
+            }
+            // Naive `now()` is local wall clock; `now(tz)` is the same instant
+            // read in `tz`, both matching CPython.
+            OsFunctionCall::DateTimeNow(tz) => {
+                let offset_seconds = tz.as_ref().map_or(local_offset_seconds, |tz| tz.offset_seconds);
+                let local = shift(utc, offset_seconds)?;
+                Some(MontyObject::DateTime(MontyDateTime {
+                    year: local.year(),
+                    month: u8::try_from(local.month()).ok()?,
+                    day: u8::try_from(local.day()).ok()?,
+                    hour: u8::try_from(local.hour()).ok()?,
+                    minute: u8::try_from(local.minute()).ok()?,
+                    second: u8::try_from(local.second()).ok()?,
+                    microsecond: local.nanosecond() / 1_000,
+                    offset_seconds: tz.as_ref().map(|tz| tz.offset_seconds),
+                    timezone_name: tz.as_ref().and_then(|tz: &MontyTimeZone| tz.name.clone()),
+                }))
+            }
+            _ => None,
+        }
+    }
+
+    /// This clock's instant as `(UTC wall clock, local offset in seconds)`.
+    ///
+    /// Both variants reduce to the same pair so the two calls above share one
+    /// conversion; `None` is [`Denied`](Self::Denied) or an unrepresentable
+    /// fixed instant.
+    fn instant(self) -> Option<(NaiveDateTime, i32)> {
+        match self {
+            Self::Denied => None,
+            Self::System => {
+                let now = Local::now();
+                Some((now.naive_utc(), now.offset().local_minus_utc()))
+            }
+            Self::Fixed {
+                unix_seconds,
+                microsecond,
+                local_offset_seconds,
+            } => {
+                let utc = DateTime::from_timestamp(unix_seconds, microsecond.checked_mul(1_000)?)?;
+                Some((utc.naive_utc(), local_offset_seconds))
+            }
+        }
+    }
+}
+
+/// Reads a UTC wall clock at `offset_seconds` from UTC, rejecting anything
+/// outside the 1..=9999 years Python's `datetime` can hold.
+fn shift(utc: NaiveDateTime, offset_seconds: i32) -> Option<NaiveDateTime> {
+    let shifted = utc.checked_add_signed(TimeDelta::seconds(i64::from(offset_seconds)))?;
+    (1..=9999).contains(&shifted.year()).then_some(shifted)
+}

--- a/crates/monty-types/src/clock.rs
+++ b/crates/monty-types/src/clock.rs
@@ -101,7 +101,12 @@ impl HostClock {
                 microsecond,
                 local_offset_seconds,
             } => {
-                let utc = DateTime::from_timestamp(unix_seconds, microsecond.checked_mul(1_000)?)?;
+                // Kept under a full second here rather than left to
+                // `from_timestamp`, which on the last second of a minute reads
+                // anything above one as a leap second and accepts it, yielding a
+                // `microsecond` no Python `datetime` can hold.
+                let nanoseconds = microsecond.checked_mul(1_000).filter(|ns| *ns < 1_000_000_000)?;
+                let utc = DateTime::from_timestamp(unix_seconds, nanoseconds)?;
                 Some((utc.naive_utc(), local_offset_seconds))
             }
         }

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -5,6 +5,7 @@ pub const MONTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod args;
 mod builtins;
+mod clock;
 mod exceptions;
 mod file_mode;
 pub mod format;
@@ -19,6 +20,7 @@ mod uuid;
 
 pub use crate::{
     builtins::BuiltinsFunctions,
+    clock::HostClock,
     exceptions::{
         CodeLoc, ExcData, ExcType, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject,
         unicode_decode_error_msg,

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -119,6 +119,7 @@ Async host functions are supported too: `FunctionCall::resume_pending` continues
 - `fs` module — mount real host directories into the sandbox at virtual paths (read-write, read-only, or copy-on-write in-memory overlay), with path resolution hardened against escapes.
 - `RunProgress::OsCall` — filesystem and other `os`-level operations the host can intercept or delegate.
 - `FunctionCall::object_id` and `NameLookup::object_id` — `Some(uuid)` when the suspension is a method call or lazy attribute lookup on a host object sent as `MontyObject::ClassInstance` / `MontyObject::Type`; the receiver is not in `args`.
+- `MontyRun::with_host_clock` / `MontyRepl::with_host_clock` — choose what `date.today()` and `datetime.now()` read on the non-suspending paths, which have no host to ask. `HostClock::System` (this machine's clock) unless changed; `Denied` takes it away, `Fixed` freezes an instant for reproducible runs.
 
 ## Monty crates
 

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -26,7 +26,7 @@ const MAGIC: &[u8; 6] = b"MONTY\0";
 /// rejected instead of decoding as their neighbour. That covers the
 /// interpreter's own types *and* everything reachable from [`Dump`] — notably
 /// [`TypeCheckingConfig`](monty_types::TypeCheckingConfig) in `monty-types`.
-pub const DUMP_VERSION: u16 = 8;
+pub const DUMP_VERSION: u16 = 9;
 
 /// Number of bytes before the postcard payload.
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u16>();

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -9,10 +9,12 @@
 //! cloned, so the cost of a feed depends on the snippet, not on how much the
 //! session has already run.
 
-use std::mem;
+use std::{mem, ops::ControlFlow};
 
 use ahash::AHashMap;
-use monty_types::{ExcType, MontyException, MontyObject, MontyUuid, OsFunctionCall, PrintWriter, ResourceTracker};
+use monty_types::{
+    ExcType, HostClock, MontyException, MontyObject, MontyUuid, OsFunctionCall, PrintWriter, ResourceTracker,
+};
 use ruff_python_ast::token::TokenKind;
 use ruff_python_parser::{InterpolatedStringErrorType, LexicalErrorType, ParseErrorType, parse_module};
 
@@ -27,7 +29,7 @@ use crate::{
     intern::Interns,
     name_map::NameMap,
     object_bridge::MontyObjectExt,
-    run::{CompileOptions, Executor},
+    run::{CompileOptions, Executor, default_clock},
     run_progress::{
         ConvertedExit, ExtFunctionResult, ExtFunctionResultExt, LookupAnswer, LookupScope, NameLookupResult,
         convert_frame_exit, resume_lookup,
@@ -74,6 +76,12 @@ pub struct MontyRepl {
     /// at construction so all snippets compile consistently.
     #[serde(default)]
     options: CompileOptions,
+    /// Clock serving `date.today()` / `datetime.now()` on the non-suspending
+    /// [`feed_run`](Self::feed_run) and [`call_function`](Self::call_function)
+    /// paths. The host's own unless changed; see
+    /// [`with_host_clock`](Self::with_host_clock).
+    #[serde(default = "default_clock")]
+    clock: HostClock,
     /// Persistent heap across snippets.
     heap: Heap,
     /// Persistent global variable values across snippets.
@@ -101,9 +109,23 @@ impl MontyRepl {
             interns: Interns::default(),
             sources: AHashMap::new(),
             options,
+            clock: default_clock(),
             heap,
             globals: Vec::new(),
         }
+    }
+
+    /// Chooses what `date.today()` and `datetime.now()` read, replacing the
+    /// [`System`](HostClock::System) clock a session starts with.
+    ///
+    /// Only the non-suspending [`feed_run`](Self::feed_run) and
+    /// [`call_function`](Self::call_function) consult it. Under
+    /// [`feed_start`](Self::feed_start) the host answers both calls itself, so
+    /// a clock set here is ignored.
+    #[must_use]
+    pub fn with_host_clock(mut self, clock: HostClock) -> Self {
+        self.clock = clock;
+        self
     }
 
     /// Injects `fault` into a compiled function's metadata.
@@ -262,7 +284,8 @@ impl MontyRepl {
             &mut self.interns,
             &input_names,
             self.options,
-        )?;
+        )?
+        .with_clock(self.clock);
 
         self.ensure_globals_size(executor.namespace_size());
 
@@ -337,7 +360,8 @@ impl MontyRepl {
             self.global_names.clone(),
             &mut self.interns,
             self.options,
-        )?;
+        )?
+        .with_clock(self.clock);
         self.sources.insert(input_script_name, executor.code.clone());
 
         let original_globals_len = self.globals.len();
@@ -376,10 +400,16 @@ impl MontyRepl {
                                 vm.push(value);
                                 vm.run_external()
                             }
-                            Ok(exit) => {
-                                let error = vm.unsupported_frame_exit("MontyRepl::call_function", exit);
-                                vm.resume_with_exception(error)
-                            }
+                            // A granted clock is the session's, not the entry
+                            // point's: `date.today()` / `datetime.now()` are
+                            // answered here exactly as `feed_run` answers them.
+                            Ok(exit) => match executor.resolve_clock_call(vm, exit) {
+                                ControlFlow::Continue(resumed) => resumed,
+                                ControlFlow::Break(exit) => {
+                                    let error = vm.unsupported_frame_exit("MontyRepl::call_function", exit);
+                                    vm.resume_with_exception(error)
+                                }
+                            },
                             Err(error) => {
                                 break Err(error.into_python_exception(&executor.interns, |fname| {
                                     self.sources.get(fname).map(String::as_str)

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -1,13 +1,14 @@
 //! Public interface for running Monty code.
 use std::{
     mem,
+    ops::ControlFlow,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
 };
 
-pub use monty_types::CompileOptions;
+pub use monty_types::{CompileOptions, HostClock};
 use monty_types::{ExcType, MontyException, MontyObject, PrintWriter, ResourceTracker};
 use ruff_python_stdlib::identifiers::is_identifier;
 
@@ -84,6 +85,44 @@ impl MontyRun {
     #[must_use]
     pub fn code(&self) -> &str {
         &self.executor.code
+    }
+
+    /// Chooses what `date.today()` and `datetime.now()` read, replacing the
+    /// [`System`](HostClock::System) clock a runner starts with.
+    ///
+    /// Only [`run`](Self::run) and [`run_no_limits`](Self::run_no_limits)
+    /// consult it: they have no host to suspend to. Under
+    /// [`start`](Self::start) the host answers both calls itself, so a clock
+    /// set here is ignored.
+    ///
+    /// Reading the wall clock is a capability, weak but real — it is what makes
+    /// elapsed time measurable from inside the sandbox, and it discloses the
+    /// host's UTC offset. [`Denied`](HostClock::Denied) takes it away;
+    /// [`Fixed`](HostClock::Fixed) freezes an instant, for runs that have to be
+    /// reproducible.
+    ///
+    /// ```
+    /// use monty::MontyRun;
+    /// use monty_types::{CompileOptions, HostClock, MontyObject};
+    ///
+    /// let runner = MontyRun::new(
+    ///     "from datetime import date\ndate.today().year".to_owned(),
+    ///     "today.py",
+    ///     vec![],
+    ///     CompileOptions::default(),
+    /// )
+    /// .unwrap()
+    /// .with_host_clock(HostClock::Fixed {
+    ///     unix_seconds: 1_700_000_000,
+    ///     microsecond: 0,
+    ///     local_offset_seconds: 0,
+    /// });
+    /// assert_eq!(runner.run_no_limits(vec![]).unwrap(), MontyObject::Int(2023));
+    /// ```
+    #[must_use]
+    pub fn with_host_clock(mut self, clock: HostClock) -> Self {
+        self.executor = self.executor.with_clock(clock);
+        self
     }
 
     /// Executes the code and returns both the result and reference count data, used for testing only.
@@ -211,6 +250,14 @@ pub(crate) struct Executor {
     /// UTF-8 byte cap for each operand repr in introspected assert messages.
     /// Stored with the compiled program and passed to every VM.
     pub(crate) assert_repr_max_bytes: u32,
+    /// Clock serving `date.today()` / `datetime.now()` on the non-suspending
+    /// path; `System` unless the embedder chose otherwise. The serde default
+    /// matches the constructors, so a host serializing this in a
+    /// self-describing format that omits the field gets the same clock a fresh
+    /// runner has; dumps are postcard, so adding this field bumped
+    /// `DUMP_VERSION`.
+    #[serde(default = "default_clock")]
+    pub(crate) clock: HostClock,
     /// Estimated heap capacity for pre-allocation on subsequent runs.
     /// Uses AtomicUsize for thread-safety (required by PyO3's Sync bound).
     heap_capacity: AtomicUsize,
@@ -225,6 +272,7 @@ impl Clone for Executor {
             code: self.code.clone(),
             input_slots: self.input_slots.clone(),
             assert_repr_max_bytes: self.assert_repr_max_bytes,
+            clock: self.clock,
             heap_capacity: AtomicUsize::new(self.heap_capacity.load(Ordering::Relaxed)),
         }
     }
@@ -263,6 +311,7 @@ impl Executor {
             code,
             input_slots: Vec::new(),
             assert_repr_max_bytes: options.assert_message_annotations.max_bytes(),
+            clock: default_clock(),
             heap_capacity: AtomicUsize::new(namespace_size),
         })
     }
@@ -271,6 +320,13 @@ impl Executor {
     #[inline]
     pub(crate) fn namespace_size(&self) -> usize {
         self.globals.len()
+    }
+
+    /// Replaces the clock serving `date.today()` / `datetime.now()`, so a
+    /// REPL snippet runs under its session's clock rather than the default.
+    pub(crate) fn with_clock(mut self, clock: HostClock) -> Self {
+        self.clock = clock;
+        self
     }
 
     /// Compiles one REPL snippet against the session's compiler tables.
@@ -327,6 +383,8 @@ impl Executor {
             code,
             input_slots,
             assert_repr_max_bytes: options.assert_message_annotations.max_bytes(),
+            // overwritten by `with_clock` from the owning `MontyRepl`
+            clock: HostClock::Denied,
             heap_capacity: AtomicUsize::new(0),
         })
     }
@@ -392,6 +450,8 @@ impl Executor {
             code,
             input_slots: vec![args_slot],
             assert_repr_max_bytes: options.assert_message_annotations.max_bytes(),
+            // overwritten by `with_clock` from the owning `MontyRepl`
+            clock: HostClock::Denied,
             heap_capacity: AtomicUsize::new(0),
         })
     }
@@ -443,8 +503,9 @@ impl Executor {
     ///
     /// Executes [`VM::run_module`], then answers the lookup and `ExternalCall`
     /// exits no host will serve by raising `NameError` / `AttributeError`
-    /// through the VM so tracebacks are properly captured. Finally converts
-    /// the result via [`frame_exit_to_object`].
+    /// through the VM so tracebacks are properly captured, and answers the
+    /// clock OS calls from [`Executor::clock`]. Finally converts the result via
+    /// [`frame_exit_to_object`].
     ///
     /// This is the shared non-iterative execution core used by both the standard
     /// `run` path and the REPL's `feed_run` path.
@@ -474,8 +535,48 @@ impl Executor {
                     let err = ExcType::name_error(name);
                     frame_exit_result = vm.resume_with_exception(err.into());
                 }
-                other => return frame_exit_to_object(other, vm),
+                // `date.today()` / `datetime.now()` with a clock granted are
+                // answered in-process; every other exit converts as before.
+                Ok(exit) => match self.resolve_clock_call(vm, exit) {
+                    ControlFlow::Continue(resumed) => frame_exit_result = resumed,
+                    ControlFlow::Break(exit) => return frame_exit_to_object(Ok(exit), vm),
+                },
+                err => return frame_exit_to_object(err, vm),
             }
+        }
+    }
+
+    /// Answers `date.today()` / `datetime.now()` from [`Executor::clock`], for
+    /// the execution paths that have no host loop to suspend to.
+    ///
+    /// `Continue` carries the exit the VM reached after the time was resumed
+    /// into it; `Break` hands the exit straight back, which is every OS call
+    /// the clock does not serve — including a clock call carrying a
+    /// `PendingOsEffect`, which these two never do. Callers keep their own
+    /// handling of the exits they get back, which differs between `run` and
+    /// `MontyRepl::call_function`.
+    pub(crate) fn resolve_clock_call(
+        &self,
+        vm: &mut VM<'_>,
+        exit: FrameExit,
+    ) -> ControlFlow<FrameExit, RunResult<FrameExit>> {
+        match exit {
+            FrameExit::OsCall {
+                function_call,
+                call_id,
+                effect: None,
+            } => match self.clock.resolve(&function_call) {
+                Some(result) => {
+                    function_call.drop_with(vm);
+                    ControlFlow::Continue(vm.resume(result))
+                }
+                None => ControlFlow::Break(FrameExit::OsCall {
+                    function_call,
+                    call_id,
+                    effect: None,
+                }),
+            },
+            other => ControlFlow::Break(other),
         }
     }
 
@@ -607,6 +708,17 @@ impl Executor {
         }
         Ok(())
     }
+}
+
+/// The clock a runner or REPL session starts with: the host's own.
+///
+/// Standard execution has no host loop to ask, so denying it by default would
+/// make ordinary date-handling scripts raise — which is the whole of
+/// [#330](https://github.com/pydantic/monty/issues/330). Embedders that do not
+/// want sandboxed code reading their wall clock pass
+/// [`HostClock::Denied`](monty_types::HostClock::Denied) explicitly.
+pub(crate) fn default_clock() -> HostClock {
+    HostClock::System
 }
 
 /// Converts module/frame exit results into plain `MontyObject` outputs.

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -95,28 +95,17 @@ impl MontyRun {
     /// [`start`](Self::start) the host answers both calls itself, so a clock
     /// set here is ignored.
     ///
-    /// Reading the wall clock is a capability, weak but real — it is what makes
-    /// elapsed time measurable from inside the sandbox, and it discloses the
-    /// host's UTC offset. [`Denied`](HostClock::Denied) takes it away;
-    /// [`Fixed`](HostClock::Fixed) freezes an instant, for runs that have to be
-    /// reproducible.
+    /// [`Denied`](HostClock::Denied) takes the clock away; [`Fixed`](HostClock::Fixed)
+    /// freezes an instant, for runs that have to be reproducible. Reading the
+    /// wall clock is a weak but real capability — see `docs/security.md`.
     ///
     /// ```
     /// use monty::MontyRun;
     /// use monty_types::{CompileOptions, HostClock, MontyObject};
     ///
-    /// let runner = MontyRun::new(
-    ///     "from datetime import date\ndate.today().year".to_owned(),
-    ///     "today.py",
-    ///     vec![],
-    ///     CompileOptions::default(),
-    /// )
-    /// .unwrap()
-    /// .with_host_clock(HostClock::Fixed {
-    ///     unix_seconds: 1_700_000_000,
-    ///     microsecond: 0,
-    ///     local_offset_seconds: 0,
-    /// });
+    /// let code = "from datetime import date\ndate.today().year".to_owned();
+    /// let clock = HostClock::Fixed { unix_seconds: 1_700_000_000, microsecond: 0, local_offset_seconds: 0 };
+    /// let runner = MontyRun::new(code, "today.py", vec![], CompileOptions::default()).unwrap().with_host_clock(clock);
     /// assert_eq!(runner.run_no_limits(vec![]).unwrap(), MontyObject::Int(2023));
     /// ```
     #[must_use]
@@ -251,11 +240,7 @@ pub(crate) struct Executor {
     /// Stored with the compiled program and passed to every VM.
     pub(crate) assert_repr_max_bytes: u32,
     /// Clock serving `date.today()` / `datetime.now()` on the non-suspending
-    /// path; `System` unless the embedder chose otherwise. The serde default
-    /// matches the constructors, so a host serializing this in a
-    /// self-describing format that omits the field gets the same clock a fresh
-    /// runner has; dumps are postcard, so adding this field bumped
-    /// `DUMP_VERSION`.
+    /// path; `System` unless the embedder chose otherwise.
     #[serde(default = "default_clock")]
     pub(crate) clock: HostClock,
     /// Estimated heap capacity for pre-allocation on subsequent runs.
@@ -383,7 +368,7 @@ impl Executor {
             code,
             input_slots,
             assert_repr_max_bytes: options.assert_message_annotations.max_bytes(),
-            // overwritten by `with_clock` from the owning `MontyRepl`
+            // Fail-closed placeholder; the owning `MontyRepl` overwrites it via `with_clock`.
             clock: HostClock::Denied,
             heap_capacity: AtomicUsize::new(0),
         })
@@ -450,7 +435,7 @@ impl Executor {
             code,
             input_slots: vec![args_slot],
             assert_repr_max_bytes: options.assert_message_annotations.max_bytes(),
-            // overwritten by `with_clock` from the owning `MontyRepl`
+            // Fail-closed placeholder; the owning `MontyRepl` overwrites it via `with_clock`.
             clock: HostClock::Denied,
             heap_capacity: AtomicUsize::new(0),
         })
@@ -549,12 +534,11 @@ impl Executor {
     /// Answers `date.today()` / `datetime.now()` from [`Executor::clock`], for
     /// the execution paths that have no host loop to suspend to.
     ///
-    /// `Continue` carries the exit the VM reached after the time was resumed
-    /// into it; `Break` hands the exit straight back, which is every OS call
-    /// the clock does not serve — including a clock call carrying a
-    /// `PendingOsEffect`, which these two never do. Callers keep their own
-    /// handling of the exits they get back, which differs between `run` and
-    /// `MontyRepl::call_function`.
+    /// `Continue` carries the exit the VM reached after resuming with the time.
+    /// `Break` hands back everything else: every non-`OsCall` exit, every OS
+    /// call that is not a clock call, and a clock call carrying a
+    /// `PendingOsEffect`, which these two never do. Callers handle those
+    /// themselves, differently in `run` and `MontyRepl::call_function`.
     pub(crate) fn resolve_clock_call(
         &self,
         vm: &mut VM<'_>,

--- a/crates/monty/tests/host_clock.rs
+++ b/crates/monty/tests/host_clock.rs
@@ -1,0 +1,249 @@
+//! [`HostClock`]: the opt-in clock that answers `date.today()` and
+//! `datetime.now()` on the non-suspending run paths.
+//!
+//! These can't live in `test_cases/`, which has no way to grant a clock and
+//! runs every fixture against a real CPython whose clock keeps moving. The
+//! expected values below were therefore diffed against CPython 3.14 by hand,
+//! not produced by Monty: naive `now()` and `today()` read local wall time,
+//! and `now(tz)` converts the instant into the argument. That conversion is
+//! new arithmetic here — under the OS-call path the host performs it, so
+//! `datetime__core.py` does not cover it.
+
+use insta::assert_snapshot;
+use monty::{Dump, MontyRepl, MontyRun, Session, SessionRef, dump};
+use monty_types::{CompileOptions, HostClock, MontyObject, ResourceTracker};
+
+/// 2023-11-14 22:13:20 UTC — the instant the datatest fixtures already freeze
+/// to, reused so both harnesses tell the same story.
+const FIXTURE_SECONDS: i64 = 1_700_000_000;
+
+/// A clock frozen at [`FIXTURE_SECONDS`] in a UTC+02:00 local zone, which puts
+/// the local date one day ahead of the UTC one.
+const FIXED: HostClock = HostClock::Fixed {
+    unix_seconds: FIXTURE_SECONDS,
+    microsecond: 123_456,
+    local_offset_seconds: 7_200,
+};
+
+/// Runs `code` under `clock` and returns its result.
+fn run(code: &str, clock: HostClock) -> Result<MontyObject, String> {
+    MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default())
+        .unwrap()
+        .with_host_clock(clock)
+        .run_no_limits(vec![])
+        .map_err(|err| err.to_string())
+}
+
+/// Runs a `datetime` expression under `clock` and returns its `repr()`.
+fn run_repr(expr: &str, clock: HostClock) -> String {
+    let code = format!("from datetime import date, datetime, timedelta, timezone\nrepr({expr})");
+    let obj = run(&code, clock).unwrap();
+    (&obj).try_into().unwrap()
+}
+
+/// A runner that was never given a clock still answers both calls: standard
+/// execution has no host to ask, so denying by default is what made ordinary
+/// date-handling scripts raise.
+#[test]
+fn the_host_clock_is_the_default() {
+    let code = "from datetime import date, datetime\n(date.today().year, datetime.now().year)";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let MontyObject::Tuple(years) = runner.run_no_limits(vec![]).unwrap() else {
+        panic!("expected a tuple of years");
+    };
+    for year in years {
+        let MontyObject::Int(year) = year else {
+            panic!("expected an int year");
+        };
+        assert!((2026..=2100).contains(&year), "implausible year {year}");
+    }
+}
+
+/// `Denied` is how an embedder takes the default clock away again.
+#[test]
+fn a_denied_clock_refuses_both_calls() {
+    assert_eq!(
+        run("from datetime import datetime\ndatetime.now()", HostClock::Denied).unwrap_err(),
+        "NotImplementedError: OS function 'datetime.now' not implemented with standard execution"
+    );
+    assert_eq!(
+        run("from datetime import date\ndate.today()", HostClock::Denied).unwrap_err(),
+        "NotImplementedError: OS function 'date.today' not implemented with standard execution"
+    );
+}
+
+#[test]
+fn fixed_clock_reads_local_wall_time() {
+    // 22:13:20 UTC + 2h, so both the time and the date roll over.
+    assert_eq!(
+        run_repr("datetime.now()", FIXED),
+        "datetime.datetime(2023, 11, 15, 0, 13, 20, 123456)"
+    );
+    assert_eq!(run_repr("date.today()", FIXED), "datetime.date(2023, 11, 15)");
+}
+
+#[test]
+fn fixed_clock_converts_into_the_requested_timezone() {
+    assert_eq!(
+        run_repr("datetime.now(timezone.utc)", FIXED),
+        "datetime.datetime(2023, 11, 14, 22, 13, 20, 123456, tzinfo=datetime.timezone.utc)"
+    );
+    assert_eq!(
+        run_repr("datetime.now(timezone(timedelta(hours=-5), 'EST'))", FIXED),
+        "datetime.datetime(2023, 11, 14, 17, 13, 20, 123456, \
+         tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=68400), 'EST'))"
+    );
+}
+
+/// An aware `now(tz)` and a naive one are the same instant, whatever the
+/// clock's own local offset is.
+#[test]
+fn aware_and_naive_agree_on_the_instant() {
+    let code = "from datetime import datetime, timezone\n\
+                (datetime.now(timezone.utc).hour - datetime.now().hour) % 24";
+    assert_eq!(run(code, FIXED).unwrap(), MontyObject::Int(22));
+}
+
+/// A fixed instant outside `datetime`'s 1..=9999 years is refused rather than
+/// producing an out-of-range value.
+#[test]
+fn unrepresentable_fixed_instant_reads_as_denied() {
+    let far_future = HostClock::Fixed {
+        unix_seconds: 300_000_000_000,
+        microsecond: 0,
+        local_offset_seconds: 0,
+    };
+    assert_eq!(
+        run("from datetime import date\ndate.today()", far_future).unwrap_err(),
+        "NotImplementedError: OS function 'date.today' not implemented with standard execution"
+    );
+}
+
+#[test]
+fn out_of_range_microsecond_reads_as_denied() {
+    // Nothing in `instant()` bounds this itself — `from_timestamp` rejects the
+    // nanoseconds it becomes, so this pins the behaviour the field documents
+    // against a chrono that might one day accept them as a leap second.
+    let overflowing = HostClock::Fixed {
+        unix_seconds: FIXTURE_SECONDS,
+        microsecond: 1_500_000,
+        local_offset_seconds: 0,
+    };
+    assert_eq!(
+        run("from datetime import datetime\ndatetime.now()", overflowing).unwrap_err(),
+        "NotImplementedError: OS function 'datetime.now' not implemented with standard execution"
+    );
+}
+
+#[test]
+fn system_clock_returns_a_plausible_now() {
+    // Written 2026; a system clock that reads before then is broken, not stale.
+    let code = "from datetime import date, datetime\n\
+                date.today() == datetime.now().date() and datetime.now().year >= 2026";
+    assert_eq!(run(code, HostClock::System).unwrap(), MontyObject::Bool(true));
+}
+
+/// The clock is a *standard execution* fallback: with a host loop present the
+/// call still reaches the host, which is what lets a host deny or fake it.
+#[test]
+fn iterative_execution_still_suspends() {
+    let runner = MontyRun::new(
+        "from datetime import date\ndate.today()".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap()
+    .with_host_clock(HostClock::System);
+
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), monty_types::PrintWriter::Disabled)
+        .unwrap();
+    let call = progress.into_os_call().expect("date.today() suspends to the host");
+    assert_eq!(call.function_call.name(), "date.today");
+}
+
+#[test]
+fn repl_sessions_take_a_clock_too() {
+    let mut repl =
+        MontyRepl::new("<test>", ResourceTracker::default(), CompileOptions::default()).with_host_clock(FIXED);
+    let result = repl
+        .feed_run(
+            "from datetime import date\nrepr(date.today())",
+            vec![],
+            monty_types::PrintWriter::Disabled,
+        )
+        .unwrap();
+    assert_eq!(result, MontyObject::String("datetime.date(2023, 11, 15)".to_owned()));
+}
+
+/// The clock is granted on the session, so which entry point runs the code
+/// must not change what the code can do.
+#[test]
+fn call_function_takes_the_session_clock_too() {
+    let mut repl =
+        MontyRepl::new("<test>", ResourceTracker::default(), CompileOptions::default()).with_host_clock(FIXED);
+    repl.feed_run(
+        "from datetime import date\ndef when():\n    return repr(date.today())",
+        vec![],
+        monty_types::PrintWriter::Disabled,
+    )
+    .unwrap();
+
+    let result = repl
+        .call_function("when", vec![], monty_types::PrintWriter::Disabled)
+        .unwrap();
+    assert_eq!(result, MontyObject::String("datetime.date(2023, 11, 15)".to_owned()));
+}
+
+/// A denied clock refuses through `call_function` too, as it does `feed_run`.
+#[test]
+fn call_function_honours_a_denied_clock_too() {
+    let mut repl = MontyRepl::new("<test>", ResourceTracker::default(), CompileOptions::default())
+        .with_host_clock(HostClock::Denied);
+    repl.feed_run(
+        "from datetime import date\ndef when():\n    return date.today()",
+        vec![],
+        monty_types::PrintWriter::Disabled,
+    )
+    .unwrap();
+
+    let err = repl
+        .call_function("when", vec![], monty_types::PrintWriter::Disabled)
+        .unwrap_err();
+    assert_snapshot!(err.to_string(), @r#"
+    Traceback (most recent call last):
+      File "<python-input-1>", line 1, in <module>
+        when()
+        ~~~~~~
+      File "<python-input-0>", line 3, in when
+        return date.today()
+               ~~~~~~~~~~~~
+    NotImplementedError: MontyRepl::call_function: OS function 'date.today' is not yet supported in this context
+    "#);
+}
+
+/// The clock is part of the serialized session, so a restored dump must still
+/// answer with it — a dropped field would silently turn a granted clock back
+/// into a denied one.
+#[test]
+fn a_granted_clock_survives_a_dump() {
+    let mut repl =
+        MontyRepl::new("<test>", ResourceTracker::default(), CompileOptions::default()).with_host_clock(FIXED);
+    repl.feed_run("x = 1", vec![], monty_types::PrintWriter::Disabled)
+        .unwrap();
+
+    let bytes = dump("<test>", None, SessionRef::Idle(&repl)).unwrap();
+    let Session::Idle(mut restored) = Dump::load(&bytes).unwrap().state else {
+        panic!("expected an idle session");
+    };
+
+    let result = restored
+        .feed_run(
+            "from datetime import date\nrepr(date.today())",
+            vec![],
+            monty_types::PrintWriter::Disabled,
+        )
+        .unwrap();
+    assert_eq!(result, MontyObject::String("datetime.date(2023, 11, 15)".to_owned()));
+}

--- a/crates/monty/tests/host_clock.rs
+++ b/crates/monty/tests/host_clock.rs
@@ -17,6 +17,11 @@ use monty_types::{CompileOptions, HostClock, MontyObject, ResourceTracker};
 /// to, reused so both harnesses tell the same story.
 const FIXTURE_SECONDS: i64 = 1_700_000_000;
 
+/// 2023-11-14 22:13:59 UTC, i.e. [`FIXTURE_SECONDS`] moved onto the last
+/// second of its minute — the only place chrono will read a microsecond past a
+/// full second as a leap second instead of rejecting it.
+const LAST_SECOND_OF_A_MINUTE: i64 = 1_700_000_039;
+
 /// A clock frozen at [`FIXTURE_SECONDS`] in a UTC+02:00 local zone, which puts
 /// the local date one day ahead of the UTC one.
 const FIXED: HostClock = HostClock::Fixed {
@@ -121,9 +126,6 @@ fn unrepresentable_fixed_instant_reads_as_denied() {
 
 #[test]
 fn out_of_range_microsecond_reads_as_denied() {
-    // Nothing in `instant()` bounds this itself — `from_timestamp` rejects the
-    // nanoseconds it becomes, so this pins the behaviour the field documents
-    // against a chrono that might one day accept them as a leap second.
     let overflowing = HostClock::Fixed {
         unix_seconds: FIXTURE_SECONDS,
         microsecond: 1_500_000,
@@ -131,6 +133,19 @@ fn out_of_range_microsecond_reads_as_denied() {
     };
     assert_eq!(
         run("from datetime import datetime\ndatetime.now()", overflowing).unwrap_err(),
+        "NotImplementedError: OS function 'datetime.now' not implemented with standard execution"
+    );
+
+    // On the last second of a minute chrono reads nanoseconds past a full
+    // second as a leap second and accepts them, so `from_timestamp` alone does
+    // not bound this — only `instant()`'s own check does.
+    let leap_second = HostClock::Fixed {
+        unix_seconds: LAST_SECOND_OF_A_MINUTE,
+        microsecond: 1_500_000,
+        local_offset_seconds: 0,
+    };
+    assert_eq!(
+        run("from datetime import datetime\ndatetime.now()", leap_second).unwrap_err(),
         "NotImplementedError: OS function 'datetime.now' not implemented with standard execution"
     );
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,20 @@ See [filesystem access](filesystem.md).
 
 CLI mounts always use the default per-mount memory limit of 100 MB; there is no flag to change it.
 
+## The clock
+
+`date.today()` and `datetime.now()` read the machine's clock and local timezone.
+
+```console
+$ monty -c "from datetime import datetime; print(datetime.now())"
+```
+
+An in-process Rust run reads the same clock; `MontyRun::with_host_clock` is how an embedder chooses otherwise, and the
+CLI has no flag for it.
+A sandbox driven through the pool is different: there both calls reach your `os=` handler (see
+[the clock](security.md#the-clock)).
+See [`limitations/datetime.md`](https://github.com/pydantic/monty/blob/main/limitations/datetime.md).
+
 ## Worker mode
 
 `monty subprocess` runs the binary as a wire-protocol child: framed protobuf requests on stdin, framed events on stdout.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,6 +63,7 @@ CLI mounts always use the default per-mount memory limit of 100 MB; there is no 
 
 ```console
 $ monty -c "from datetime import datetime; print(datetime.now())"
+2026-09-03 21:02:32.871568
 ```
 
 An in-process Rust run reads the same clock; `MontyRun::with_host_clock` is how an embedder chooses otherwise, and the

--- a/docs/limitations/datetime.md
+++ b/docs/limitations/datetime.md
@@ -78,9 +78,12 @@ and `MontyRepl::call_function` in Rust, and the `monty` CLI — has no host to
 ask and reads this machine's clock, so it matches CPython.
 `MontyRun::with_host_clock` / `MontyRepl::with_host_clock` choose otherwise:
 
-- `HostClock::Denied` makes both raise `NotImplementedError: OS function
-  'datetime.now' not implemented with standard execution` — a different
+- `HostClock::Denied` makes both raise `NotImplementedError` — a different
   exception from the suspend path's `RuntimeError` for the same refusal.
+  Through `MontyRun::run` and `MontyRepl::feed_run` the message is `OS
+  function 'datetime.now' not implemented with standard execution`; through
+  `MontyRepl::call_function` it is `MontyRepl::call_function: OS function
+  'datetime.now' is not yet supported in this context`.
 - `HostClock::Fixed` answers every call with one frozen instant, so
   `datetime.now() == datetime.now()` is `True`, a loop polling
   `datetime.now()` never sees it move, and `(datetime.now() - start)` is

--- a/docs/limitations/datetime.md
+++ b/docs/limitations/datetime.md
@@ -10,9 +10,13 @@ Constructor: `date(year, month, day)`.
 Attributes: `year`, `month`, `day`.
 Methods: `isoformat`, `strftime`, `replace`, `weekday`, `isoweekday`.
 
-Class methods `today()`, `fromisoformat()`, `fromisocalendar()`,
-`fromtimestamp()`, `fromordinal()` are not implemented. `today()` is
-missing because the sandbox has no access to the host clock.
+Class methods supported: `today()`, `fromisoformat()`.
+`fromisocalendar()`, `fromtimestamp()`, `fromordinal()` are not
+implemented. `strptime()`, added in CPython 3.14, is not implemented
+either.
+
+`today()` reads the clock, so it depends on the embedder granting one —
+see "Reading the clock" below.
 
 Constructor overflow wording on Windows: CPython's `i` converter goes
 through C `long`, which is 32 bits on Windows, so `date(2**40, 1, 1)`
@@ -37,12 +41,11 @@ Methods: `isoformat`, `strftime`, `replace`, `weekday`, `isoweekday`,
 Class methods supported: `now(tz=None)`, `strptime(date_string, format)`,
 `fromisoformat(date_string)`.
 
-- `now()` reaches the host for the current time (the only "live" datetime
-    call); it yields an external call.
+- `now()` reads the clock — see "Reading the clock" below.
 - `now(tz)` returns a `datetime` whose `tzinfo` is `==` the input timezone
     but not `is` it: the original `tzinfo` object isn't threaded through the
-    OS-call resume, so a fresh `timezone` is reconstructed from the
-    offset/name on the return path.
+    return path, so a fresh `timezone` is reconstructed from the
+    offset/name. This holds however the call is answered.
 - `utcnow()` (the deprecated class method) and `today()` are not
     implemented.
 - `combine()`, `fromtimestamp()`, `fromordinal()`, `utcfromtimestamp()`
@@ -57,6 +60,39 @@ Subclassing `datetime` is not possible, since there is no class inheritance
 keyword arguments** in Monty. CPython accepts positional args too
 (`d.replace(2025)` is valid in CPython 3.14). Calling with positionals
 in Monty raises `TypeError: replace expected at most 0 arguments, got N`.
+
+## Reading the clock
+
+`date.today()` and `datetime.now()` are the only two calls that read a
+clock, and Monty has none of its own. What answers them depends on how the
+sandbox is driven.
+
+Under the suspend/resume path — every pool session (`pydantic_monty`,
+`@pydantic/monty`, `monty-pool`) and `MontyRun::start` — both reach the
+host, and a host that answers neither makes them raise `RuntimeError:
+'date.today' is not supported in this environment` (`'datetime.now'`
+likewise), where CPython would return a time.
+
+Standard (non-suspending) execution — `MontyRun::run`, `MontyRepl::feed_run`
+and `MontyRepl::call_function` in Rust, and the `monty` CLI — has no host to
+ask and reads this machine's clock, so it matches CPython.
+`MontyRun::with_host_clock` / `MontyRepl::with_host_clock` choose otherwise:
+
+- `HostClock::Denied` makes both raise `NotImplementedError: OS function
+  'datetime.now' not implemented with standard execution` — a different
+  exception from the suspend path's `RuntimeError` for the same refusal.
+- `HostClock::Fixed` answers every call with one frozen instant, so
+  `datetime.now() == datetime.now()` is `True`, a loop polling
+  `datetime.now()` never sees it move, and `(datetime.now() - start)` is
+  always a zero `timedelta`. An instant outside `datetime`'s 1..=9999 years
+  reads as `Denied` rather than failing some other way.
+
+Whatever answers them, both calls read local wall time for `date.today()`
+and a naive `datetime.now()`, and convert into the argument for
+`datetime.now(tz)`, matching CPython.
+
+`time.time()` has no equivalent — the `time` module is not importable at
+all (see ./modules.md).
 
 ## `time`
 

--- a/docs/limitations/datetime.md
+++ b/docs/limitations/datetime.md
@@ -68,27 +68,29 @@ clock, and Monty has none of its own. What answers them depends on how the
 sandbox is driven.
 
 Under the suspend/resume path — every pool session (`pydantic_monty`,
-`@pydantic/monty`, `monty-pool`) and `MontyRun::start` — both reach the
-host, and a host that answers neither makes them raise `RuntimeError:
-'date.today' is not supported in this environment` (`'datetime.now'`
-likewise), where CPython would return a time.
+`@pydantic/monty`, `monty-pool`) and `MontyRun::start` — both reach the host.
+A host that answers neither makes them raise
+`RuntimeError: 'date.today' is not supported in this environment`
+(`'datetime.now'` likewise), where CPython would return a time.
 
 Standard (non-suspending) execution — `MontyRun::run`, `MontyRepl::feed_run`
-and `MontyRepl::call_function` in Rust, and the `monty` CLI — has no host to
-ask and reads this machine's clock, so it matches CPython.
+and `MontyRepl::call_function` in Rust — has no host to ask and reads this
+machine's clock, so it matches CPython. The `monty` CLI reads the same clock,
+though there it is the host answering: it serves both calls itself rather than
+passing them on.
 `MontyRun::with_host_clock` / `MontyRepl::with_host_clock` choose otherwise:
 
 - `HostClock::Denied` makes both raise `NotImplementedError` — a different
-  exception from the suspend path's `RuntimeError` for the same refusal.
-  Through `MontyRun::run` and `MontyRepl::feed_run` the message is `OS
-  function 'datetime.now' not implemented with standard execution`; through
-  `MontyRepl::call_function` it is `MontyRepl::call_function: OS function
-  'datetime.now' is not yet supported in this context`.
+    exception from the suspend path's `RuntimeError` for the same refusal.
+    Through `MontyRun::run` and `MontyRepl::feed_run` the message is
+    `OS function 'datetime.now' not implemented with standard execution`;
+    through `MontyRepl::call_function` it is
+    `MontyRepl::call_function: OS function 'datetime.now' is not yet supported in this context`.
 - `HostClock::Fixed` answers every call with one frozen instant, so
-  `datetime.now() == datetime.now()` is `True`, a loop polling
-  `datetime.now()` never sees it move, and `(datetime.now() - start)` is
-  always a zero `timedelta`. An instant outside `datetime`'s 1..=9999 years
-  reads as `Denied` rather than failing some other way.
+    `datetime.now() == datetime.now()` is `True`, a loop polling
+    `datetime.now()` never sees it move, and `(datetime.now() - start)` is
+    always a zero `timedelta`. An instant outside `datetime`'s 1..=9999 years
+    reads as `Denied` rather than failing some other way.
 
 Whatever answers them, both calls read local wall time for `date.today()`
 and a naive `datetime.now()`, and convert into the argument for

--- a/docs/quickstart/rust.md
+++ b/docs/quickstart/rust.md
@@ -180,6 +180,27 @@ let err = runner.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout).
 assert!(err.to_string().contains("time limit exceeded"));
 ```
 
+### Reading the clock
+
+`run` has no host to ask, so it answers `date.today()` and `datetime.now()` from a clock of its own — this machine's,
+unless you choose otherwise:
+
+```rust
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject, PrintWriter, ResourceTracker};
+
+let code = "from datetime import date\ndate.today().year";
+let runner = MontyRun::new(code.to_owned(), "today.py", vec![], CompileOptions::default()).unwrap();
+let year = runner.run(vec![], ResourceTracker::default(), PrintWriter::Stdout).unwrap();
+assert!(matches!(year, MontyObject::Int(y) if y >= 2026));
+```
+
+`with_host_clock` changes that: `HostClock::Denied` takes the clock away, for embedders who would rather sandboxed code
+could not read their wall time at all, and `HostClock::Fixed` freezes an instant, for runs that have to be reproducible.
+
+`start` ignores this: there the call pauses and the host answers it, like any other OS call, and the same is true of
+every pool session (see [the clock](../security.md#the-clock)).
+
 ### Host functions and pausing
 
 [`MontyRun::start`](../api/rust/monty.md#montyrun) returns a [`RunProgress`](../api/rust/monty.md#runprogress) that pauses whenever the sandboxed code calls a function the host provides.

--- a/docs/security.md
+++ b/docs/security.md
@@ -301,7 +301,7 @@ In-process Rust runs have no host loop to ask, so they read this machine's clock
 `HostClock::Fixed` for a frozen instant.
 
 Wall-clock time is a weak capability, but it is one — it is what makes elapsed time measurable from inside the sandbox,
-and it discloses the host's UTC offset, which is what a naive `datetime.now()` is read in.
+and a naive `datetime.now()` is read in the host's local zone, which discloses its UTC offset.
 
 ## Crash isolation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -285,6 +285,22 @@ Confinement is structural rather than checked:
 
 `/tmp`, `/etc`, `/proc`, `/dev`, `~` and the host working directory are not reachable unless you mount them.
 
+### The clock
+
+`date.today()` and `datetime.now()` are the only two calls that read a clock, and what answers them depends on how you
+run the sandbox.
+
+Through the pool — `pydantic_monty`, `@pydantic/monty`, or `monty-pool` — they reach your `os=` handler as OS calls like
+any other, so the sandbox reads no clock until you write a handler that gives it one, and a handler that answers neither
+makes both raise.
+
+In-process Rust runs have no host loop to ask, so they read this machine's clock, as the `monty` CLI does.
+`MontyRun::with_host_clock` changes that: `HostClock::Denied` if sandboxed code should not read your wall time at all,
+`HostClock::Fixed` for a frozen instant.
+
+Wall-clock time is a weak capability, but it is one — it is what makes elapsed time measurable from inside the sandbox,
+and it discloses the host's UTC offset, which is what a naive `datetime.now()` is read in.
+
 ## Crash isolation
 
 Monty runs in a subprocess, so an unexpected memory error or panic in the interpreter cannot kill the main process;

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,6 +23,8 @@ Concretely:
 - **There is no ambient authority.** With no mounts and no host functions configured, the sandbox cannot read a file,
     read an environment variable, open a socket, or spawn a process.
     Not "it is blocked" — the capability does not exist in the bytecode VM.
+    The wall clock is the one exception, and only for in-process Rust runs, which read it by default; see
+    [the clock](#the-clock).
 - **The interpreter performs no filesystem I/O at all.** It suspends with a description of the operation it wants, and a
     host component decides what to do about it.
     All filesystem code lives in a separate crate (`monty-fs`) that worker artifacts do not even link in some builds.


### PR DESCRIPTION
`date.today()` and `datetime.now()` are OS calls, so the paths with no host to ask could not answer them at all — that is [#330](https://github.com/pydantic/monty/issues/330), whose repro now works:

```console
$ monty -c "from datetime import datetime; print(datetime.now())"
2026-09-03 21:02:32.871568
```

Adds `HostClock`, an enum with variants:

1. `System` — this machine's clock, in its local timezone.
2. `Denied` — both calls raise, for embedders who would rather sandboxed code could not read their wall time.
3. `Fixed { unix_seconds, microsecond, local_offset_seconds }` — one frozen instant, for runs that have to be reproducible. There is no host callback on this path, so this is the only way to pin one.

How this affects runtimes:

| Runtime | Before | Current Default | Available Options |
| --- | --- | --- | --- |
| `MontyRun::run`, `MontyRepl::feed_run` / `call_function` | `NotImplementedError` | `System` | any variant, via `with_host_clock` |
| `monty` CLI | `NotImplementedError` | `System` | none — there is no flag |
| Pool session (Python, JavaScript, `monty-pool`) | the host's `os=` handler | unchanged — the host still answers | n/a — not part of the wire protocol |

Only standard execution consults the clock. `start`, `feed_start` and every pool session still surface both calls to the host, so the Python and JavaScript packages are unchanged.

`DUMP_VERSION` goes 8 → 9: `Executor` carries the field and postcard is not self-describing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5b91DLacG2pY8UZ1wNwZC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standard execution now answers `date.today()` and `datetime.now()` in-process instead of raising `NotImplementedError`, fixing #330. Adds a `HostClock` enum (`System`, `Denied`, `Fixed`) with `System` as the default and a `with_host_clock` setter on `MontyRun` and `MontyRepl`.

- `System` reads the machine's clock in its local timezone, matching CPython; the CLI uses it.
- `Denied` makes both calls raise; `Fixed` freezes one instant for reproducible runs.
- Suspend/resume paths (pool sessions, `start`) are unchanged — the host still answers those calls, and worker tests pin that both calls still bubble to the parent.
- `DUMP_VERSION` goes from 8 to 9 because `Executor` and `MontyRepl` serialize the clock field.
- Out-of-range `Fixed` microseconds read as `Denied`, and the clock is read only when a call is actually a clock call, so other OS calls don't pay for it.
- Docs now correct the `datetime` limitations list and note the clock as the one ambient-authority exception for in-process runs.

<sup>Written for commit 9a576d5e5ce9f2f0a72e37c499a69c618eb35adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

