### PR TITLE
Support `print(file=sys.stderr)`

### DIFF
--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -43,6 +43,18 @@ test('batched into fewer callbacks than prints', async () => {
   t.true(output.length < 100, `expected far fewer callbacks than prints, got ${output.length}`)
 })
 
+test('stderr is labelled, and keeps its place in the output', async () => {
+  const received: [string, string][] = []
+  await run("import sys\nprint('a')\nprint('b', file=sys.stderr)\nprint('c')", {
+    printCallback: (stream, text) => received.push([stream, text]),
+  })
+  t.deepEqual(received, [
+    ['stdout', 'a\n'],
+    ['stderr', 'b\n'],
+    ['stdout', 'c\n'],
+  ])
+})
+
 test('a zero flush interval delivers one callback per line', async () => {
   const { output, callback } = makePrintCollector()
   await run('for i in range(20):\n    print(i)', { printCallback: callback, printFlushInterval: 0 })

--- a/crates/monty-js/__test__/wasm_print.spec.ts
+++ b/crates/monty-js/__test__/wasm_print.spec.ts
@@ -1,0 +1,26 @@
+// One `Print` event can carry runs from both streams, which the worker
+// expands into one callback per run. Over the wasm transport that expansion
+// happens inside the component, so the labels are worth checking there too.
+
+import { test } from 'vitest'
+
+import { t } from './assertions.js'
+import { skipIfBrowser } from './env.js'
+import { Monty } from '@pydantic/monty/wasm'
+
+test('stdout and stderr keep their labels and order over the wasm transport', async (ctx) => {
+  skipIfBrowser(ctx)
+  await using pool = await Monty.create()
+  await using session = await pool.checkout({})
+
+  const received: [string, string][] = []
+  await session.feedRun("import sys\nprint('a')\nprint('b', file=sys.stderr)\nprint('c')", {
+    printCallback: (stream, text) => received.push([stream, text]),
+  })
+
+  t.deepEqual(received, [
+    ['stdout', 'a\n'],
+    ['stderr', 'b\n'],
+    ['stdout', 'c\n'],
+  ])
+})

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -1273,25 +1273,29 @@ impl Checkout {
             }
             match event.kind {
                 Some(pb::child_event::Kind::Print(print)) => {
-                    let stream = match print.stream() {
-                        pb::PrintStream::Stderr => PrintStream::Stderr,
-                        pb::PrintStream::Stdout | pb::PrintStream::Unspecified => PrintStream::Stdout,
-                    };
                     #[cfg(feature = "telemetry")]
                     let context = self.callback_context();
-                    let future = {
+                    // One event can carry several runs: hand each to the host
+                    // in order, so the callback shape stays per-stream.
+                    for segment in &print.segments {
+                        let stream = match segment.stream() {
+                            pb::PrintStream::Stderr => PrintStream::Stderr,
+                            pb::PrintStream::Stdout | pb::PrintStream::Unspecified => PrintStream::Stdout,
+                        };
+                        let future = {
+                            #[cfg(feature = "telemetry")]
+                            let _context = context.has_active_span().then(|| context.clone().attach());
+                            on_print(stream, &segment.text)
+                        };
                         #[cfg(feature = "telemetry")]
-                        let _context = context.has_active_span().then(|| context.clone().attach());
-                        on_print(stream, &print.text)
-                    };
-                    #[cfg(feature = "telemetry")]
-                    if context.has_active_span() {
-                        future.with_context(context).await;
-                    } else {
+                        if context.has_active_span() {
+                            future.with_context(context.clone()).await;
+                        } else {
+                            future.await;
+                        }
+                        #[cfg(not(feature = "telemetry"))]
                         future.await;
                     }
-                    #[cfg(not(feature = "telemetry"))]
-                    future.await;
                 }
                 Some(pb::child_event::Kind::FunctionCall(call)) => {
                     self.pending = Some(Pending::Call {

--- a/crates/monty-pool/src/telemetry/metrics.rs
+++ b/crates/monty-pool/src/telemetry/metrics.rs
@@ -556,11 +556,17 @@ impl TurnMetrics {
             self.reported_micros = self.reported_micros.max(event.total_execution_micros);
         }
         match &event.kind {
-            Some(pb::child_event::Kind::Print(p)) => self.metrics.record(
-                &PRINT_BYTES,
-                MetricValue::bytes(p.text.len()),
-                &[KeyValue::new("stream", print_stream(p.stream))],
-            ),
+            Some(pb::child_event::Kind::Print(p)) => {
+                // One sample per run rather than per event: a run is the
+                // largest span of output that has a single stream to name.
+                for segment in &p.segments {
+                    self.metrics.record(
+                        &PRINT_BYTES,
+                        MetricValue::bytes(segment.text.len()),
+                        &[KeyValue::new("stream", print_stream(segment.stream))],
+                    );
+                }
+            }
             Some(pb::child_event::Kind::FunctionCall(_)) => self.suspend(SuspensionKind::FunctionCall),
             Some(pb::child_event::Kind::OsCall(c)) => self.suspend(SuspensionKind::OsCall(os_call(c.call.as_ref()))),
             Some(pb::child_event::Kind::NameLookup(_)) => self.suspend(SuspensionKind::NameLookup),

--- a/crates/monty-pool/src/telemetry/metrics.rs
+++ b/crates/monty-pool/src/telemetry/metrics.rs
@@ -557,14 +557,18 @@ impl TurnMetrics {
         }
         match &event.kind {
             Some(pb::child_event::Kind::Print(p)) => {
-                // One sample per run rather than per event: a run is the
-                // largest span of output that has a single stream to name.
-                for segment in &p.segments {
-                    self.metrics.record(
-                        &PRINT_BYTES,
-                        MetricValue::bytes(segment.text.len()),
-                        &[KeyValue::new("stream", print_stream(segment.stream))],
-                    );
+                // One measurement per stream rather than per run: the
+                // instrument is a counter, so the totals sum identically, and a
+                // sandbox alternating the streams starts a run per fragment.
+                let totals = print_bytes_by_stream(&p.segments);
+                for (stream, bytes) in PRINT_STREAM_NAMES.into_iter().zip(totals) {
+                    if bytes > 0 {
+                        self.metrics.record(
+                            &PRINT_BYTES,
+                            MetricValue::bytes(bytes),
+                            &[KeyValue::new("stream", stream)],
+                        );
+                    }
                 }
             }
             Some(pb::child_event::Kind::FunctionCall(_)) => self.suspend(SuspensionKind::FunctionCall),
@@ -795,13 +799,26 @@ fn os_call(call: Option<&Call>) -> &'static str {
     }
 }
 
-/// The name of a `PrintStream` enum value.
-fn print_stream(stream: i32) -> &'static str {
-    match pb::PrintStream::try_from(stream) {
-        Ok(pb::PrintStream::Stdout) => "stdout",
-        Ok(pb::PrintStream::Stderr) => "stderr",
-        _ => "unspecified",
+/// The stream names a print measurement can be labelled with, in the order
+/// [`print_bytes_by_stream`] totals them.
+///
+/// An unrecognised value keeps its own total rather than folding into stdout,
+/// so a stream added to the protocol later cannot quietly inflate one.
+const PRINT_STREAM_NAMES: [&str; 3] = ["stdout", "stderr", "unspecified"];
+
+/// Totals one `Print` event's text bytes per stream, indexed into
+/// [`PRINT_STREAM_NAMES`].
+fn print_bytes_by_stream(segments: &[pb::PrintSegment]) -> [usize; 3] {
+    let mut totals = [0usize; 3];
+    for segment in segments {
+        let index = match pb::PrintStream::try_from(segment.stream) {
+            Ok(pb::PrintStream::Stdout) => 0,
+            Ok(pb::PrintStream::Stderr) => 1,
+            _ => 2,
+        };
+        totals[index] = totals[index].saturating_add(segment.text.len());
     }
+    totals
 }
 // tests live here rather than in `tests/` because `TurnMetrics` is
 // crate-private: recording is a side effect of the worker, not part of the
@@ -810,7 +827,7 @@ fn print_stream(stream: i32) -> &'static str {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::{Arc, Barrier},
+        sync::{Arc, Barrier, Mutex, PoisonError},
         thread,
         time::Duration,
     };
@@ -818,13 +835,20 @@ mod tests {
     use logfire::{Logfire, config::MetricsOptions};
     use monty_proto::{WireFunctionCall, pb, pb::os_call::Call};
     use monty_types::MontyObject;
-    use opentelemetry::KeyValue;
-    use opentelemetry_sdk::metrics::{
-        InMemoryMetricExporter, PeriodicReader,
-        data::{AggregatedMetrics, MetricData},
+    use opentelemetry::{
+        KeyValue,
+        trace::{SpanId, TraceId},
+    };
+    use opentelemetry_sdk::{
+        logs::SdkLogRecord,
+        metrics::{
+            InMemoryMetricExporter, PeriodicReader,
+            data::{AggregatedMetrics, MetricData},
+        },
+        trace::SpanData,
     };
 
-    use super::{Metrics, TurnMetrics};
+    use super::{Measurement, MetricValue, Metrics, TelemetryAdapter, TurnMetrics, print_bytes_by_stream};
 
     /// A cumulative aggregate exported from the test's Logfire provider.
     struct Capture {
@@ -967,6 +991,43 @@ mod tests {
     }
 
     /// A recorder writing into a fresh local Logfire provider.
+    /// A foreign-SDK adapter that keeps every raw measurement, so a test can
+    /// count them — the aggregated exporter only ever shows their sum.
+    #[derive(Default)]
+    struct MeasurementCapture(Mutex<Vec<(String, String, i64)>>);
+
+    impl TelemetryAdapter for MeasurementCapture {
+        fn start_span(&self, _: &SpanData) -> bool {
+            true
+        }
+
+        fn end_span(&self, _: &SpanData) -> bool {
+            true
+        }
+
+        fn emit_log(&self, _: SpanId, _: &SdkLogRecord) -> bool {
+            true
+        }
+
+        fn disable_root(&self, _: TraceId, _: SpanId) {}
+
+        fn record_metric(&self, measurement: &Measurement<'_>) {
+            let stream = measurement
+                .attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == "stream")
+                .map_or_else(String::new, |kv| kv.value.to_string());
+            let value = match measurement.value {
+                MetricValue::I64(value) => value,
+                other @ MetricValue::F64(_) => panic!("{} recorded {other:?}", measurement.name),
+            };
+            self.0
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push((measurement.name.to_owned(), stream, value));
+        }
+    }
+
     fn recorder() -> (TurnMetrics, Arc<Capture>) {
         let exporter = InMemoryMetricExporter::default();
         let logfire = logfire::configure()
@@ -1114,6 +1175,59 @@ mod tests {
             .map(|attributes| attribute(attributes, "outcome").unwrap().to_owned())
             .collect();
         assert_eq!(outcomes, ["error", "not_found", "value"]);
+    }
+
+    /// A sandbox that alternates between the streams starts a segment per
+    /// fragment, so recording one measurement per segment would let it charge
+    /// the host a measurement per byte. The instrument is a counter, so the
+    /// per-stream totals carry the same numbers at one measurement per stream.
+    #[test]
+    fn a_print_event_records_one_measurement_per_stream() {
+        let alternating: Vec<pb::PrintSegment> = (0..64)
+            .map(|i| pb::PrintSegment {
+                stream: if i % 2 == 0 {
+                    pb::PrintStream::Stdout as i32
+                } else {
+                    pb::PrintStream::Stderr as i32
+                },
+                text: "a".to_owned(),
+            })
+            .collect();
+        assert_eq!(print_bytes_by_stream(&alternating), [32, 32, 0]);
+
+        let capture = Arc::new(MeasurementCapture::default());
+        let mut metrics = TurnMetrics::new(Metrics::for_adapter(capture.clone()));
+        metrics.begin_turn(&feed());
+        metrics.event(&event(pb::child_event::Kind::Print(pb::Print {
+            segments: alternating,
+        })));
+
+        let recorded = capture.0.lock().unwrap_or_else(PoisonError::into_inner).clone();
+        assert_eq!(
+            recorded,
+            [
+                ("monty.print.bytes".to_owned(), "stdout".to_owned(), 32),
+                ("monty.print.bytes".to_owned(), "stderr".to_owned(), 32),
+            ]
+        );
+    }
+
+    /// A stream that printed nothing gets no measurement, so an unrecognised
+    /// value cannot mint a series for output that never happened.
+    #[test]
+    fn a_print_event_skips_streams_with_no_output() {
+        let capture = Arc::new(MeasurementCapture::default());
+        let mut metrics = TurnMetrics::new(Metrics::for_adapter(capture.clone()));
+        metrics.begin_turn(&feed());
+        metrics.event(&event(pb::child_event::Kind::Print(pb::Print {
+            segments: vec![pb::PrintSegment {
+                stream: pb::PrintStream::Stdout as i32,
+                text: "hello\n".to_owned(),
+            }],
+        })));
+
+        let recorded = capture.0.lock().unwrap_or_else(PoisonError::into_inner).clone();
+        assert_eq!(recorded, [("monty.print.bytes".to_owned(), "stdout".to_owned(), 6)]);
     }
 
     /// An os call is the one suspension that names what it did — from the

--- a/crates/monty-pool/src/telemetry/tracing.rs
+++ b/crates/monty-pool/src/telemetry/tracing.rs
@@ -268,14 +268,18 @@ impl Recorder {
         }
         match &event.kind {
             Some(pb::child_event::Kind::Print(p)) => {
-                let (text, cut) = truncate_str(&p.text);
-                logfire::info!(
-                    parent: self.context_span(),
-                    "print {stream}",
-                    stream = print_stream(p.stream),
-                    text = text,
-                    length_limit_exceeded = cut.then_some(true),
-                );
+                // One record per run rather than per event: a run is the
+                // largest span of output that has a single stream to name.
+                for segment in &p.segments {
+                    let (text, cut) = truncate_str(&segment.text);
+                    logfire::info!(
+                        parent: self.context_span(),
+                        "print {stream}",
+                        stream = print_stream(segment.stream),
+                        text = text,
+                        length_limit_exceeded = cut.then_some(true),
+                    );
+                }
             }
             Some(pb::child_event::Kind::FunctionCall(c)) => {
                 let (args, kwargs, args_cut) = render_call_arguments(c);

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -628,11 +628,23 @@ enum PrintStream {
   PRINT_STREAM_STDERR = 2;
 }
 
-// Streamed sandbox print() output. Zero or more of these precede each
-// turn-ending event; text is flushed at line granularity.
-message Print {
+// One run of print() output on a single stream, as one `Print` event may
+// carry several.
+message PrintSegment {
   PrintStream stream = 1;
   string text = 2;
+}
+
+// Streamed sandbox print() output. Zero or more of these precede each
+// turn-ending event, and each carries the runs the worker had buffered, in
+// the order the sandbox produced them — so output alternating between the
+// streams batches into one event without losing that order.
+message Print {
+  // 1 and 2 were the single stream and text this event carried before it
+  // could hold more than one run.
+  reserved 1, 2;
+  reserved "stream", "text";
+  repeated PrintSegment segments = 3;
 }
 
 // Suspension: the sandbox called an external function, or — when `object_id`

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -665,14 +665,23 @@ pub mod child_event {
         Shutdown(super::ShutdownDump),
     }
 }
-/// Streamed sandbox print() output. Zero or more of these precede each
-/// turn-ending event; text is flushed at line granularity.
+/// One run of print() output on a single stream, as one `Print` event may
+/// carry several.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct Print {
+pub struct PrintSegment {
     #[prost(enumeration = "PrintStream", tag = "1")]
     pub stream: i32,
     #[prost(string, tag = "2")]
     pub text: ::prost::alloc::string::String,
+}
+/// Streamed sandbox print() output. Zero or more of these precede each
+/// turn-ending event, and each carries the runs the worker had buffered, in
+/// the order the sandbox produced them — so output alternating between the
+/// streams batches into one event without losing that order.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Print {
+    #[prost(message, repeated, tag = "3")]
+    pub segments: ::prost::alloc::vec::Vec<PrintSegment>,
 }
 /// Suspension: the sandbox performed an OS operation, surfaced for the parent
 /// to service (e.g. from a mount) or answer with `ResumeCall`. One typed arm

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -21,10 +21,13 @@ pub mod worker;
 /// or repurposing a field, changing a field's meaning, or adding one the child
 /// requires. Purely additive changes an older peer can ignore do not need a
 /// bump.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Oldest [`PROTOCOL_VERSION`] this build still serves.
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 2;
+///
+/// Version 2 is not served: its `Print` event carried a single stream and
+/// text, which this build no longer emits or reads.
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 3;
 
 /// How long the child holds buffered `print()` output before emitting it as a
 /// `Print` event, when [`pb::Configure::print_flush_interval_ms`] says nothing.

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -26,7 +26,7 @@ use monty::{Dump, MontyRepl, ReplProgress, ReplStartError, Session, SessionRef, 
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
     AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, OsFunctionCall,
-    PrintWriter, PrintWriterCallback, ResourceLimits, ResourceTracker, TypeCheckState, TypeCheckingConfig,
+    PrintStream, PrintWriter, PrintWriterCallback, ResourceLimits, ResourceTracker, TypeCheckState, TypeCheckingConfig,
 };
 
 use super::{
@@ -1082,10 +1082,17 @@ fn named_inputs(inputs: Vec<pb::NamedValue>) -> Result<Vec<(String, MontyObject)
 /// what one large print costs. [`Self::drain`] empties the buffer before every
 /// turn-ending event, so ordering against suspensions stays exact.
 ///
+/// Output on both streams shares the buffer, held as one segment per run, so
+/// alternating between them batches like any other output and still reaches
+/// the parent in the order the sandbox produced it.
+///
 /// A zero `interval` disables the timer and restores line buffering, one event
 /// per completed line.
 struct ProtoPrint<'a> {
-    buf: String,
+    /// Buffered output, one segment per run on a single stream.
+    segments: Vec<pb::PrintSegment>,
+    /// Text bytes held across `segments`, so the size check stays O(1).
+    buffered_bytes: usize,
     sink: &'a mut dyn EventSink,
     /// How long the oldest buffered byte may wait; zero means line buffering.
     interval: Duration,
@@ -1099,45 +1106,62 @@ impl<'a> ProtoPrint<'a> {
 
     fn new(sink: &'a mut dyn EventSink, interval: Duration) -> Self {
         Self {
-            buf: String::new(),
+            segments: Vec::new(),
+            buffered_bytes: 0,
             sink,
             interval,
             buffered_since: None,
         }
     }
 
-    /// Writes the buffer (if any) as one `Print` event.
+    /// Writes everything buffered (if anything) as one `Print` event.
     fn flush(&mut self) -> Result<(), MontyException> {
-        if self.buf.is_empty() {
+        if self.segments.is_empty() {
             return Ok(());
         }
         self.buffered_since = None;
-        let text = mem::take(&mut self.buf);
-        self.send(text)
+        self.buffered_bytes = 0;
+        let segments = mem::take(&mut self.segments);
+        self.send(segments)
     }
 
     /// Emits one `Print` event per completed line, leaving any trailing
     /// partial line buffered. With the timer off the contract is one event per
     /// completed line, so a single write carrying embedded newlines has to be
-    /// split rather than shipped whole.
+    /// split rather than shipped whole; a line spanning a stream switch keeps
+    /// its runs together in one event.
     fn flush_lines(&mut self) -> Result<(), MontyException> {
-        while let Some(end) = self.buf.find('\n') {
-            let rest = self.buf.split_off(end + 1);
-            let line = mem::replace(&mut self.buf, rest);
+        while let Some((index, end)) = self.first_line_end() {
+            let mut line: Vec<pb::PrintSegment> = self.segments.drain(..index).collect();
+            let rest = self.segments[0].text.split_off(end);
+            line.push(pb::PrintSegment {
+                stream: self.segments[0].stream,
+                text: mem::replace(&mut self.segments[0].text, rest),
+            });
+            if self.segments[0].text.is_empty() {
+                self.segments.remove(0);
+            }
+            self.buffered_bytes -= line.iter().map(|segment| segment.text.len()).sum::<usize>();
             self.send(line)?;
         }
-        if self.buf.is_empty() {
+        if self.segments.is_empty() {
             self.buffered_since = None;
         }
         Ok(())
     }
 
-    /// Sends `text` as one `Print` event.
-    fn send(&mut self, text: String) -> Result<(), MontyException> {
-        let event = event(pb::child_event::Kind::Print(pb::Print {
-            stream: pb::PrintStream::Stdout.into(),
-            text,
-        }));
+    /// Where the first buffered line ends: the segment holding the `\n`, and
+    /// the offset just past it. `None` while no line is complete.
+    fn first_line_end(&self) -> Option<(usize, usize)> {
+        self.segments
+            .iter()
+            .enumerate()
+            .find_map(|(index, segment)| segment.text.find('\n').map(|at| (index, at + 1)))
+    }
+
+    /// Sends `segments` as one `Print` event.
+    fn send(&mut self, segments: Vec<pb::PrintSegment>) -> Result<(), MontyException> {
+        let event = event(pb::child_event::Kind::Print(pb::Print { segments }));
         self.sink.send(&event).map_err(|err| {
             MontyException::new(
                 ExcType::RuntimeError,
@@ -1155,7 +1179,7 @@ impl<'a> ProtoPrint<'a> {
         if self.interval.is_zero() {
             self.flush_lines()?;
         }
-        if self.buf.len() >= Self::FLUSH_BYTES || (!self.interval.is_zero() && self.interval_elapsed()) {
+        if self.buffered_bytes >= Self::FLUSH_BYTES || (!self.interval.is_zero() && self.interval_elapsed()) {
             self.flush()
         } else {
             Ok(())
@@ -1182,35 +1206,72 @@ impl<'a> ProtoPrint<'a> {
     fn drain(&mut self) {
         let _ = self.flush();
     }
-}
 
-impl PrintWriterCallback for ProtoPrint<'_> {
-    fn stdout_write(&mut self, output: Cow<'_, str>) -> Result<(), MontyException> {
+    /// Buffers `text`, extending the trailing segment while it is on the same
+    /// stream and starting a new one when the stream changes.
+    fn append(&mut self, stream: PrintStream, text: &str) {
+        self.mark_buffered();
+        self.buffered_bytes += text.len();
+        let stream = wire_stream(stream);
+        match self.segments.last_mut() {
+            Some(segment) if segment.stream == stream => segment.text.push_str(text),
+            _ => self.segments.push(pb::PrintSegment {
+                stream,
+                text: text.to_owned(),
+            }),
+        }
+    }
+
+    fn write(&mut self, stream: PrintStream, output: &str) -> Result<(), MontyException> {
         // Append in pieces no larger than the flush threshold so a single huge
         // write cannot inflate the buffer (and the untracked copy it holds)
         // past `FLUSH_BYTES`: each filled chunk is flushed before the next is
         // appended.
-        let mut rest = output.as_ref();
+        let mut rest = output;
         while !rest.is_empty() {
-            let take = floor_char_boundary(rest, Self::FLUSH_BYTES - self.buf.len());
+            let take = floor_char_boundary(rest, Self::FLUSH_BYTES - self.buffered_bytes);
             if take == 0 {
                 // not even one char fits in the remaining room; flush to free
                 // the whole threshold (far larger than any single char)
                 self.flush()?;
                 continue;
             }
-            self.mark_buffered();
-            self.buf.push_str(&rest[..take]);
+            self.append(stream, &rest[..take]);
             rest = &rest[take..];
             self.maybe_flush()?;
         }
         Ok(())
     }
 
-    fn stdout_push(&mut self, end: char) -> Result<(), MontyException> {
-        self.mark_buffered();
-        self.buf.push(end);
+    fn push(&mut self, stream: PrintStream, end: char) -> Result<(), MontyException> {
+        self.append(stream, end.encode_utf8(&mut [0; 4]));
         self.maybe_flush()
+    }
+}
+
+/// Maps the interpreter's stream tag onto its wire enum value.
+fn wire_stream(stream: PrintStream) -> i32 {
+    match stream {
+        PrintStream::Stdout => i32::from(pb::PrintStream::Stdout),
+        PrintStream::Stderr => i32::from(pb::PrintStream::Stderr),
+    }
+}
+
+impl PrintWriterCallback for ProtoPrint<'_> {
+    fn stdout_write(&mut self, output: Cow<'_, str>) -> Result<(), MontyException> {
+        self.write(PrintStream::Stdout, &output)
+    }
+
+    fn stdout_push(&mut self, end: char) -> Result<(), MontyException> {
+        self.push(PrintStream::Stdout, end)
+    }
+
+    fn stderr_write(&mut self, output: Cow<'_, str>) -> Result<(), MontyException> {
+        self.write(PrintStream::Stderr, &output)
+    }
+
+    fn stderr_push(&mut self, end: char) -> Result<(), MontyException> {
+        self.push(PrintStream::Stderr, end)
     }
 
     /// Releases output the program stopped writing to: without this a script

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -53,6 +53,11 @@ fn split_turn(bytes: &[u8]) -> (Vec<pb::Print>, pb::child_event::Kind) {
 }
 
 fn create_repl(child: &mut Child) {
+    create_repl_with_flush_interval(child, None);
+}
+
+/// `create_repl`, naming the print flush interval the session runs with.
+fn create_repl_with_flush_interval(child: &mut Child, print_flush_interval_ms: Option<u32>) {
     let request = frame_request(pb::parent_request::Kind::Configure(pb::Configure {
         script_name: "main.py".to_owned(),
         limits: None,
@@ -61,6 +66,7 @@ fn create_repl(child: &mut Child) {
         assert_message_annotations: None,
         monty_version: MONTY_VERSION.to_owned(),
         protocol_version: PROTOCOL_VERSION,
+        print_flush_interval_ms,
         ..Default::default()
     }));
     let (bytes, outcome) = dispatch_frame(child, &request);
@@ -80,6 +86,21 @@ fn feed(child: &mut Child, code: &str) -> (Vec<pb::Print>, pb::child_event::Kind
     let (bytes, outcome) = dispatch_frame(child, &request);
     assert_eq!(outcome, HandleOutcome::Continue);
     split_turn(&bytes)
+}
+
+/// The runs each `Print` event carried, as `(stream, text)` per event, so a
+/// test can assert both what was batched together and in what order.
+fn segments_per_event(prints: &[pb::Print]) -> Vec<Vec<(pb::PrintStream, &str)>> {
+    prints
+        .iter()
+        .map(|print| {
+            print
+                .segments
+                .iter()
+                .map(|segment| (segment.stream(), segment.text.as_str()))
+                .collect()
+        })
+        .collect()
 }
 
 fn expect_complete(event: pb::child_event::Kind) -> MontyObject {
@@ -120,9 +141,78 @@ fn print_output_is_streamed_before_the_terminator() {
     create_repl(&mut child);
 
     let (prints, event) = feed(&mut child, "print('hello'); print('world')");
-    let streamed: String = prints.into_iter().map(|print| print.text).collect();
+    let streamed: String = prints
+        .into_iter()
+        .flat_map(|print| print.segments)
+        .map(|segment| segment.text)
+        .collect();
     assert_eq!(streamed, "hello\nworld\n");
     assert_eq!(expect_complete(event), MontyObject::None);
+}
+
+/// Output alternating between the streams batches into one event, holding a
+/// segment per run: the worker never has to flush to change stream, so the
+/// debounce applies to mixed output as much as to plain stdout.
+#[test]
+fn alternating_streams_batch_into_one_event() {
+    let mut child = Child::default();
+    // an interval no test will wait out leaves the flush to `drain`, so this
+    // asserts how output is segmented rather than how the timer fires
+    create_repl_with_flush_interval(&mut child, Some(60_000));
+
+    let (prints, event) = feed(
+        &mut child,
+        "import sys\nprint('a')\nprint('b', file=sys.stderr)\nprint('c')",
+    );
+    assert_eq!(expect_complete(event), MontyObject::None);
+    assert_eq!(
+        segments_per_event(&prints),
+        vec![vec![
+            (pb::PrintStream::Stdout, "a\n"),
+            (pb::PrintStream::Stderr, "b\n"),
+            (pb::PrintStream::Stdout, "c\n"),
+        ]]
+    );
+}
+
+/// With the timer off, a completed line still ends the event whichever stream
+/// wrote it, so a host that asked for line buffering gets one event per line.
+#[test]
+fn line_buffering_gives_each_line_its_own_event() {
+    let mut child = Child::default();
+    create_repl_with_flush_interval(&mut child, Some(0));
+
+    let (prints, event) = feed(&mut child, "import sys\nprint('a')\nprint('b', file=sys.stderr)");
+    assert_eq!(expect_complete(event), MontyObject::None);
+    assert_eq!(
+        segments_per_event(&prints),
+        vec![
+            vec![(pb::PrintStream::Stdout, "a\n")],
+            vec![(pb::PrintStream::Stderr, "b\n")],
+        ]
+    );
+}
+
+/// A line the sandbox wrote across both streams is one line, so line buffering
+/// ships the runs it spans in one event rather than cutting at the switch. The
+/// trailing partial line waits for the drain at the end of the turn.
+#[test]
+fn line_buffering_keeps_a_line_spanning_the_streams_together() {
+    let mut child = Child::default();
+    create_repl_with_flush_interval(&mut child, Some(0));
+
+    let (prints, event) = feed(
+        &mut child,
+        "import sys\nprint('out', end='')\nprint('err', file=sys.stderr)\nprint('next', end='')",
+    );
+    assert_eq!(expect_complete(event), MontyObject::None);
+    assert_eq!(
+        segments_per_event(&prints),
+        vec![
+            vec![(pb::PrintStream::Stdout, "out"), (pb::PrintStream::Stderr, "err\n")],
+            vec![(pb::PrintStream::Stdout, "next")],
+        ]
+    );
 }
 
 #[test]

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -763,14 +763,23 @@ pub mod child_event {
         Shutdown(super::ShutdownDump),
     }
 }
-/// Streamed sandbox print() output. Zero or more of these precede each
-/// turn-ending event; text is flushed at line granularity.
+/// One run of print() output on a single stream, as one `Print` event may
+/// carry several.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct Print {
+pub struct PrintSegment {
     #[prost(enumeration = "PrintStream", tag = "1")]
     pub stream: i32,
     #[prost(string, tag = "2")]
     pub text: ::prost::alloc::string::String,
+}
+/// Streamed sandbox print() output. Zero or more of these precede each
+/// turn-ending event, and each carries the runs the worker had buffered, in
+/// the order the sandbox produced them — so output alternating between the
+/// streams batches into one event without losing that order.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Print {
+    #[prost(message, repeated, tag = "3")]
+    pub segments: ::prost::alloc::vec::Vec<PrintSegment>,
 }
 /// Suspension: the sandbox called an external function, or — when `object_id`
 /// is set — a method on a host-backed object (the receiver is NOT included in

--- a/crates/monty-python/src/print_target.rs
+++ b/crates/monty-python/src/print_target.rs
@@ -22,7 +22,10 @@
 use std::sync::{Arc, Mutex, PoisonError};
 
 use monty_proto::python::exc_py_to_monty;
-use monty_types::{DEFAULT_MAX_PRINT_COLLECT_BYTES, MontyException, PrintStream, check_print_collect_limit};
+use monty_types::{
+    COLLECT_STREAMS_ENTRY_OVERHEAD, DEFAULT_MAX_PRINT_COLLECT_BYTES, MontyException, PrintStream,
+    check_print_collect_limit,
+};
 use pyo3::{
     PyRef,
     exceptions::PyTypeError,
@@ -32,12 +35,6 @@ use pyo3::{
 };
 
 use crate::callback_context::{self, CallbackContext};
-
-/// Host bytes charged per retained `(stream, text)` entry beyond the payload.
-///
-/// `String` / `Vec` bookkeeping is not free: many tiny prints can exhaust the
-/// host long before payload bytes hit the cap. Charged toward `max_bytes`.
-const COLLECT_STREAMS_ENTRY_OVERHEAD: usize = 64;
 
 /// Shared collect-streams state: labelled fragments plus optional byte cap.
 #[derive(Debug)]

--- a/crates/monty-python/tests/test_print.py
+++ b/crates/monty-python/tests/test_print.py
@@ -268,6 +268,56 @@ list(map(print, [1, 2, 3]))
     assert ''.join(output) == snapshot('1\n2\n3\n')
 
 
+# === print(file=sys.stderr) ===
+
+
+def test_print_file_stderr_is_labelled(monty_run: RunMonty) -> None:
+    collector = CollectStreams()
+
+    monty_run('import sys\nprint("out")\nprint("err", file=sys.stderr)', print_callback=collector)
+
+    assert collector.output == snapshot([('stdout', 'out\n'), ('stderr', 'err\n')])
+
+
+def test_print_streams_are_not_reordered(monty_run: RunMonty) -> None:
+    """The worker buffers a run per stream in order, so a switch cannot reorder output."""
+    collector = CollectStreams()
+
+    code = 'import sys\nfor i in range(3):\n    print(i)\n    print(i, file=sys.stderr)'
+    monty_run(code, print_callback=collector)
+
+    assert collector.output == snapshot(
+        [
+            ('stdout', '0\n'),
+            ('stderr', '0\n'),
+            ('stdout', '1\n'),
+            ('stderr', '1\n'),
+            ('stdout', '2\n'),
+            ('stderr', '2\n'),
+        ]
+    )
+
+
+def test_print_file_callback_receives_stderr(monty_run: RunMonty) -> None:
+    received: list[tuple[str, str]] = []
+
+    def callback(stream: Literal['stdout', 'stderr'], text: str) -> None:
+        received.append((stream, text))
+
+    monty_run('import sys\nprint("warning", file=sys.stderr)', print_callback=callback)
+
+    assert received == snapshot([('stderr', 'warning\n')])
+
+
+def test_print_file_unsupported_object(monty_run: RunMonty) -> None:
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run('print("x", file=42)')
+
+    assert str(exc_info.value) == snapshot(
+        "TypeError: print() 'file' argument must be sys.stdout or sys.stderr, not int"
+    )
+
+
 # === CollectStreams / CollectString ===
 
 

--- a/crates/monty-python/tests/test_telemetry.py
+++ b/crates/monty-python/tests/test_telemetry.py
@@ -163,7 +163,7 @@ def test_standard_components_receive_session_tree():
             'logfire.json_schema': '{"type":"object","properties":{"stream":{},"text":{},"length_limit_exceeded":{}}}',
             'thread.id': 1,
             'code.file.path': 'crates/monty-pool/src/telemetry/tracing.rs',
-            'code.line.number': 272,
+            'code.line.number': 275,
             'code.module.name': 'monty_pool::telemetry::tracing',
             'logfire.null_args': ('length_limit_exceeded',),
         }

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -280,10 +280,11 @@ fn print_output_is_streamed_in_order() {
     child.create_repl();
     let (prints, event) = child.feed("print('one')\nprint('two')\nprint('three', end='')\n'done'");
     expect_complete(event);
-    let text: String = prints.iter().map(|p| p.text.as_str()).collect();
+    let segments = || prints.iter().flat_map(|print| print.segments.iter());
+    let text: String = segments().map(|segment| segment.text.as_str()).collect();
     // the partial (no-newline) third line must still arrive before the turn ends
     assert_eq!(text, "one\ntwo\nthree");
-    assert!(prints.iter().all(|p| p.stream == i32::from(pb::PrintStream::Stdout)));
+    assert!(segments().all(|segment| segment.stream == i32::from(pb::PrintStream::Stdout)));
     child.shutdown();
 }
 

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -18,7 +18,8 @@ implementation**.
 - `ResourceTracker` / `ResourceLimits` — the resource tracker the
   interpreter uses to enforce time/memory/recursion limits, plus the
   `max_suspensions` budget hosts enforce themselves.
-- `PrintStream` / `PrintWriter` — `print()` output capture.
+- `PrintStream` / `PrintWriter` / `CollectedStreams` — `print()` output
+  capture, and the labelled buffer behind `PrintWriter::CollectStreams`.
 - `CompileOptions`, `ExtFunctionResult`, `NameLookupResult`, `FileMode`, and
   the CPython-compatible formatting helpers behind their `repr()`s.
 

--- a/crates/monty-types/src/io.rs
+++ b/crates/monty-types/src/io.rs
@@ -18,15 +18,13 @@ pub const DEFAULT_MAX_PRINT_COLLECT_BYTES: usize = 10 * 1024 * 1024;
 
 /// Identifies the output stream for a single print fragment.
 ///
-/// Today the `print()` builtin only writes to `Stdout`. The `Stderr` variant is
-/// included for forward compatibility with a future `print(..., file=sys.stderr)`
-/// implementation so the collected-output API shape does not have to change when
-/// that lands.
+/// `print()` writes to `Stdout` unless it is given `file=sys.stderr`, which is
+/// the only way sandboxed code can reach `Stderr`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrintStream {
-    /// Standard output — the default for every `print()` call today.
+    /// Standard output, the default for a `print()` call with no `file=`.
     Stdout,
-    /// Standard error — reserved for future `print(..., file=sys.stderr)` support.
+    /// Standard error, reached by `print(..., file=sys.stderr)`.
     Stderr,
 }
 
@@ -59,19 +57,18 @@ pub enum PrintWriter<'a> {
     /// Second field: max collected bytes (`None` = unlimited). Exceeding raises
     /// `MemoryError` with the same message as [`ResourceError::Memory`].
     CollectString(&'a mut String, Option<usize>),
-    /// Collect all output as `(stream, text)` tuples.
+    /// Collect all output as `(stream, text)` entries.
     ///
-    /// The builtin `print()` implementation calls `stdout_write` for each argument
-    /// and `stdout_push` for each separator/terminator. To avoid one tuple per
-    /// fragment, this variant appends to the trailing tuple when it already matches
-    /// the current stream; a new tuple is only pushed when the stream changes.
-    /// So long as every write targets the same stream (the status quo today, since
-    /// `print()` only writes to stdout), a single `print(a, b)` call produces one
-    /// `(Stdout, "a b\n")` entry — and consecutive prints with `end=''` likewise
-    /// merge into a single trailing entry.
+    /// The builtin `print()` implementation calls `write` for each argument and
+    /// `push` for each separator/terminator. To avoid one entry per fragment,
+    /// [`CollectedStreams`] appends to the trailing entry when it already
+    /// matches the current stream; a new entry is only pushed when the stream
+    /// changes. So a run that stays on one stream collects a single entry
+    /// however many fragments it wrote, and one that alternates collects one
+    /// per run.
     ///
-    /// Second field: max collected bytes across all tuples (`None` = unlimited).
-    CollectStreams(&'a mut Vec<(PrintStream, String)>, Option<usize>),
+    /// Second field: max collected bytes across all entries (`None` = unlimited).
+    CollectStreams(&'a mut CollectedStreams, Option<usize>),
     /// Delegate to a custom callback.
     Callback(&'a mut dyn PrintWriterCallback),
 }
@@ -83,7 +80,7 @@ impl PrintWriter<'_> {
     }
 
     /// Collect into `buf` with the default [`DEFAULT_MAX_PRINT_COLLECT_BYTES`] cap.
-    pub fn collect_streams(buf: &mut Vec<(PrintStream, String)>) -> PrintWriter<'_> {
+    pub fn collect_streams(buf: &mut CollectedStreams) -> PrintWriter<'_> {
         PrintWriter::CollectStreams(buf, Some(DEFAULT_MAX_PRINT_COLLECT_BYTES))
     }
 
@@ -107,12 +104,19 @@ impl PrintWriter<'_> {
     ///
     /// This method writes only the given argument's text, without adding
     /// separators or a trailing newline. Separators (spaces) and the final
-    /// terminator (newline) are emitted via [`stdout_push`](Self::stdout_push).
-    pub fn stdout_write(&mut self, output: Cow<'_, str>) -> Result<(), MontyException> {
+    /// terminator (newline) are emitted via [`push`](Self::push).
+    ///
+    /// `CollectString` keeps no stream labels, so a run that prints to both
+    /// streams interleaves them in one buffer. Use `CollectStreams` to tell
+    /// them apart.
+    pub fn write(&mut self, stream: PrintStream, output: Cow<'_, str>) -> Result<(), MontyException> {
         match self {
             Self::Disabled => Ok(()),
             Self::Stdout => {
-                print!("{output}");
+                match stream {
+                    PrintStream::Stdout => print!("{output}"),
+                    PrintStream::Stderr => eprint!("{output}"),
+                }
                 Ok(())
             }
             Self::CollectString(buf, max_bytes) => {
@@ -120,20 +124,26 @@ impl PrintWriter<'_> {
                 buf.push_str(&output);
                 Ok(())
             }
-            Self::CollectStreams(buf, max_bytes) => append_streams_str(buf, PrintStream::Stdout, &output, *max_bytes),
-            Self::Callback(cb) => cb.stdout_write(output),
+            Self::CollectStreams(buf, max_bytes) => buf.push_str(stream, &output, *max_bytes),
+            Self::Callback(cb) => match stream {
+                PrintStream::Stdout => cb.stdout_write(output),
+                PrintStream::Stderr => cb.stderr_write(output),
+            },
         }
     }
 
-    /// Appends a single character to the output.
+    /// Appends a single character to the given stream.
     ///
     /// Generally called to add spaces (separators) and newlines (terminators)
     /// within print output.
-    pub fn stdout_push(&mut self, end: char) -> Result<(), MontyException> {
+    pub fn push(&mut self, stream: PrintStream, end: char) -> Result<(), MontyException> {
         match self {
             Self::Disabled => Ok(()),
             Self::Stdout => {
-                print!("{end}");
+                match stream {
+                    PrintStream::Stdout => print!("{end}"),
+                    PrintStream::Stderr => eprint!("{end}"),
+                }
                 Ok(())
             }
             Self::CollectString(buf, max_bytes) => {
@@ -141,9 +151,22 @@ impl PrintWriter<'_> {
                 buf.push(end);
                 Ok(())
             }
-            Self::CollectStreams(buf, max_bytes) => append_streams_char(buf, PrintStream::Stdout, end, *max_bytes),
-            Self::Callback(cb) => cb.stdout_push(end),
+            Self::CollectStreams(buf, max_bytes) => buf.push_char(stream, end, *max_bytes),
+            Self::Callback(cb) => match stream {
+                PrintStream::Stdout => cb.stdout_push(end),
+                PrintStream::Stderr => cb.stderr_push(end),
+            },
         }
+    }
+
+    /// [`write`](Self::write) to [`PrintStream::Stdout`].
+    pub fn stdout_write(&mut self, output: Cow<'_, str>) -> Result<(), MontyException> {
+        self.write(PrintStream::Stdout, output)
+    }
+
+    /// [`push`](Self::push) to [`PrintStream::Stdout`].
+    pub fn stdout_push(&mut self, end: char) -> Result<(), MontyException> {
+        self.push(PrintStream::Stdout, end)
     }
 
     /// Whether this writer wants [`poll_flush`](Self::poll_flush) called at all.
@@ -162,6 +185,65 @@ impl PrintWriter<'_> {
             Self::Callback(cb) => cb.poll_flush(),
             _ => Ok(()),
         }
+    }
+}
+
+/// The buffer behind [`PrintWriter::CollectStreams`]: `(stream, text)` entries
+/// plus the byte total their cap is checked against.
+///
+/// The total is carried rather than re-derived because the cap is checked on
+/// every fragment: summing the entries each time is O(entries), which a run
+/// alternating between the streams turns into quadratic work, since each switch
+/// starts a new entry. `pydantic_monty`'s collector keeps the same running
+/// charge for the same reason.
+#[derive(Debug, Default)]
+pub struct CollectedStreams {
+    entries: Vec<(PrintStream, String)>,
+    /// UTF-8 bytes across `entries`, kept in step with every append.
+    bytes: usize,
+}
+
+impl CollectedStreams {
+    /// The collected fragments, in the order the sandbox produced them.
+    #[must_use]
+    pub fn entries(&self) -> &[(PrintStream, String)] {
+        &self.entries
+    }
+
+    /// Takes the collected fragments, leaving the buffer empty.
+    #[must_use]
+    pub fn into_entries(self) -> Vec<(PrintStream, String)> {
+        self.entries
+    }
+
+    /// Appends a string fragment, merging into the trailing entry when the
+    /// stream matches.
+    fn push_str(&mut self, stream: PrintStream, text: &str, max_bytes: Option<usize>) -> Result<(), MontyException> {
+        self.charge(text.len(), max_bytes)?;
+        match self.entries.last_mut() {
+            Some((s, existing)) if *s == stream => existing.push_str(text),
+            _ => self.entries.push((stream, text.to_owned())),
+        }
+        Ok(())
+    }
+
+    /// Appends a single character, merging into the trailing entry when the
+    /// stream matches.
+    fn push_char(&mut self, stream: PrintStream, ch: char, max_bytes: Option<usize>) -> Result<(), MontyException> {
+        self.charge(ch.len_utf8(), max_bytes)?;
+        match self.entries.last_mut() {
+            Some((s, existing)) if *s == stream => existing.push(ch),
+            _ => self.entries.push((stream, String::from(ch))),
+        }
+        Ok(())
+    }
+
+    /// Checks `add` bytes against the cap and books them, leaving the total
+    /// untouched when the cap refuses them.
+    fn charge(&mut self, add: usize, max_bytes: Option<usize>) -> Result<(), MontyException> {
+        check_print_collect_limit(self.bytes, add, max_bytes)?;
+        self.bytes = self.bytes.saturating_add(add);
+        Ok(())
     }
 }
 
@@ -188,43 +270,6 @@ pub fn check_print_collect_limit(
     }
 }
 
-/// Total UTF-8 bytes across all collect-streams tuples.
-fn streams_byte_len(buf: &[(PrintStream, String)]) -> usize {
-    buf.iter().map(|(_, s)| s.len()).sum()
-}
-
-/// Appends a string fragment to the collect-streams buffer, merging into the
-/// trailing tuple when the stream matches.
-fn append_streams_str(
-    buf: &mut Vec<(PrintStream, String)>,
-    stream: PrintStream,
-    text: &str,
-    max_bytes: Option<usize>,
-) -> Result<(), MontyException> {
-    check_print_collect_limit(streams_byte_len(buf), text.len(), max_bytes)?;
-    match buf.last_mut() {
-        Some((s, existing)) if *s == stream => existing.push_str(text),
-        _ => buf.push((stream, text.to_owned())),
-    }
-    Ok(())
-}
-
-/// Appends a single character to the collect-streams buffer, merging into the
-/// trailing tuple when the stream matches.
-fn append_streams_char(
-    buf: &mut Vec<(PrintStream, String)>,
-    stream: PrintStream,
-    ch: char,
-    max_bytes: Option<usize>,
-) -> Result<(), MontyException> {
-    check_print_collect_limit(streams_byte_len(buf), ch.len_utf8(), max_bytes)?;
-    match buf.last_mut() {
-        Some((s, existing)) if *s == stream => existing.push(ch),
-        _ => buf.push((stream, String::from(ch))),
-    }
-    Ok(())
-}
-
 /// Trait for custom output handling from the `print()` builtin function.
 ///
 /// Implement this trait and pass it via [`PrintWriter::Callback`] to capture
@@ -248,6 +293,20 @@ pub trait PrintWriterCallback {
     /// # Arguments
     /// * `end` - The character to print after the formatted output.
     fn stdout_push(&mut self, end: char) -> Result<(), MontyException>;
+
+    /// Called for each formatted argument of a `print(..., file=sys.stderr)`.
+    ///
+    /// Defaults to [`stdout_write`](Self::stdout_write), so a host written
+    /// before stderr existed still receives the text instead of losing it.
+    fn stderr_write(&mut self, output: Cow<'_, str>) -> Result<(), MontyException> {
+        self.stdout_write(output)
+    }
+
+    /// Adds a single character to stderr. Defaults to
+    /// [`stdout_push`](Self::stdout_push), as [`stderr_write`](Self::stderr_write) does.
+    fn stderr_push(&mut self, end: char) -> Result<(), MontyException> {
+        self.stdout_push(end)
+    }
 
     /// Gives a buffering implementation a chance to release what it holds.
     ///

--- a/crates/monty-types/src/io.rs
+++ b/crates/monty-types/src/io.rs
@@ -16,6 +16,14 @@ use crate::{
 /// Pass `max_bytes: None` to opt out on trusted hosts.
 pub const DEFAULT_MAX_PRINT_COLLECT_BYTES: usize = 10 * 1024 * 1024;
 
+/// Host bytes charged for each retained `(stream, text)` entry beyond its text.
+///
+/// A retained entry costs about 32 bytes in the vector plus its `String`'s own
+/// allocation, none of which is text. Charging only the text would let a run
+/// that starts a fresh entry per byte — one that alternates between the two
+/// streams — occupy roughly 64x the host memory the cap accounts for.
+pub const COLLECT_STREAMS_ENTRY_OVERHEAD: usize = 64;
+
 /// Identifies the output stream for a single print fragment.
 ///
 /// `print()` writes to `Stdout` unless it is given `file=sys.stderr`, which is
@@ -67,7 +75,9 @@ pub enum PrintWriter<'a> {
     /// however many fragments it wrote, and one that alternates collects one
     /// per run.
     ///
-    /// Second field: max collected bytes across all entries (`None` = unlimited).
+    /// Second field: the cap the collector's charge is checked against (`None`
+    /// = unlimited), which counts [`COLLECT_STREAMS_ENTRY_OVERHEAD`] per entry
+    /// as well as the text.
     CollectStreams(&'a mut CollectedStreams, Option<usize>),
     /// Delegate to a custom callback.
     Callback(&'a mut dyn PrintWriterCallback),
@@ -189,9 +199,9 @@ impl PrintWriter<'_> {
 }
 
 /// The buffer behind [`PrintWriter::CollectStreams`]: `(stream, text)` entries
-/// plus the byte total their cap is checked against.
+/// plus the running charge their cap is checked against.
 ///
-/// The total is carried rather than re-derived because the cap is checked on
+/// The charge is carried rather than re-derived because the cap is checked on
 /// every fragment: summing the entries each time is O(entries), which a run
 /// alternating between the streams turns into quadratic work, since each switch
 /// starts a new entry. `pydantic_monty`'s collector keeps the same running
@@ -199,8 +209,9 @@ impl PrintWriter<'_> {
 #[derive(Debug, Default)]
 pub struct CollectedStreams {
     entries: Vec<(PrintStream, String)>,
-    /// UTF-8 bytes across `entries`, kept in step with every append.
-    bytes: usize,
+    /// Text bytes plus [`COLLECT_STREAMS_ENTRY_OVERHEAD`] per entry, kept in
+    /// step with every append.
+    charged_bytes: usize,
 }
 
 impl CollectedStreams {
@@ -219,7 +230,8 @@ impl CollectedStreams {
     /// Appends a string fragment, merging into the trailing entry when the
     /// stream matches.
     fn push_str(&mut self, stream: PrintStream, text: &str, max_bytes: Option<usize>) -> Result<(), MontyException> {
-        self.charge(text.len(), max_bytes)?;
+        let starts_entry = self.starts_entry(stream);
+        self.charge(text.len(), starts_entry, max_bytes)?;
         match self.entries.last_mut() {
             Some((s, existing)) if *s == stream => existing.push_str(text),
             _ => self.entries.push((stream, text.to_owned())),
@@ -230,7 +242,8 @@ impl CollectedStreams {
     /// Appends a single character, merging into the trailing entry when the
     /// stream matches.
     fn push_char(&mut self, stream: PrintStream, ch: char, max_bytes: Option<usize>) -> Result<(), MontyException> {
-        self.charge(ch.len_utf8(), max_bytes)?;
+        let starts_entry = self.starts_entry(stream);
+        self.charge(ch.len_utf8(), starts_entry, max_bytes)?;
         match self.entries.last_mut() {
             Some((s, existing)) if *s == stream => existing.push(ch),
             _ => self.entries.push((stream, String::from(ch))),
@@ -238,11 +251,23 @@ impl CollectedStreams {
         Ok(())
     }
 
-    /// Checks `add` bytes against the cap and books them, leaving the total
-    /// untouched when the cap refuses them.
-    fn charge(&mut self, add: usize, max_bytes: Option<usize>) -> Result<(), MontyException> {
-        check_print_collect_limit(self.bytes, add, max_bytes)?;
-        self.bytes = self.bytes.saturating_add(add);
+    /// Whether a fragment on `stream` would start an entry rather than extend
+    /// the trailing one.
+    fn starts_entry(&self, stream: PrintStream) -> bool {
+        !matches!(self.entries.last(), Some((s, _)) if *s == stream)
+    }
+
+    /// Checks a fragment's `add` text bytes against the cap and books them,
+    /// with [`COLLECT_STREAMS_ENTRY_OVERHEAD`] on top when it starts an entry.
+    /// The charge is left untouched when the cap refuses the fragment.
+    fn charge(&mut self, add: usize, starts_entry: bool, max_bytes: Option<usize>) -> Result<(), MontyException> {
+        let add = if starts_entry {
+            add.saturating_add(COLLECT_STREAMS_ENTRY_OVERHEAD)
+        } else {
+            add
+        };
+        check_print_collect_limit(self.charged_bytes, add, max_bytes)?;
+        self.charged_bytes = self.charged_bytes.saturating_add(add);
         Ok(())
     }
 }

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -28,8 +28,8 @@ pub use crate::{
     file_mode::FileMode,
     format::{FormatFloat, StringRepr, bytes_repr, bytes_repr_fmt, string_repr_fmt, utf8_error_reason},
     io::{
-        CollectedStreams, DEFAULT_MAX_PRINT_COLLECT_BYTES, PrintStream, PrintWriter, PrintWriterCallback,
-        check_print_collect_limit,
+        COLLECT_STREAMS_ENTRY_OVERHEAD, CollectedStreams, DEFAULT_MAX_PRINT_COLLECT_BYTES, PrintStream, PrintWriter,
+        PrintWriterCallback, check_print_collect_limit,
     },
     object::{
         ConversionError, DictPairs, InvalidInputError, MAX_TIMEZONE_OFFSET_SECONDS, MIN_TIMEZONE_OFFSET_SECONDS,

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -27,7 +27,10 @@ pub use crate::{
     },
     file_mode::FileMode,
     format::{FormatFloat, StringRepr, bytes_repr, bytes_repr_fmt, string_repr_fmt, utf8_error_reason},
-    io::{DEFAULT_MAX_PRINT_COLLECT_BYTES, PrintStream, PrintWriter, PrintWriterCallback, check_print_collect_limit},
+    io::{
+        CollectedStreams, DEFAULT_MAX_PRINT_COLLECT_BYTES, PrintStream, PrintWriter, PrintWriterCallback,
+        check_print_collect_limit,
+    },
     object::{
         ConversionError, DictPairs, InvalidInputError, MAX_TIMEZONE_OFFSET_SECONDS, MIN_TIMEZONE_OFFSET_SECONDS,
         MontyClassInstance, MontyClassType, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTime,

--- a/crates/monty-wasm-runtime/src/lib.rs
+++ b/crates/monty-wasm-runtime/src/lib.rs
@@ -126,6 +126,18 @@ impl EventSink for ComponentEventSink {
                 len,
                 max: MAX_FRAME_LEN,
             })
+        } else if let Some(pb::child_event::Kind::Print(print)) = &event.kind {
+            // A `Print` event carries a run per stream switch, while the
+            // component's `PrintEvent` names one stream, so it expands into one
+            // event per run rather than converting whole. Checked before the
+            // clone below so print text is copied once, not twice.
+            for segment in &print.segments {
+                self.events.push(Event::Print(PrintEvent {
+                    stderr: segment.stream == i32::from(pb::PrintStream::Stderr),
+                    text: segment.text.clone(),
+                }));
+            }
+            Ok(())
         } else {
             let mut event = event.clone();
             let component_event = match event.kind.take() {
@@ -366,10 +378,7 @@ fn raised_exception_from_component(error: RaisedError) -> pb::RaisedException {
 /// Converts one child event into its semantic component representation.
 fn event_from_proto(event: pb::ChildEvent) -> Event {
     match event.kind {
-        Some(pb::child_event::Kind::Print(print)) => Event::Print(PrintEvent {
-            stderr: print.stream == i32::from(pb::PrintStream::Stderr),
-            text: print.text,
-        }),
+        Some(pb::child_event::Kind::Print(_)) => invalid_event("Print event bypassed segment expansion"),
         Some(pb::child_event::Kind::FunctionCall(call)) => {
             let object_id = call.object_id.map(|uuid| uuid.to_string());
             Event::FunctionCall(FunctionCallEvent {

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -42,7 +42,7 @@ let result = runner.run(vec![MontyObject::Int(10)], ResourceTracker::default(), 
 assert_eq!(result, MontyObject::Int(55));
 ```
 
-Errors are returned as `MontyException`, with a traceback matching what CPython would produce. `PrintWriter` controls where `print()` output goes: `Stdout`, `Disabled`, or collected into a `String` / `(stream, text)` tuples for the host to inspect.
+Errors are returned as `MontyException`, with a traceback matching what CPython would produce. `PrintWriter` controls where `print()` output goes: `Stdout`, `Disabled`, or collected for the host to inspect — into a `String`, or into a `CollectedStreams` buffer whose `entries()` label each run `stdout` or `stderr`.
 
 ## Resource limits
 

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -1,13 +1,16 @@
 //! Implementation of the print() builtin function.
 
+use monty_types::PrintStream;
+
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::HeapData,
+    intern::StaticStrings,
     types::PyTrait,
-    value::Value,
+    value::{Marker, Value},
 };
 
 /// Implementation of the print() builtin function.
@@ -15,12 +18,10 @@ use crate::{
 /// Supports the following keyword arguments:
 /// - `sep`: separator between values (default: " ")
 /// - `end`: string appended after the last value (default: "\n")
+/// - `file`: `sys.stdout` (the default) or `sys.stderr`; anything else raises
+///   `TypeError`, since Monty has no file objects to write into
 /// - `flush`: whether to flush the stream (accepted but ignored — Monty
 ///   doesn't buffer stdout)
-///
-/// The `file` keyword is recognised so it can produce a *specific* error
-/// (`"print() 'file' argument is not supported"`) rather than the generic
-/// "unexpected keyword" produced by leaving it off the struct.
 pub fn builtin_print(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let PrintArgs {
         objects,
@@ -34,45 +35,63 @@ pub fn builtin_print(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(end, vm);
     defer_drop!(file, vm);
 
-    if !matches!(file, Value::None) {
-        return Err(SimpleException::new_msg(ExcType::TypeError, "print() 'file' argument is not supported").into());
-    }
-
+    // `sep` and `end` are checked before `file` because CPython reports them in
+    // that order: `print(x, sep=1, file=3)` raises about `sep`, not the file.
     let sep_str = extract_string_kwarg(sep, "sep", vm)?;
     let end_str = extract_string_kwarg(end, "end", vm)?;
+    let stream = print_stream(file, vm)?;
 
     let mut first = true;
     for value in objects.as_slice() {
         if first {
             first = false;
         } else if let Some(sep) = &sep_str {
-            vm.print_writer.stdout_write(sep.as_str().into())?;
+            vm.print_writer.write(stream, sep.as_str().into())?;
         } else {
-            vm.print_writer.stdout_push(' ')?;
+            vm.print_writer.push(stream, ' ')?;
         }
         let s = value.py_str(vm)?;
         defer_drop!(s, vm);
         // Resolve the `str` `Value` against the heap/interns tables directly so
         // the `&str` borrow stays disjoint from the `&mut vm.print_writer` write.
         vm.print_writer
-            .stdout_write(s.to_str_heap(vm.heap, vm.interns)?.into())?;
+            .write(stream, s.to_str_heap(vm.heap, vm.interns)?.into())?;
     }
 
     if let Some(end) = end_str {
-        vm.print_writer.stdout_write(end.into())?;
+        vm.print_writer.write(stream, end.into())?;
     } else {
-        vm.print_writer.stdout_push('\n')?;
+        vm.print_writer.push(stream, '\n')?;
     }
 
     Ok(Value::None)
+}
+
+/// Resolves the `file` kwarg to the stream `print()` should write to.
+///
+/// `sys.stdout` and `sys.stderr` are opaque markers rather than file objects
+/// (see `limitations/sys.md`), so they are matched by identity. Any other
+/// value, including a class defining `write()`, has nothing to write into.
+fn print_stream(file: &Value, vm: &VM<'_>) -> RunResult<PrintStream> {
+    match file {
+        Value::None | Value::Marker(Marker(StaticStrings::Stdout)) => Ok(PrintStream::Stdout),
+        Value::Marker(Marker(StaticStrings::Stderr)) => Ok(PrintStream::Stderr),
+        _ => Err(SimpleException::new_msg(
+            ExcType::TypeError,
+            format!(
+                "print() 'file' argument must be sys.stdout or sys.stderr, not {}",
+                file.py_type_name(vm)
+            ),
+        )
+        .into()),
+    }
 }
 
 /// Argument shape for `print(*objects, sep=' ', end='\n', file=sys.stdout, flush=False)`.
 ///
 /// Every kwarg is held as a raw `Value` so the caller can do the
 /// "must be None or str" coercion inline, and so `flush` can be accepted
-/// without forcing a type check. Explicit `file` rejection lives in
-/// `builtin_print`.
+/// without forcing a type check. `file` is resolved by `print_stream`.
 #[derive(FromArgs)]
 #[from_args(name = "print")]
 struct PrintArgs {

--- a/crates/monty/test_cases/builtin__print_kwargs.py
+++ b/crates/monty/test_cases/builtin__print_kwargs.py
@@ -1,4 +1,5 @@
-# Tests dynamic keyword arguments for print()
+# Tests keyword arguments for print()
+import sys
 
 # === Dynamic sep via **kwargs ===
 dynamic_sep = 's' + 'e' + 'p'
@@ -10,3 +11,24 @@ assert result is None
 dynamic_end = 'e' + 'n' + 'd'
 result2 = print('line', **{dynamic_end: ''})
 assert result2 is None
+
+
+# === file=sys.stdout / sys.stderr ===
+# Output goes to the host, so these only assert that both are accepted;
+# where the text ends up is covered by the Rust and pytest suites.
+assert print('to stdout', file=sys.stdout) is None
+assert print('to stderr', file=sys.stderr) is None
+assert print('default', file=None) is None
+
+
+# === sep and end are reported before file ===
+try:
+    print('x', sep=1, file=3)
+    assert False, 'expected TypeError'
+except TypeError as exc:
+    assert str(exc) == 'sep must be None or a string, not int'
+try:
+    print('x', end=1, file=3)
+    assert False, 'expected TypeError'
+except TypeError as exc:
+    assert str(exc) == 'end must be None or a string, not int'

--- a/crates/monty/tests/print_collect_limits.rs
+++ b/crates/monty/tests/print_collect_limits.rs
@@ -6,7 +6,7 @@
 //! Loops stay at ~256 KiB — safe, not a real OOM.
 
 use monty::MontyRun;
-use monty_types::{CompileOptions, ExcType, PrintStream, PrintWriter, ResourceTracker};
+use monty_types::{CollectedStreams, CompileOptions, ExcType, PrintStream, PrintWriter, ResourceTracker};
 
 /// One KiB payload reused across prints so heap growth stays small.
 const CHUNK: &str = "A";
@@ -58,7 +58,7 @@ fn collect_string_respects_max_bytes() {
 #[test]
 fn collect_streams_respects_max_bytes() {
     let ex = monty_run(print_loop_code());
-    let mut streams: Vec<(PrintStream, String)> = Vec::new();
+    let mut streams = CollectedStreams::default();
 
     let err = ex
         .run(
@@ -68,7 +68,7 @@ fn collect_streams_respects_max_bytes() {
         )
         .expect_err("expected MemoryError when collect buffer exceeds max_bytes");
 
-    let total: usize = streams.iter().map(|(_, s)| s.len()).sum();
+    let total: usize = streams.entries().iter().map(|(_, s)| s.len()).sum();
     assert_eq!(err.exc_type(), ExcType::MemoryError);
     let expected = format!(
         "memory limit exceeded: {} bytes > {LIMIT_BYTES} bytes",
@@ -104,12 +104,43 @@ fn collect_string_unlimited_allows_growth_past_64kib() {
     );
 }
 
-/// Covers `PrintWriter::collect_streams` and `stdout_push` → `append_streams_char`
+/// The cap charges both streams against one total, and a refused fragment books
+/// nothing. Each switch starts a new entry, so this is also what pins the
+/// running total against the entries it is meant to track.
+#[test]
+fn collect_streams_charges_both_streams_against_one_cap() {
+    // 'a' and 'b' alternate a byte at a time: 4 payload bytes plus 4 newlines,
+    // so the 7-byte cap refuses the last newline with 8 bytes.
+    let ex = monty_run("import sys\nfor i in range(2):\n    print('a')\n    print('b', file=sys.stderr)\n");
+    let mut streams = CollectedStreams::default();
+
+    let err = ex
+        .run(
+            vec![],
+            ResourceTracker::default(),
+            PrintWriter::CollectStreams(&mut streams, Some(7)),
+        )
+        .expect_err("expected MemoryError once both streams together pass the cap");
+
+    assert_eq!(err.exc_type(), ExcType::MemoryError);
+    assert_eq!(err.message(), Some("memory limit exceeded: 8 bytes > 7 bytes"));
+    assert_eq!(
+        streams.entries(),
+        [
+            (PrintStream::Stdout, "a\n".to_owned()),
+            (PrintStream::Stderr, "b\n".to_owned()),
+            (PrintStream::Stdout, "a\n".to_owned()),
+            (PrintStream::Stderr, "b".to_owned()),
+        ]
+    );
+}
+
+/// Covers `PrintWriter::collect_streams` and `stdout_push` → `CollectedStreams::push_char`
 /// (the `end=''` loop tests never push a terminator).
 #[test]
 fn collect_streams_helper_merges_newline_push() {
     let ex = monty_run("print('hi')");
-    let mut streams: Vec<(PrintStream, String)> = Vec::new();
+    let mut streams = CollectedStreams::default();
 
     ex.run(
         vec![],
@@ -118,15 +149,15 @@ fn collect_streams_helper_merges_newline_push() {
     )
     .expect("default-capped collect_streams should accept a short print");
 
-    assert_eq!(streams, vec![(PrintStream::Stdout, "hi\n".to_owned())]);
+    assert_eq!(streams.entries(), [(PrintStream::Stdout, "hi\n".to_owned())]);
 }
 
 /// Bare `print()` only `stdout_push`es `'\n'` — exercises the empty-buffer branch
-/// of `append_streams_char`.
+/// of `CollectedStreams::push_char`.
 #[test]
 fn collect_streams_empty_print_pushes_newline_entry() {
     let ex = monty_run("print()");
-    let mut streams: Vec<(PrintStream, String)> = Vec::new();
+    let mut streams = CollectedStreams::default();
 
     ex.run(
         vec![],
@@ -135,7 +166,7 @@ fn collect_streams_empty_print_pushes_newline_entry() {
     )
     .expect("empty print should succeed");
 
-    assert_eq!(streams, vec![(PrintStream::Stdout, "\n".to_owned())]);
+    assert_eq!(streams.entries(), [(PrintStream::Stdout, "\n".to_owned())]);
 }
 
 /// Cap of 1 byte: `print('a')` writes `'a'` then fails on the newline push.
@@ -161,7 +192,7 @@ fn collect_string_max_bytes_rejects_newline_push() {
 #[test]
 fn collect_streams_max_bytes_rejects_newline_push() {
     let ex = monty_run("print('a')");
-    let mut streams: Vec<(PrintStream, String)> = Vec::new();
+    let mut streams = CollectedStreams::default();
 
     let err = ex
         .run(
@@ -173,5 +204,5 @@ fn collect_streams_max_bytes_rejects_newline_push() {
 
     assert_eq!(err.exc_type(), ExcType::MemoryError);
     assert_eq!(err.message(), Some("memory limit exceeded: 2 bytes > 1 bytes"));
-    assert_eq!(streams, vec![(PrintStream::Stdout, "a".to_owned())]);
+    assert_eq!(streams.entries(), [(PrintStream::Stdout, "a".to_owned())]);
 }

--- a/crates/monty/tests/print_collect_limits.rs
+++ b/crates/monty/tests/print_collect_limits.rs
@@ -6,7 +6,10 @@
 //! Loops stay at ~256 KiB — safe, not a real OOM.
 
 use monty::MontyRun;
-use monty_types::{CollectedStreams, CompileOptions, ExcType, PrintStream, PrintWriter, ResourceTracker};
+use monty_types::{
+    COLLECT_STREAMS_ENTRY_OVERHEAD, CollectedStreams, CompileOptions, ExcType, PrintStream, PrintWriter,
+    ResourceTracker,
+};
 
 /// One KiB payload reused across prints so heap growth stays small.
 const CHUNK: &str = "A";
@@ -70,13 +73,15 @@ fn collect_streams_respects_max_bytes() {
 
     let total: usize = streams.entries().iter().map(|(_, s)| s.len()).sum();
     assert_eq!(err.exc_type(), ExcType::MemoryError);
+    // The loop stays on stdout, so one entry overhead is charged on top of the
+    // payload: the cap is reached a chunk earlier than the `CollectString` case.
     let expected = format!(
         "memory limit exceeded: {} bytes > {LIMIT_BYTES} bytes",
-        LIMIT_BYTES + CHUNK_REPS
+        COLLECT_STREAMS_ENTRY_OVERHEAD + total + CHUNK_REPS
     );
     assert_eq!(err.message(), Some(expected.as_str()));
     assert!(total <= LIMIT_BYTES, "buffer must stay at or under cap, got {total}");
-    assert_eq!(total, LIMIT_BYTES);
+    assert_eq!(total, LIMIT_BYTES - CHUNK_REPS);
 }
 
 /// Opt-out: `max_bytes=None` still allows growth past a 64 KiB would-be cap.
@@ -109,8 +114,10 @@ fn collect_string_unlimited_allows_growth_past_64kib() {
 /// running total against the entries it is meant to track.
 #[test]
 fn collect_streams_charges_both_streams_against_one_cap() {
-    // 'a' and 'b' alternate a byte at a time: 4 payload bytes plus 4 newlines,
-    // so the 7-byte cap refuses the last newline with 8 bytes.
+    // 'a' and 'b' alternate a byte at a time, so each of the four writes starts
+    // an entry: 4 overheads plus 8 payload bytes. A cap one byte short of that
+    // refuses the last newline.
+    const CAP: usize = 4 * COLLECT_STREAMS_ENTRY_OVERHEAD + 7;
     let ex = monty_run("import sys\nfor i in range(2):\n    print('a')\n    print('b', file=sys.stderr)\n");
     let mut streams = CollectedStreams::default();
 
@@ -118,12 +125,13 @@ fn collect_streams_charges_both_streams_against_one_cap() {
         .run(
             vec![],
             ResourceTracker::default(),
-            PrintWriter::CollectStreams(&mut streams, Some(7)),
+            PrintWriter::CollectStreams(&mut streams, Some(CAP)),
         )
         .expect_err("expected MemoryError once both streams together pass the cap");
 
     assert_eq!(err.exc_type(), ExcType::MemoryError);
-    assert_eq!(err.message(), Some("memory limit exceeded: 8 bytes > 7 bytes"));
+    let expected = format!("memory limit exceeded: {} bytes > {CAP} bytes", CAP + 1);
+    assert_eq!(err.message(), Some(expected.as_str()));
     assert_eq!(
         streams.entries(),
         [
@@ -188,9 +196,11 @@ fn collect_string_max_bytes_rejects_newline_push() {
     assert_eq!(output, "a");
 }
 
-/// Same as the string case, but through CollectStreams' char-append path.
+/// Same as the string case, but through CollectStreams' char-append path: the
+/// cap has room for one entry and its byte, so the newline is what crosses it.
 #[test]
 fn collect_streams_max_bytes_rejects_newline_push() {
+    const CAP: usize = COLLECT_STREAMS_ENTRY_OVERHEAD + 1;
     let ex = monty_run("print('a')");
     let mut streams = CollectedStreams::default();
 
@@ -198,11 +208,39 @@ fn collect_streams_max_bytes_rejects_newline_push() {
         .run(
             vec![],
             ResourceTracker::default(),
-            PrintWriter::CollectStreams(&mut streams, Some(1)),
+            PrintWriter::CollectStreams(&mut streams, Some(CAP)),
         )
         .expect_err("expected MemoryError on newline push past max_bytes");
 
     assert_eq!(err.exc_type(), ExcType::MemoryError);
-    assert_eq!(err.message(), Some("memory limit exceeded: 2 bytes > 1 bytes"));
+    let expected = format!("memory limit exceeded: {} bytes > {CAP} bytes", CAP + 1);
+    assert_eq!(err.message(), Some(expected.as_str()));
     assert_eq!(streams.entries(), [(PrintStream::Stdout, "a".to_owned())]);
+}
+
+/// The overhead is what stops a stream-switching run from holding far more host
+/// memory than its text: every fragment starts an entry, so the cap bounds the
+/// entries retained rather than the handful of bytes printed.
+#[test]
+fn collect_streams_bounds_entries_not_just_payload() {
+    const CAP: usize = 4 * 1024;
+    /// Each fragment is one byte and starts its own entry.
+    const PER_ENTRY: usize = COLLECT_STREAMS_ENTRY_OVERHEAD + 1;
+    let ex = monty_run(
+        "import sys\nfor _ in range(200):\n    print('a', end='')\n    print('b', end='', file=sys.stderr)\n",
+    );
+    let mut streams = CollectedStreams::default();
+
+    let err = ex
+        .run(
+            vec![],
+            ResourceTracker::default(),
+            PrintWriter::CollectStreams(&mut streams, Some(CAP)),
+        )
+        .expect_err("expected MemoryError once the per-entry charge fills the cap");
+
+    assert_eq!(err.exc_type(), ExcType::MemoryError);
+    assert_eq!(streams.entries().len(), CAP / PER_ENTRY);
+    let payload: usize = streams.entries().iter().map(|(_, s)| s.len()).sum();
+    assert_eq!(payload, CAP / PER_ENTRY);
 }

--- a/crates/monty/tests/print_writer.rs
+++ b/crates/monty/tests/print_writer.rs
@@ -10,11 +10,12 @@
 
 use insta::assert_snapshot;
 use monty::MontyRun;
-use monty_types::{CompileOptions, PrintWriter, ResourceTracker};
+use monty_types::{CollectedStreams, CompileOptions, PrintStream, PrintWriter, ResourceTracker};
 
 /// Run `code` under Monty with a string-collecting `PrintWriter` and return
 /// whatever was printed. Panics on parse/runtime errors — callers only care
-/// about the captured output.
+/// about the captured output. `CollectString` keeps no stream labels, so
+/// stderr output lands in the same buffer; see `run_and_capture_streams`.
 fn run_and_capture(code: &str) -> String {
     let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
     let mut output = String::new();
@@ -232,4 +233,77 @@ fn print_multiline_sep() {
     2
     3
     ");
+}
+
+// === file= routing ===
+
+/// Run `code` and return the labelled fragments, so a test can tell which
+/// stream each one went to.
+fn run_and_capture_streams(code: &str) -> Vec<(PrintStream, String)> {
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let mut streams = CollectedStreams::default();
+    ex.run(
+        vec![],
+        ResourceTracker::default(),
+        PrintWriter::collect_streams(&mut streams),
+    )
+    .unwrap();
+    streams.into_entries()
+}
+
+#[test]
+fn print_file_stderr_is_labelled_stderr() {
+    assert_eq!(
+        run_and_capture_streams("import sys\nprint('oops', file=sys.stderr)"),
+        vec![(PrintStream::Stderr, "oops\n".to_owned())]
+    );
+}
+
+#[test]
+fn print_file_stdout_matches_the_default() {
+    assert_eq!(
+        run_and_capture_streams("import sys\nprint('a', file=sys.stdout)\nprint('b')"),
+        vec![(PrintStream::Stdout, "a\nb\n".to_owned())]
+    );
+}
+
+/// Consecutive fragments merge per stream, so alternating between the two
+/// produces one entry per switch and keeps them in the order printed.
+#[test]
+fn print_alternating_streams_keep_their_order() {
+    assert_eq!(
+        run_and_capture_streams("import sys\nprint('1')\nprint('2', file=sys.stderr)\nprint('3')"),
+        vec![
+            (PrintStream::Stdout, "1\n".to_owned()),
+            (PrintStream::Stderr, "2\n".to_owned()),
+            (PrintStream::Stdout, "3\n".to_owned()),
+        ]
+    );
+}
+
+/// `sep` and `end` follow the file the call names, not the default stream.
+#[test]
+fn print_sep_and_end_follow_the_file() {
+    assert_eq!(
+        run_and_capture_streams("import sys\nprint('a', 'b', sep='-', end='!', file=sys.stderr)"),
+        vec![(PrintStream::Stderr, "a-b!".to_owned())]
+    );
+}
+
+#[test]
+fn print_file_other_than_a_sys_stream_raises() {
+    let ex = MontyRun::new(
+        "print('x', file=42)".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let err = ex
+        .run(vec![], ResourceTracker::default(), PrintWriter::Disabled)
+        .expect_err("only sys.stdout and sys.stderr can be written to");
+    assert_snapshot!(
+        err.message().unwrap(),
+        @"print() 'file' argument must be sys.stdout or sys.stderr, not int"
+    );
 }

--- a/docs/limitations/print.md
+++ b/docs/limitations/print.md
@@ -1,8 +1,8 @@
 # `print()`
 
 Output always goes to the host via a print callback (`vm.print_writer`). The
-host decides where it ends up; there is no real `sys.stdout` underneath (see
-[sys.md](sys.md)).
+host decides where it ends up; there is no real `sys.stdout` or `sys.stderr`
+underneath (see [sys.md](sys.md)).
 
 ## Supported keyword arguments
 
@@ -13,9 +13,12 @@ host decides where it ends up; there is no real `sys.stdout` underneath (see
 
 ## Rejected / ignored
 
-- `file=...` — rejected with `TypeError: "print() 'file' argument is not supported"`. Code that does
-    `print(..., file=sys.stderr)` will not work;
-    `sys.stderr` is an opaque marker (see [sys.md](sys.md)).
+- `file=...` — only `sys.stdout` and `sys.stderr` are accepted; both are
+    opaque markers matched by identity (see [sys.md](sys.md)). Anything else
+    raises `TypeError: "print() 'file' argument must be sys.stdout or sys.stderr, not {type}"`,
+    including an object defining `write()`, which CPython would call. CPython
+    instead raises `AttributeError: '{type}' object has no attribute 'write'`
+    for an object without one.
 - `flush=...` — accepted and ignored. Output is delivered to the host through
     the subprocess protocol on its own schedule (see "Chunk boundaries" below);
     a `print()` cannot make it arrive sooner.
@@ -27,6 +30,9 @@ host decides where it ends up; there is no real `sys.stdout` underneath (see
     before being written.
 - The host callback receives formatted chunks. There is no atomicity guarantee
     across multiple `print()` calls if the host interleaves with other output.
+- Stderr output is delivered through the same callback with `stream='stderr'`.
+    `CollectString` keeps no labels and interleaves both streams in one buffer;
+    `CollectStreams` labels each entry.
 
 ## Chunk boundaries
 
@@ -48,8 +54,12 @@ out the flush interval (5 ms by default), so:
     buffer is still drained before the next host call and at the end of the
     turn, so a host that needs liveness here can set the interval to 0 and get a
     callback as each line is written.
-- Ordering is exact, and the buffer is always drained before a host call or the
-    end of a run, so output cannot arrive after the event it preceded.
+- Both streams share that one buffer, so output alternating between them is
+    batched like any other; the callback is still called once per run, so a
+    chunk never mixes the two.
+- Ordering is exact, between the streams as well, and the buffer is always
+    drained before a host call or the end of a run, so output cannot arrive
+    after the event it preceded.
 - Buffered output is lost if the worker dies *hard*: the pool killing it on
     `request_timeout`, the allocator ending the process at its hard memory
     ceiling, or a crash. A graceful turn drains first, so this only affects a

--- a/docs/limitations/print.md
+++ b/docs/limitations/print.md
@@ -105,18 +105,22 @@ buffers. That growth is **not** covered by `ResourceLimits.max_memory`
         check is its own TypeScript implementation
         (`crates/monty-js/ts/print.ts`), not the Rust `PrintWriter`.
 - Pass `max_bytes=None` to disable the cap (trusted hosts only).
-- Python `CollectStreams` also charges a fixed per-entry overhead toward the
-    cap, since many tiny fragments would otherwise OOM the host before payload
-    bytes hit the limit. Rust `PrintWriter::CollectStreams` merges consecutive
-    same-stream fragments, so entry count stays small for normal `print()`.
+- Every `CollectStreams` also charges a fixed **64 bytes** per retained entry
+    toward the cap, since a retained entry costs vector and `String` bookkeeping
+    that is not text: without it, output alternating between the streams would
+    hold roughly 64x the host memory the cap accounts for. So the cap bounds
+    entries as well as payload, and a run collects less text than `max_bytes`
+    suggests — a fragment per entry caps out at `max_bytes / 65` of them.
+    Rust `PrintWriter::CollectStreams` merges consecutive same-stream fragments,
+    so an ordinary `print()` pays the overhead once.
 - Entries follow the chunk boundaries above, not `print()` calls: several
     prints usually collect into one entry. Set `print_flush_interval=0` to get
     one entry per completed line.
 - JS (`@pydantic/monty`): `CollectString` / `CollectStreams` accept `maxBytes`
     (camelCase), same 10 MiB default and message; `CollectStreams` charges the
-    same **64-byte** per-entry overhead as the Python host path and does **not**
-    merge consecutive same-stream fragments (unlike Rust in-process
-    `PrintWriter::CollectStreams`). Output entries are `{ stream, text }` objects
+    same **64-byte** per-entry overhead and does **not** merge consecutive
+    same-stream fragments (unlike Rust in-process
+    `PrintWriter::CollectStreams`), so it charges one per fragment. Output entries are `{ stream, text }` objects
     rather than Python tuples. The cap is a **logical UTF-8 charge**, not a hard
     V8/host-RSS bound: JS stores strings as UTF-16, so host RSS can exceed the
     stated cap.

--- a/docs/limitations/sys.md
+++ b/docs/limitations/sys.md
@@ -11,8 +11,10 @@ access raises `AttributeError`.
     `"win32"`. Code that branches on the host OS will not work; the sandbox
     does not expose which OS it runs on.
 - `sys.stdout` / `sys.stderr` — opaque marker objects with no methods. They
-    cannot be written to via `.write()`; printing always goes through the host
-    print callback regardless.
+    cannot be written to via `.write()`, and `sys.stdout.flush()` and the rest
+    raise `AttributeError`. They are useful only as `print(..., file=...)`,
+    which routes output to that stream through the host print callback (see
+    [print.md](print.md)).
 
 ## Not implemented
 

--- a/docs/quickstart/rust.md
+++ b/docs/quickstart/rust.md
@@ -159,7 +159,8 @@ assert_eq!(result, MontyObject::Int(55));
 ```
 
 Errors come back as [`MontyException`](../api/rust/monty-types.md#montyexception), with a traceback matching what CPython would produce.
-[`PrintWriter`](../api/rust/monty-types.md#printwriter) controls where `print()` output goes: `Stdout`, `Disabled`, or collected into a `String` or `(stream, text)` tuples.
+[`PrintWriter`](../api/rust/monty-types.md#printwriter) controls where `print()` output goes: `Stdout`, `Disabled`, or collected — into a `String`, or into a
+`CollectedStreams` buffer whose `entries()` label each run `stdout` or `stderr`.
 
 ### Resource limits
 


### PR DESCRIPTION
**Monty gains a second output producer.** Until now everything a sandbox printed arrived labelled `stdout`, because that was the only stream it could reach. `print(file=sys.stderr)` now routes to a stderr stream, so sandboxed code can emit a diagnostic without mixing it into the program's own output, and the host callback receives it as `('stderr', text)` to route, filter or colour on its own. `sys.stdout` and `sys.stderr` are matched by identity; any other `file=` still raises `TypeError`.

**How it interacts with the print debounce (#809).** The debounce holds output in one buffer, so the obvious way to keep two streams in order is to flush whenever the stream changes — which costs a frame per switch and undoes the batching for any run that alternates. Instead `Print` carries a repeated `PrintSegment`, so one event holds the runs of both streams in the order the sandbox produced them, and the size, interval and line triggers are untouched. The protocol version moves to 3.

This makes stderr a usable destination for `print()`, not a file object; the last column is what that would take.

| Capability | Today (`main`) | After this PR | Fully functional |
| --- | --- | --- | --- |
| `print(..., file=sys.stderr)` | `TypeError: … is not supported` | routes to the stderr stream | same |
| Stream label the host sees | always `stdout`; stderr unreachable | `stderr`, order kept across switches | same |
| Custom `file=` object with `.write()` | rejected, like every `file=` | rejected, message names the two markers | called, as CPython does |
| `sys.stderr` itself | opaque marker; `type()` claims `_io.TextIOWrapper`, `repr` is `<stderr>` | unchanged | real file object, honest `repr` |
| `.write()`, `.writelines()`, `.flush()`, `.close()`, `.encoding`, `.buffer`, `.isatty()` | `AttributeError` | unchanged | present, with `flush`/`close` no-ops over a callback and `fileno()` still an error |
| `sys.stderr = f`, `contextlib.redirect_stderr` | `AttributeError`; `contextlib` not importable | unchanged | assignable, and `print`/`write` honour the rebound object |
| `logging`, `warnings`, `traceback`; uncaught tracebacks | not importable; the traceback returns to the host as an exception value | unchanged | importable and defaulting to stderr |

`sys.stdin` stays absent by design.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrPbGFXrDG3H1MTV7QX3ab

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`print(file=sys.stderr)` previously raised `TypeError`; it now routes output to stderr, and hosts receive `('stderr', text)` while preserving order with stdout in batched events. Only `sys.stdout` and `sys.stderr` are accepted as `file=` targets; other objects still raise `TypeError`.

**Migration**
- Protocol version moves to 3, and version 2 peers are no longer served; `Print` now carries ordered stream segments.
- `PrintWriter::CollectStreams` now borrows a `CollectedStreams` buffer instead of a `Vec<(PrintStream, String)>`.
- `PrintWriterCallback` gains `stderr_write` and `stderr_push`, defaulting to stdout so existing hosts keep receiving output.
- The collect-streams cap charges 64 bytes per retained entry to bound alternating-stream output.
- `monty.print.bytes` records one measurement per stream per event instead of one per segment.

<sup>Written for commit 734b487c2cd34bae411a343c064e3885926ebda4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

