### PR TITLE
Define snapshotting on the alternatives page and fix the #813 review findings

### DIFF
--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -17,16 +17,23 @@ Most were not conceived as an LLM sandbox, which is why they are not necessarily
 
 The chart is the time to create a sandbox and then run ten REPL commands in it; both halves are measured below.
 
-| Tech               | Language completeness      | Security             | Start latency                | FOSS       | Setup complexity | File mounting  | Snapshotting |
-| ------------------ | -------------------------- | -------------------- | ---------------------------- | ---------- | ---------------- | -------------- | ------------ |
-| Monty              | partial                    | strict               | 0.08 ms warm pool, 5 ms cold | free / OSS | easy             | easy           | easy         |
-| Full Monty         | partial, or full via proxy | strict, OS-level too | 2 ms warm, 4 ms cold         | not free   | easy             | easy           | easy         |
-| Docker             | full                       | good                 | 195 ms                       | free / OSS | intermediate     | easy           | intermediate |
-| Pyodide            | full                       | poor                 | 2700 ms                      | free / OSS | intermediate     | easy           | hard         |
-| starlark-rust      | very limited               | good                 | 1.3 ms                       | free / OSS | easy             | not available? | impossible?  |
-| WASI / wasmtime    | partial, almost full       | strict               | 16 ms                        | free / OSS | intermediate     | easy           | intermediate |
-| sandboxing service | full                       | strict               | 1500 ms                      | not free   | intermediate     | hard           | intermediate |
-| YOLO Python        | full                       | non-existent         | 0.1 ms / 30 ms               | free / OSS | easy             | easy / scary   | hard         |
+| Tech               | Language completeness      | Security          | Start latency           | FOSS       | Setup        | File mounting  | Snapshotting                |
+| ------------------ | -------------------------- | ----------------- | ----------------------- | ---------- | ------------ | -------------- | --------------------------- |
+| Monty              | partial                    | strict            | 0.08 ms warm, 5 ms cold | free / OSS | easy         | easy           | interpreter, kilobytes      |
+| Full Monty         | partial, or full via proxy | strict + OS-level | 2 ms warm, 4 ms cold    | not free   | easy         | easy           | interpreter, kilobytes      |
+| Docker             | full                       | good              | 195 ms                  | free / OSS | intermediate | easy           | CRIU image, experimental    |
+| Pyodide            | full                       | poor              | 2700 ms                 | free / OSS | intermediate | easy           | no                          |
+| starlark-rust      | very limited               | good              | 1.3 ms                  | free / OSS | easy         | not available? | no                          |
+| WASI / wasmtime    | partial, almost full       | strict            | 16 ms                   | free / OSS | intermediate | easy           | no                          |
+| sandboxing service | full                       | strict            | 1500 ms                 | not free   | intermediate | hard           | VM memory image, 100s of MB |
+| YOLO Python        | full                       | non-existent      | 0.1 ms / 30 ms          | free / OSS | easy         | easy / scary   | no                          |
+
+Snapshotting means pausing code mid-execution, serialising its state, and resuming it later, possibly elsewhere or
+more than once.
+Only an interpreter built for it can do that at the interpreter level; a microVM can do it for its whole memory, at
+a thousand times the size, and without knowing what the paused code was waiting for.
+Durable-execution frameworks such as Temporal are not snapshotting: they replay a workflow written for them, which a
+script a model just wrote is not.
 
 Start latency is the time from requesting a sandbox to receiving the result of `1 + 1`.
 The agent run below is ten REPL commands against a sandbox that already exists.
@@ -84,7 +91,7 @@ The tables round the numbers; the measured cold-start values are in the text bel
     not Docker Desktop's port-forwarding proxy.
     Cold start creates the client pool and opens the WebSocket connection, on which the server spawns a worker for the
     session, then checks out a session and runs `1 + 1`; the median of 7 runs is 3.5 ms.
-    The second row is the median of 20 further `checkout()` + `feed_run()` round trips on that client pool, at 1.6 ms;
+    The client-pool row is the median of 20 further `checkout()` + `feed_run()` round trips on that pool, at 1.6 ms;
     each is a new connection and a new worker, because the server never lets one process serve two clients.
     The worker spawns inside the Linux container, where Monty's own cold start measures 2.4 ms against 4.5 ms on
     macOS, so the Full Monty rows are not directly comparable with the macOS rows above.
@@ -132,7 +139,8 @@ The tables round the numbers; the measured cold-start values are in the text bel
 - **Start latency**: a warm checkout is one message to a worker that already exists; a cold start spawns the worker.
 - **Setup complexity**: `pip install pydantic-monty` or `npm install @pydantic/monty`, about 4.5 MB download.
 - **File mounting**: strictly controlled, see [filesystem access](filesystem.md).
-- **Snapshotting**: `feed_start()` and `dump()` pause, resume and fork execution.
+- **Snapshotting**: `feed_start()` pauses at a host call and `dump()` serialises the interpreter, paused call stack
+    included, to a few kilobytes; restore it once to resume, or several times to fork.
     See [snapshots](snapshots.md).
 
 ## Full Monty
@@ -160,8 +168,8 @@ The tables round the numbers; the measured cold-start values are in the text bel
 - **Setup complexity**: requires the Docker daemon, container images and orchestration; `python:3.14-alpine` is 50 MB
     and Docker cannot be installed from PyPI.
 - **File mounting**: volume mounts work well.
-- **Snapshotting**: possible with durable execution solutions like Temporal, or by snapshotting a container and saving
-    it as an image.
+- **Snapshotting**: not of a running process, except experimentally with CRIU on Linux; committing a container to an
+    image saves its filesystem, not its execution state.
 
 ## Pyodide
 
@@ -173,7 +181,7 @@ The tables round the numbers; the measured cold-start values are in the text bel
 - **Setup complexity**: load the WASM runtime and handle async initialisation; the Pyodide npm package is about 12 MB
     and Deno about 50 MB, so Pyodide cannot be used with PyPI packages alone.
 - **File mounting**: virtual filesystem via browser APIs.
-- **Snapshotting**: presumably possible with durable execution solutions like Temporal, but hard.
+- **Snapshotting**: no; a running Pyodide heap has no serialised form.
 
 ## starlark-rust
 
@@ -184,7 +192,7 @@ See [starlark-rust](https://github.com/facebook/starlark-rust).
 - **Start latency**: runs embedded in the process; 1.3 ms for the first evaluation, around 0.01 ms after that.
 - **Setup complexity**: usable from Python via [starlark-pyo3](https://github.com/inducer/starlark-pyo3).
 - **File mounting**: no file handling by design, as far as we know.
-- **Snapshotting**: impossible, as far as we know.
+- **Snapshotting**: no.
 
 ## WASI / wasmtime
 
@@ -203,7 +211,7 @@ CPython compiled to WebAssembly (WASI), run by [wasmtime](https://wasmtime.dev/)
 - **Setup complexity**: `pip install wasmtime` plus a CPython WASI build, a 13 MB download that unpacks to about 54 MB
     with the standard library; you manage the module, its precompilation and the stdlib directory yourself.
 - **File mounting**: preopened directories.
-- **Snapshotting**: not built in; a paused interpreter cannot be serialised, and pre-initialisation tools like
+- **Snapshotting**: no; a paused interpreter cannot be serialised, and pre-initialisation tools like
     [Wizer](https://github.com/bytecodealliance/wizer) only snapshot a module before it starts running.
 
 ## Sandboxing service
@@ -220,8 +228,9 @@ latency.
 - **FOSS**: pay per execution or compute time; some implementations are open source.
 - **Setup complexity**: API integration and auth tokens; fine for startups but often a non-starter for enterprises.
 - **File mounting**: upload and download via API calls.
-- **Snapshotting**: possible with durable execution solutions like Temporal; the services also offer their own
-    solutions, generally based on container snapshots.
+- **Snapshotting**: a microVM's whole memory can be paused and saved, which E2B and Modal offer as pause and resume;
+    it is hundreds of megabytes, takes hundreds of milliseconds or more, is tied to the host's CPU and kernel, and
+    the host cannot see what the paused code was waiting for.
 
 ## YOLO Python
 
@@ -232,4 +241,4 @@ Running Python directly via `exec()` (about 0.1 ms) or a subprocess (about 30 ms
 - **Start latency**: near zero for `exec()`, about 30 ms for a subprocess.
 - **Setup complexity**: none.
 - **File mounting**: direct filesystem access, which is the problem.
-- **Snapshotting**: possible with durable execution solutions like Temporal.
+- **Snapshotting**: no; `pickle` can save the globals between blocks, which is a session dump, not a paused frame.

--- a/docs/img/startup-latency.svg
+++ b/docs/img/startup-latency.svg
@@ -17,10 +17,10 @@
 <text x='670.0' y='272' text-anchor='middle' fill='#8a8f98' font-size='12' font-family='ui-sans-serif, system-ui, sans-serif'>3,000 ms</text>
 <text x='140' y='59.4' text-anchor='end' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>Monty</text>
 <rect x='150' y='44' width='2.0' height='22' rx='3' fill='#e520e9'/>
-<text x='160.0' y='59.4' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>5 ms</text>
+<text x='160.0' y='59.4' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>4.9 ms</text>
 <text x='140' y='93.4' text-anchor='end' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>Full Monty</text>
 <rect x='150' y='78' width='2.0' height='22' rx='3' fill='#e520e9'/>
-<text x='160.0' y='93.4' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>7 ms</text>
+<text x='160.0' y='93.4' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>7.4 ms</text>
 <text x='140' y='127.4' text-anchor='end' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>WASI / wasmtime</text>
 <rect x='150' y='112' width='34.7' height='22' rx='3' fill='#7c8592'/>
 <text x='192.7' y='127.4' fill='#8a8f98' font-size='14' font-family='ui-sans-serif, system-ui, sans-serif'>200 ms</text>

--- a/scripts/startup_latency_chart.py
+++ b/scripts/startup_latency_chart.py
@@ -15,8 +15,8 @@ from pathlib import Path
 # (label, milliseconds, is_monty): cold start plus a warm agent run of 10 REPL
 # commands, the "Combined" column of the table in docs/index.md
 ROWS: list[tuple[str, float, bool]] = [
-    ('Monty', 5, True),
-    ('Full Monty', 7, True),
+    ('Monty', 4.9, True),
+    ('Full Monty', 7.4, True),
     ('WASI / wasmtime', 200, False),
     ('Docker', 900, False),
     ('Sandboxing service', 1900, False),
@@ -95,8 +95,8 @@ def x_for(ms: float) -> float:
 
 
 def fmt_ms(ms: float) -> str:
-    """`0.08 ms`, `7 ms`, `2,800 ms`: no trailing zeros, thousands separated."""
-    if ms < 1:
+    """`0.08 ms`, `4.9 ms`, `16 ms`, `2,800 ms`: a decimal only below 10 ms, thousands separated."""
+    if ms < 10:
         return f'{ms:g} ms'
     return f'{ms:,.0f} ms'
 

--- a/scripts/startup_performance.py
+++ b/scripts/startup_performance.py
@@ -463,6 +463,9 @@ def selected(name: str) -> bool:
 
 
 if __name__ == '__main__':
+    names = sorted({name for name, _ in MEASUREMENTS + AGENT_MEASUREMENTS})
+    if unknown := sorted(set(sys.argv[1:]) - set(names)):
+        sys.exit(f'unknown measurement {", ".join(unknown)}; choose from {", ".join(names)}')
     for name, measure in MEASUREMENTS:
         if selected(name):
             measure()


### PR DESCRIPTION
Follow-up to #813.

**Snapshotting column on the alternatives page.** It mixed three unrelated things under one word. The column now says what each setup can actually serialise: the interpreter (kilobytes) for Monty and Full Monty, a whole microVM memory image (hundreds of MB, host-tied, opaque) for a sandboxing service, CRIU for Docker, and nothing for Pyodide, WASI, starlark-rust and YOLO Python. A definition sits under the table, and the Temporal mentions are gone: durable execution replays a workflow written for it, which a script a model just wrote is not.

**The three open review findings on #813:**

- The chart rounded Monty and Full Monty to 5 ms and 7 ms while the table beside it said 4.90 ms and 7.40 ms. `ROWS` now carries 4.9 and 7.4 and `fmt_ms` keeps one decimal below 10 ms, so the labels read 4.9 ms and 7.4 ms. README's "5 ms" is the rounded prose figure and is unchanged.
- `scripts/startup_performance.py` ran nothing and exited 0 on a misspelled measurement name; it now exits 1 listing the valid names.
- The Full Monty measurement prose called the 1.6 ms figure "the second row" when it is the first; it now says "the client-pool row".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXjM4nojQQwqqDkPazkx8M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines what snapshotting means on the alternatives page and fixes the three open review findings from #813.

- The Snapshotting column now says what each setup can actually serialise: the interpreter for Monty and Full Monty, a microVM memory image for the sandboxing service, CRIU for Docker, and nothing for the rest.
- Durable-execution frameworks like Temporal are no longer described as snapshotting; a definition under the table explains why.
- The chart labels now read 4.9 ms and 7.4 ms to match the table, `fmt_ms` keeps one decimal below 10 ms, and README's rounded prose figure is unchanged.
- `scripts/startup_performance.py` exits 1 and lists valid names when given an unknown measurement name instead of silently running nothing.
- The Full Monty prose now calls the 1.6 ms figure "the client-pool row" instead of "the second row".

<sup>Written for commit c5192a12c6e163b1faadc0b5ed44de15c21950bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

