### PR TITLE
Bump version to v0.0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "ahash",
  "chrono",
@@ -2445,14 +2445,14 @@ dependencies = [
 
 [[package]]
 name = "monty-alloc"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "monty-types",
 ]
 
 [[package]]
 name = "monty-apidoc"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "insta",
  "rustdoc-types",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "ahash",
  "chrono",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "monty-doctest"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "monty",
  "monty-pool",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fs"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "ahash",
  "cap-std",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "monty-pool",
  "monty-types",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "futures-util",
  "insta",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "insta",
  "monty",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "monty-types"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "chrono",
  "monty-macros",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "monty-alloc",
  "monty-proto",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty-client"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "ahash",
  "monty-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.21"
+version = "0.0.22"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -60,15 +60,15 @@ strip = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.21" }
-monty-types = { path = "crates/monty-types", version = "0.0.21" }
-monty-alloc = { path = "crates/monty-alloc", version = "0.0.21" }
-monty-fs = { path = "crates/monty-fs", version = "0.0.21" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.21" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.21" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.21" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.21" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.21" }
+monty = { path = "crates/monty", version = "0.0.22" }
+monty-types = { path = "crates/monty-types", version = "0.0.22" }
+monty-alloc = { path = "crates/monty-alloc", version = "0.0.22" }
+monty-fs = { path = "crates/monty-fs", version = "0.0.22" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.22" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.22" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.22" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.22" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.22" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.9"
 ruff_python_stdlib = "0.0.9"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "^0.19.0"
@@ -32,11 +32,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.21",
-        "@pydantic/monty-darwin-x64": "0.0.21",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.21",
-        "@pydantic/monty-linux-x64-gnu": "0.0.21",
-        "@pydantic/monty-win32-x64-msvc": "0.0.21"
+        "@pydantic/monty-darwin-arm64": "0.0.22",
+        "@pydantic/monty-darwin-x64": "0.0.22",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.22",
+        "@pydantic/monty-linux-x64-gnu": "0.0.22",
+        "@pydantic/monty-win32-x64-msvc": "0.0.22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3417,90 +3417,19 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.21.tgz",
-      "integrity": "sha512-Awo+F3nRN6yswwUlaiD+rQHOYcPEQsO6mnMp2kPYPpjGc94qwE5+1RA+P+KMQtgt8bR8vTn3hktFk8HSvXuyEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.21.tgz",
-      "integrity": "sha512-DCuK8VsSJ+ojHiNGKX4UhlX3ieMW4SMl/KhIiZ/jd8bsksILZioV1T77OkqL02epJkM2DiXMmPRb/g4Q+CRUNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.21.tgz",
-      "integrity": "sha512-RvFQPBqXA093OreVcTEV0vtQYItdyFvRjJZrv76urbhVhybaOlhTo+2X75Z3LmEkOyJI5Qij/rKGeNeuGiM2YQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.21.tgz",
-      "integrity": "sha512-HZ6cg641Ag/uxLaSi8jfWvoB2RSJTWinTv94Hj7+DJy/Ax1YyvXOUpREIwfztbvRR9KVIibFVrKjXhpw8ZRotg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.21.tgz",
-      "integrity": "sha512-BnKIbwllixx1NgsDFWbRPtc7ldlMpwZ1/Q+9JxrrHcbyos0f4O33FHGjn8o+EAG/YthGRSLoXkXWOpTtXL61ZA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -97,10 +97,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.21",
-    "@pydantic/monty-darwin-arm64": "0.0.21",
-    "@pydantic/monty-linux-x64-gnu": "0.0.21",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.21",
-    "@pydantic/monty-win32-x64-msvc": "0.0.21"
+    "@pydantic/monty-darwin-x64": "0.0.22",
+    "@pydantic/monty-darwin-arm64": "0.0.22",
+    "@pydantic/monty-linux-x64-gnu": "0.0.22",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.22",
+    "@pydantic/monty-win32-x64-msvc": "0.0.22"
   }
 }

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -21,7 +21,7 @@ pub mod worker;
 /// or repurposing a field, changing a field's meaning, or adding one the child
 /// requires. Purely additive changes an older peer can ignore do not need a
 /// bump.
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Oldest [`PROTOCOL_VERSION`] this build still serves.
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 2;
@@ -39,20 +39,24 @@ pub fn check_protocol_version(version: u32) -> Result<(), String> {
     if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
         Ok(())
     } else {
-        Err(format!(
-            "unsupported protocol version {version} ({})",
-            supported_versions()
-        ))
-    }
-}
+        // Singular while the window is one version wide — "2 to 2" reads as a range it is not.
+        // `let`-bound so the `format_args!` temporaries live long enough to be formatted below.
+        // use "server" since this error should only ever happen when using a client/server architecture
+        let supported = if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
+            format_args!("server supports protocol version {PROTOCOL_VERSION}")
+        } else {
+            format_args!("server supports protocol versions {MIN_SUPPORTED_PROTOCOL_VERSION} to {PROTOCOL_VERSION}")
+        };
 
-/// Names [`SUPPORTED_PROTOCOL_VERSIONS`] for the refusal above, singular while
-/// the window is one version wide — "1 to 1" reads as a range it is not.
-fn supported_versions() -> String {
-    if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
-        format!("this build supports protocol version {PROTOCOL_VERSION}")
-    } else {
-        format!("this build supports protocol versions {MIN_SUPPORTED_PROTOCOL_VERSION} to {PROTOCOL_VERSION}")
+        // Points the reader at the client for the refusal above: the worker is typically a deployed build the
+        // reader cannot change, so the client is the half to move.
+        let tip = if version < MIN_SUPPORTED_PROTOCOL_VERSION {
+            "try updating to a newer client version"
+        } else {
+            "make sure you are using the correct client version"
+        };
+
+        Err(format!("unsupported protocol version {version} ({supported}, {tip})"))
     }
 }
 

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -1454,6 +1454,11 @@ fn unsupported_protocol_version_on_create_is_a_fatal_error() {
         message.contains(&supported),
         "message should name the supported range: {message}"
     );
+    // Ahead of the range, so the client is on the wrong version rather than behind.
+    assert!(
+        message.contains("make sure you are using the correct client version."),
+        "message should point at the client version: {message}"
+    );
 }
 
 /// Zero means the parent declared nothing — it predates the field, or is not a
@@ -1469,6 +1474,11 @@ fn undeclared_protocol_version_is_a_fatal_error() {
     assert!(
         message.contains("unsupported protocol version 0"),
         "message should name the rejected version: {message}"
+    );
+    // Below the range, so the client needs to move forward.
+    assert!(
+        message.contains("try updating to a newer version of the client."),
+        "message should tell the client to update: {message}"
     );
 }
 

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -1446,9 +1446,9 @@ fn unsupported_protocol_version_on_create_is_a_fatal_error() {
     // Spelled out rather than taken from `check_protocol_version`, so rewording
     // the refusal a parent actually reads fails here.
     let supported = if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
-        format!("this build supports protocol version {PROTOCOL_VERSION}")
+        format!("server supports protocol version {PROTOCOL_VERSION}")
     } else {
-        format!("this build supports protocol versions {MIN_SUPPORTED_PROTOCOL_VERSION} to {PROTOCOL_VERSION}")
+        format!("server supports protocol versions {MIN_SUPPORTED_PROTOCOL_VERSION} to {PROTOCOL_VERSION}")
     };
     assert!(
         message.contains(&supported),
@@ -1456,7 +1456,7 @@ fn unsupported_protocol_version_on_create_is_a_fatal_error() {
     );
     // Ahead of the range, so the client is on the wrong version rather than behind.
     assert!(
-        message.contains("make sure you are using the correct client version."),
+        message.contains("make sure you are using the correct client version"),
         "message should point at the client version: {message}"
     );
 }
@@ -1477,7 +1477,7 @@ fn undeclared_protocol_version_is_a_fatal_error() {
     );
     // Below the range, so the client needs to move forward.
     assert!(
-        message.contains("try updating to a newer version of the client."),
+        message.contains("try updating to a newer client version"),
         "message should tell the client to update: {message}"
     );
 }

--- a/packages/pydantic-monty/pyproject.toml
+++ b/packages/pydantic-monty/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 ]
 # version and both pins are rewritten from the Cargo workspace version by
 # `crates/monty-python/build.rs` — don't edit them by hand
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
-    "pydantic-monty-client==0.0.21",
-    "pydantic-monty-runtime==0.0.21",
+    "pydantic-monty-client==0.0.22",
+    "pydantic-monty-runtime==0.0.22",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1658,7 +1658,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.21"
+version = "0.0.22"
 source = { editable = "packages/pydantic-monty" }
 dependencies = [
     { name = "pydantic-monty-client" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepares the v0.0.22 release, bumping workspace, npm, and Python package versions from 0.0.21 to 0.0.22. Also rolls the protocol version from 3 back to 2, so peers on protocol 3 are now rejected.

**Refactors**
- Rewrote the unsupported-protocol error to name the server and point at the client, suggesting an update when the client is behind or a version check when it is ahead.
- Extended subprocess tests to assert the new error wording.

<sup>Written for commit 3b9d4e6ba06ba4be8312f8caba7d75e58133f779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

