### PR TITLE
Link Python and Rust types in the docs to their API pages

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -3,3 +3,8 @@
 # One sentence per line is the house style, so never rewrap prose.
 wrap = "keep"
 end_of_line = "lf"
+
+# `[text][pydantic_monty.Name]` cross-references are resolved by mkdocs-autorefs
+# at build time, so do not escape them as missing link definitions.
+[plugin.mkdocs]
+ignore_missing_references = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1010,6 +1010,14 @@ The list of stdlib modules in `docs/limitations/index.md` must be updated if a n
 - Sandbox-side Python (code fed to Monty, not host code) belongs inside a host snippet as
     a string, or in a `test="skip"` block. It must never be a runnable top-level block —
     CPython would execute it.
+- Link the first mention of a `pydantic_monty` type, method or attribute in each section to its API page with the
+    autorefs form `[`Monty`][pydantic_monty.Monty]` / `[`MountDir.close()`][pydantic_monty.MountDir.close]`;
+    mkdocs-autorefs resolves it locally and the pydantic.dev pipeline resolves it from the `::: pydantic_monty` blocks
+    under `docs/api/python/`, so `make docs` fails on a name neither page documents (add it to a `:::` block first);
+    `.mdformat.toml` sets `ignore_missing_references` so `make format-md` leaves the syntax alone.
+    Rust items have no symbol map: link them explicitly as `[`Pool`](api/rust/monty-pool.md#pool)` (the anchor is
+    the lowercased top-level item name; methods, fields and variants share their parent's anchor).
+    JavaScript types have no API pages, so leave them as plain code spans.
 - New pages go in the `mkdocs.yml` `nav:`; the nav is what orders the docs site.
     That includes a new `limitations/` file, which goes in the flat Limitations section (nested groups would change
     the page URLs and break the relative links between limitations pages).

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -78,14 +78,14 @@ Every row was measured on 2026-09-03 (Full Monty on 2026-09-04) on an Apple M3 M
 from CPython 3.14.7, with a single sample per cold start unless stated.
 The tables round the numbers; the measured cold-start values are in the text below.
 
-- **Monty**: `pydantic-monty` 0.0.21 with a release build of the `monty` worker binary, driven through `Monty()` /
+- **Monty**: `pydantic-monty` 0.0.21 with a release build of the `monty` worker binary, driven through [`Monty()`][pydantic_monty.Monty] /
     `pool.checkout()` / `session.feed_run()`, the package's only execution API.
     Cold start creates the pool, which spawns the worker subprocess, completes the protocol handshake, checks out a
     session and runs `1 + 1`; the median of 7 runs is 4.5 ms.
     Warm pool is the median of 20 `checkout()` + `feed_run()` round trips against a pool whose worker already exists.
     The agent run is ten `feed_run` calls on one checkout, so state persists and nothing is replayed.
 - **Full Monty**: the [Full Monty](server.md) container image (0.0.22, a native `linux/arm64` build) running in Docker
-    Desktop 29.6.2 on the same machine, dialled with `pydantic-monty` 0.0.22's `AsyncMontyWebsocket` over
+    Desktop 29.6.2 on the same machine, dialled with `pydantic-monty` 0.0.22's [`AsyncMontyWebsocket`][pydantic_monty.AsyncMontyWebsocket] over
     `ws://localhost`.
     The client runs in a second container on the same host so the figure is the server's own overhead over loopback,
     not Docker Desktop's port-forwarding proxy.
@@ -153,10 +153,10 @@ The tables round the numbers; the measured cold-start values are in the text bel
     machine running your application.
 - **Start latency**: a WebSocket connection plus a worker spawn for the session, 4 ms measured over loopback inside
     a Linux container; a deployment adds its network round trip.
-- **FOSS**: closed-source and commercial; the client, `AsyncMontyWebsocket`, ships in the MIT `pydantic-monty`
+- **FOSS**: closed-source and commercial; the client, [`AsyncMontyWebsocket`][pydantic_monty.AsyncMontyWebsocket], ships in the MIT `pydantic-monty`
     package.
 - **Setup complexity**: run the container image with one environment variable, the dump-signing key.
-- **File mounting**: client directories are mounted over the wire, the same `MountDir` as a local pool.
+- **File mounting**: client directories are mounted over the wire, the same [`MountDir`][pydantic_monty.MountDir] as a local pool.
 - **Snapshotting**: as Monty, and a draining server hands each session a signed dump to restore elsewhere.
 
 ## Docker

--- a/docs/api/python/host_objects.md
+++ b/docs/api/python/host_objects.md
@@ -1,0 +1,20 @@
+---
+# Show individual methods/attributes (h5) in the docs site's on-page TOC.
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 5
+---
+
+# Host Objects
+
+The policy wrappers that put a host object, or a host class, in front of the sandbox, and the read-only proxies the
+sandbox hands back for instances the host has no original object for.
+See [host objects](../../host-objects.md) for the concepts.
+
+::: pydantic_monty
+    options:
+        members:
+            - ClassInstance
+            - ClassType
+            - MontyClassProxy
+            - MontyClassTypeProxy

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -11,7 +11,7 @@ an **`os` callback**, which answers filesystem operations in host code.
 
 ## Mounts
 
-A `MountDir` maps a host directory to a virtual path inside the sandbox.
+A [`MountDir`][pydantic_monty.MountDir] maps a host directory to a virtual path inside the sandbox.
 Mounts are per-feed, and all arguments are keyword-only:
 
 === "Python"
@@ -165,7 +165,7 @@ It is called as `(function_name, args, kwargs)` and its return value is handed b
     console.log(await session.feedRun("import os\nos.getenv('STAGE')", { os: handleOs })) // production
     ```
 
-Returning the `NOT_HANDLED` sentinel declines the call, and the sandbox raises whatever it would have raised with no
+Returning the [`NOT_HANDLED`][pydantic_monty.NOT_HANDLED] sentinel declines the call, and the sandbox raises whatever it would have raised with no
 handler at all.
 
 The operations that can arrive are a fixed set: `Path.exists`, `Path.is_file`, `Path.is_dir`, `Path.is_symlink`, `open`,
@@ -187,7 +187,7 @@ no-handler default explicitly.
 
 ## A virtual filesystem
 
-`pydantic_monty` ships a ready-made `AbstractOS` implementation for when you want a filesystem with no host directory
+`pydantic_monty` ships a ready-made [`AbstractOS`][pydantic_monty.AbstractOS] implementation for when you want a filesystem with no host directory
 behind it at all.
 JavaScript has no equivalent class, so the TypeScript tab answers the same operations from a `Map` in an `os` callback:
 
@@ -232,18 +232,18 @@ JavaScript has no equivalent class, so the TypeScript tab answers the same opera
     console.log(await session.feedRun(code, { os: fs })) // 2
     ```
 
-`OSAccess` backed by `MemoryFile` objects is fully sandboxed: content lives in host memory, path traversal cannot escape
+[`OSAccess`][pydantic_monty.OSAccess] backed by [`MemoryFile`][pydantic_monty.MemoryFile] objects is fully sandboxed: content lives in host memory, path traversal cannot escape
 to real files, and `os.getenv` sees only the `environ` mapping you passed.
 
-`CallbackFile` read and write callbacks run in the host and can reach real resources.
+[`CallbackFile`][pydantic_monty.CallbackFile] read and write callbacks run in the host and can reach real resources.
 That is the point of it, but it means an `OSAccess` containing a `CallbackFile` is exactly as sandboxed as the callback
 you wrote.
 
 For anything more specific, subclass `OSAccess` and override the methods you want to change, or implement every
 abstract method of `AbstractOS` yourself; the optional hooks (`path_open`, the append methods, `date_today`,
-`datetime_now`) report `NOT_HANDLED` to Monty if you make them raise `NotImplementedError`.
+`datetime_now`) report [`NOT_HANDLED`][pydantic_monty.NOT_HANDLED] to Monty if you make them raise `NotImplementedError`.
 
 ## Rust
 
-Rust hosts hold a `MountTable` from [`monty-fs`](https://crates.io/crates/monty-fs) and service suspensions with
-`MountTable::handle_os_call`; `monty-pool` does this for you when you pass `MountSpec`s to `Checkout::feed`.
+Rust hosts hold a [`MountTable`](api/rust/monty-fs.md#mounttable) from [`monty-fs`](https://crates.io/crates/monty-fs) and service suspensions with
+[`MountTable::handle_os_call`](api/rust/monty-fs.md#mounttable); `monty-pool` does this for you when you pass [`MountSpec`](api/rust/monty-pool.md#mountspec)s to [`Checkout::feed`](api/rust/monty-pool.md#checkout).

--- a/docs/host-functions.md
+++ b/docs/host-functions.md
@@ -164,15 +164,15 @@ Positional and keyword arguments pass through as written:
 Return values must be types Monty can represent — the same set `inputs` and `external_lookup` accept, listed under
 [which values cross the boundary](quickstart/python.md#which-values-cross-the-boundary).
 Arguments come the other way, out of the sandbox.
-A sandbox-defined class instance arrives as a read-only `MontyClassProxy`; see
+A sandbox-defined class instance arrives as a read-only [`MontyClassProxy`][pydantic_monty.MontyClassProxy]; see
 [host objects](host-objects.md#sandbox-instances).
 A sandbox value with no host equivalent arrives silently as a *string* rather than raising: the repr of a sandbox
 class object, function or compiled `re` pattern, or the bare name of a host function handed back in.
 A host function cannot tell it from a sandbox `str` of the same text.
 
-A return value Monty cannot represent does not raise `MontyConversionError`.
+A return value Monty cannot represent does not raise [`MontyConversionError`][pydantic_monty.MontyConversionError].
 It is delivered into the sandbox as `TypeError: Cannot convert X to Monty value`, which sandboxed code can catch;
-uncaught, it reaches you as `MontyRuntimeError`.
+uncaught, it reaches you as [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError].
 The same is true of an `os=` callback's return value.
 `MontyConversionError` is for host values you hand over up front, in `inputs` or `external_lookup`.
 
@@ -234,13 +234,13 @@ sandbox, so sandboxed code can catch it:
     console.log(await session.feedRun(code, { externalLookup: { fetch } })) // caught: bad url
     ```
 
-If the sandbox does not catch it, `feed_run` raises `MontyRuntimeError` with the sandbox traceback.
+If the sandbox does not catch it, `feed_run` raises [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError] with the sandbox traceback.
 Only [the exception types Monty implements](limitations/index.md) can cross; the type name is what carries over, not your
 exception class.
 
 ## Async host functions
 
-With `AsyncMonty`, callables in `external_lookup` may be coroutine functions.
+With [`AsyncMonty`][pydantic_monty.AsyncMonty], callables in `external_lookup` may be coroutine functions.
 They are awaited on your event loop, so blocking work inside one blocks it exactly as it would anywhere else in your
 async code — what `AsyncMonty` moves off the loop is worker I/O, not your callbacks.
 In JavaScript every host function may be async, and there is no separate pool class.
@@ -299,7 +299,7 @@ In JavaScript every host function may be async, and there is no separate pool cl
     console.log(await session.feedRun(code, { externalLookup: { fetch } })) // 2
     ```
 
-The sync `Monty` cannot drive coroutine host functions — use `AsyncMonty`, or resolve the pending futures by hand with
+The sync [`Monty`][pydantic_monty.Monty] cannot drive coroutine host functions — use `AsyncMonty`, or resolve the pending futures by hand with
 [`feed_start`](snapshots.md).
 
 ## Driving suspensions yourself

--- a/docs/host-objects.md
+++ b/docs/host-objects.md
@@ -1,6 +1,6 @@
 # Host Objects
 
-`ClassInstance` and `ClassType` put a host object, or a host class, in front of the sandbox.
+[`ClassInstance`][pydantic_monty.ClassInstance] and [`ClassType`][pydantic_monty.ClassType] put a host object, or a host class, in front of the sandbox.
 Each wrapper is a policy: it lists which attributes cross eagerly, which the sandbox may fetch on demand, and which
 methods it may call.
 Every policy defaults to nothing, and `'all'` never exposes underscore-prefixed names.
@@ -168,7 +168,7 @@ where sandbox code can catch it; only `AttributeError` reads as absent.
 
 `init=True` grants construction; without it, calling the class raises `TypeError: cannot instantiate host class 'Person'` in the sandbox.
 The construction runs on the host, and the new instance crosses back governed by the `instance_*` policies.
-A constructed instance keeps the `ClassType` that built it, so `type(p)` is the class the sandbox was given.
+A constructed instance keeps the [`ClassType`][pydantic_monty.ClassType] that built it, so `type(p)` is the class the sandbox was given.
 On a `ClassType` itself, `eager_attrs`, `lazy_attrs` and `allowed_methods` expose class constants, classmethods and
 staticmethods.
 
@@ -176,7 +176,7 @@ staticmethods.
 
 Nothing is wrapped automatically: a method that returns another object fails conversion unless a `convert_value` hook
 wraps it with a policy you chose.
-In Python the hook is a method on a `ClassInstance` subclass; in JavaScript it is the `convertValue` option.
+In Python the hook is a method on a [`ClassInstance`][pydantic_monty.ClassInstance] subclass; in JavaScript it is the `convertValue` option.
 
 === "Python"
 
@@ -287,17 +287,17 @@ Set it for untrusted code, and recycle long-lived sessions.
     console.log(await session.feedRun('back is counter', { inputs: { back: proxy } })) // true
     ```
 
-A sandbox-defined instance reaches the host as a read-only `MontyClassProxy` with `name`, `attributes`, `is_dataclass`
+A sandbox-defined instance reaches the host as a read-only [`MontyClassProxy`][pydantic_monty.MontyClassProxy] with `name`, `attributes`, `is_dataclass`
 and `id`; the host cannot call its methods.
 Passing the proxy back hands the sandbox its original object, and a proxy whose object the sandbox has freed raises.
 
 ## Snapshots
 
-`feed_start` suspends on a method call or a lazy attribute read as it does on a host function: `FunctionSnapshot` and
-`NameLookupSnapshot` carry `object_id`, the uuid of the wrapper involved (`ClassInstance.id` or `ClassType.id`), not
+`feed_start` suspends on a method call or a lazy attribute read as it does on a host function: [`FunctionSnapshot`][pydantic_monty.FunctionSnapshot] and
+[`NameLookupSnapshot`][pydantic_monty.NameLookupSnapshot] carry `object_id`, the uuid of the wrapper involved ([`ClassInstance.id`][pydantic_monty.ClassInstance.id] or [`ClassType.id`][pydantic_monty.ClassType.id]), not
 the host object's `id()`; it is `None` for plain host functions and name lookups.
-The instance store does not travel with a dump: a restored session returns a host instance as `MontyClassProxy` and a
-host class, `type(x)` included, as a read-only `MontyClassTypeProxy` (`name`, `id`, `is_dataclass`, `attributes`) that
+The instance store does not travel with a dump: a restored session returns a host instance as [`MontyClassProxy`][pydantic_monty.MontyClassProxy] and a
+host class, `type(x)` included, as a read-only [`MontyClassTypeProxy`][pydantic_monty.MontyClassTypeProxy] (`name`, `id`, `is_dataclass`, `attributes`) that
 re-enters as the same class; JavaScript has no such class and returns a plain `{ __monty_type__: 'Type', ... }` marker
 instead.
 On those objects, method calls and `init=True` construction raise `RuntimeError` inside the sandbox and lazy attribute

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ command *n* re-runs commands 1 to *n*.
 
 Learn more in the [comparison to alternatives](alternatives.md).
 
-!!! tip
+!!! tip "Commercial support"
 
     If you're interested in running Monty in the most secure and scalable setup, please see
     [Full Monty](server.md).

--- a/docs/limitations/AGENTS.md
+++ b/docs/limitations/AGENTS.md
@@ -33,6 +33,8 @@ Only divergences belong here; behaviour that matches CPython is not recorded.
 Link between pages with relative markdown links (`see [classes.md](classes.md)`) rather than naming the file in
 prose, so the reference works on the site as well as in the repository.
 `mkdocs build --strict` fails on a link to a page that does not exist.
+Host-side `pydantic_monty` types link to their API page as `[`MountDir`][pydantic_monty.MountDir]` and Rust items as
+`[`Checkout`](../api/rust/monty-pool.md#checkout)`, per the docs rules in the root `CLAUDE.md`.
 
 Python snippets on these pages are sandbox-side code, so they are marked ```` ```python test="skip" ````;
 `make test-docs` would otherwise run them under CPython.

--- a/docs/limitations/filesystem.md
+++ b/docs/limitations/filesystem.md
@@ -1,7 +1,7 @@
 # Filesystem and sandbox boundary
 
 The sandbox has no default filesystem access. The host explicitly mounts
-real directories at virtual paths through Monty's `MountTable`; everything
+real directories at virtual paths through Monty's [`MountTable`](../api/rust/monty-fs.md#mounttable); everything
 outside a mount is invisible. Without any mounts, `open()` and every
 `pathlib` I/O method raise `PermissionError` for every path (see
 [open.md](open.md) and [pathlib.md](pathlib.md)).
@@ -173,7 +173,7 @@ the null byte.
 
 Mounting opens a descriptor on the host directory. On macOS and the BSDs that
 needs read permission, so a search-only directory (mode `0o111`) is refused:
-`MountDir` raises at construction, even though a host process can traverse it
+[`MountDir`][pydantic_monty.MountDir] raises at construction, even though a host process can traverse it
 and read known paths inside. Linux opens directories with `O_PATH` and accepts
 it. Grant `r-x` on anything you intend to mount portably.
 
@@ -200,7 +200,7 @@ so the host cannot move or delete a directory for as long as it is mounted;
 the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
 `@pydantic/monty` is the lifetime of the mount object, not one feed. Close it
-(`MountDir.close()`, or the `with` / `using` block) to release the directory
+([`MountDir.close()`][pydantic_monty.MountDir.close], or the `with` / `using` block) to release the directory
 before the host touches it (see [pool-architecture.md](pool-architecture.md)).
 
 ### A mount follows its directory, not its path

--- a/docs/limitations/pool-architecture.md
+++ b/docs/limitations/pool-architecture.md
@@ -34,20 +34,20 @@ properties that real CPython does not provide, per the caveat above.
     REPL session in a dedicated worker, and a one-shot run is a checkout plus a
     single feed. `feed_run` drives external function calls, OS callbacks, and
     print callbacks automatically. `feed_start` instead returns a *snapshot* at
-    each suspension (`FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot`,
-    or `MontyComplete`) for the caller to inspect, `dump()`, and `resume(...)`;
+    each suspension ([`FunctionSnapshot`][pydantic_monty.FunctionSnapshot] / [`NameLookupSnapshot`][pydantic_monty.NameLookupSnapshot] / [`FutureSnapshot`][pydantic_monty.FutureSnapshot],
+    or [`MontyComplete`][pydantic_monty.MontyComplete]) for the caller to inspect, `dump()`, and `resume(...)`;
     see the snapshot divergences below.
 - A session whose worker crashed is lost: subsequent calls raise
-    `MontyCrashedError`, which also carries a worker's own account when it
-    announced a `FatalError` before exiting (e.g. an unsupported protocol
+    [`MontyCrashedError`][pydantic_monty.MontyCrashedError], which also carries a worker's own account when it
+    announced a [`FatalError`](../api/rust/monty-proto.md#fatalerror) before exiting (e.g. an unsupported protocol
     version), plus the exit status when the process could be reaped. The pool
     itself recovers by replacing the worker.
 - **WebSocket sessions are lost in two additional ways.** A connection that
-    closes mid-session raises `MontyDisconnectError`: the client cannot tell a
+    closes mid-session raises [`MontyDisconnectError`][pydantic_monty.MontyDisconnectError]: the client cannot tell a
     dead remote sandbox from a server-side policy drop (idle/session/turn
     timeout, over capacity), so the error claims no more than that the
     connection went away. A server that is shutting down instead answers the
-    session's next request with `MontyShutdown`. That request did **not** run,
+    session's next request with [`MontyShutdown`][pydantic_monty.MontyShutdown]. That request did **not** run,
     and its `dump` (when present) restores the session onto a fresh checkout
     via `session.load_session` / `session.load_snapshot`. If the interrupted
     request was answering a suspension (external function or `os` callback),
@@ -55,7 +55,7 @@ properties that real CPython does not provide, per the caveat above.
     it runs twice unless the callback is idempotent. Neither error occurs on
     the local subprocess transport; a local child claiming shutdown is a
     protocol violation.
-- **The session `Configure` request carries the parent's `protocol_version`,
+- **The session [`Configure`](../api/rust/monty-proto.md#configure) request carries the parent's `protocol_version`,
     and the worker rejects one it does not serve.** The protocol has no in-band
     negotiation, so a parent outside the child's supported range
     (`MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION`) gets a `FatalError`
@@ -108,7 +108,7 @@ properties that real CPython does not provide, per the caveat above.
     across feeds, and travels inside dumps. The worker reports its total on
     every protocol turn; the host never keeps a second clock.
 - **`max_suspensions` is enforced by the host.** The pool counts suspension
-    events per checkout and answers the first one over budget with `AbortFeed`.
+    events per checkout and answers the first one over budget with [`AbortFeed`](../api/rust/monty-proto.md#abortfeed).
     The worker raises its `RuntimeError` uncatchably at the suspension point.
     The worker stores the limit for dumps but does not count, so restoring a
     session resets the count. The limit a restore re-adopts from the worker's
@@ -123,7 +123,7 @@ properties that real CPython does not provide, per the caveat above.
     losing the session. Mount I/O runs on the host between protocol turns and
     does not count against the worker's deadline. The budget and consumed time
     are also stamped onto the worker's replies, so sessions restored via the
-    Rust `Checkout::restore` regain the backstop too. A *compromised* worker
+    Rust [`Checkout::restore`](../api/rust/monty-pool.md#checkout) regain the backstop too. A *compromised* worker
     could under-report its total, stretching each turn to the full budget plus
     grace; turns stay bounded, and `request_timeout` applies independently.
     Both deadlines fire between the turn's polls, so decoding one maximal reply
@@ -142,7 +142,7 @@ properties that real CPython does not provide, per the caveat above.
     worker's allocator exits 65 (`EX_DATAERR`: the fed snippet asked for more than
     it may have) rather than letting Rust abort (`SIGABRT`, which a stack overflow
     also produces and which would be unclassifiable), so the host gets
-    `MontyRuntimeError`/`MemoryError` with a
+    [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError]/`MemoryError` with a
     distinct message instead of `MontyCrashedError`. The worker is already
     dead and later calls on that checkout report `Finished`. An ordinary in-sandbox
     exception leaves the session usable; a failed `load_session` / `load_snapshot`
@@ -169,11 +169,11 @@ properties that real CPython does not provide, per the caveat above.
 - Process/WebSocket transports encode values as protobuf
     (`proto/monty/v1/monty.proto`). The browser component instead uses semantic
     flat node arenas because WIT cannot express recursive types. Every
-    `MontyObject` variant round-trips through either representation, with the
+    [`MontyObject`](../api/rust/monty-types.md#montyobject) variant round-trips through either representation, with the
     same nesting bound: roughly 48 nested list-like containers, 32 nested dicts,
     or 24 nested class instances. Deeper values fail the turn rather than
     crossing the boundary.
-- `Cycle` markers (self-referential containers) can be *received* from a
+- [`Cycle`](../api/rust/monty-proto.md#cycle) markers (self-referential containers) can be *received* from a
     worker but are rejected as inputs.
 - A sandbox value with no `MontyObject` equivalent — a class, a class
     instance, a function, a compiled `re` pattern — is **silently degraded to
@@ -226,11 +226,11 @@ properties that real CPython does not provide, per the caveat above.
     sandbox, not host-side.** An unrepresentable type becomes a catchable
     `TypeError: Cannot convert X to Monty value`; one nested past the wire depth
     bound becomes a catchable `RuntimeError: Max input depth exceeded`. Either
-    reaches the host as `MontyRuntimeError` only when the sandbox does not catch
+    reaches the host as [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError] only when the sandbox does not catch
     it. The same holds for an `os=` callback's return value, and for the JS
-    client. `MontyConversionError` covers only values the host supplies up
+    client. [`MontyConversionError`][pydantic_monty.MontyConversionError] covers only values the host supplies up
     front, in `inputs` or `external_lookup`.
-- **Typing errors** (`checkout(type_check=True)`) raise `MontyTypingError`
+- **Typing errors** (`checkout(type_check=True)`) raise [`MontyTypingError`][pydantic_monty.MontyTypingError]
     whose diagnostics were rendered *in the worker*, so the format is a
     checkout argument (`type_check_format=`, `type_check_color=`; JS
     `typeCheckFormat` / `typeCheckColor`) and `display()` takes no arguments:
@@ -246,10 +246,10 @@ properties that real CPython does not provide, per the caveat above.
     protocol turn, not mid-`print`; if that turn had suspended (an external
     function, OS call, or name lookup), the binding resets/discards the
     suspension before surfacing the print error so later feeds can continue.
-- **The sync API adapts to the caller's Tokio context.** `Monty` methods block
+- **The sync API adapts to the caller's Tokio context.** [`Monty`][pydantic_monty.Monty] methods block
     the calling thread on the binding's Tokio runtime. Called from a worker
     thread of a multi-thread runtime, e.g. a sync external function or
-    `print_callback` invoked by an `AsyncMonty` drive, the wait is wrapped in
+    `print_callback` invoked by an [`AsyncMonty`][pydantic_monty.AsyncMonty] drive, the wait is wrapped in
     `tokio::task::block_in_place`, so opening an independent nested sync
     pool/session works (each concurrent nested call occupies an extra OS thread
     while it waits). Called from any *current-thread* Tokio runtime context,
@@ -258,7 +258,7 @@ properties that real CPython does not provide, per the caveat above.
     nested pools/sessions are
     supported: re-entering the *same* session from its own callback deadlocks
     on the session's internal lock.
-- **Mounts are host-side.** `MountDir` objects contribute configuration only;
+- **Mounts are host-side.** [`MountDir`][pydantic_monty.MountDir] objects contribute configuration only;
     the pool builds a fresh mount table per feed on the *host* and services the
     worker's filesystem OS calls itself. The worker never sees host paths, so
     mounts work identically for local subprocess and remote WebSocket workers.
@@ -279,14 +279,14 @@ properties that real CPython does not provide, per the caveat above.
     lives.** It holds an open descriptor, and Windows refuses to rename or delete
     a directory while a handle to it is open, so the host gets
     `ERROR_SHARING_VIOLATION` until the mount is closed, not just until the feed
-    ends. `MountDir.close()` releases it (also `with` in Python, `using` in
+    ends. [`MountDir.close()`][pydantic_monty.MountDir.close] releases it (also `with` in Python, `using` in
     JavaScript); a feed already running keeps its own reference, and feeding a
     closed mount raises. Unix is unaffected, and closing is optional there.
 - **Mounts only answer calls on the automatic path.** Every OS call the sandbox
     makes surfaces as a suspension; the pool consults the mount table only when
     the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS
     call, so mounted I/O is transparent there. `feed_start` never does: a mounted
-    read comes back as a `FunctionSnapshot` with `is_os_function` set, and it is
+    read comes back as a [`FunctionSnapshot`][pydantic_monty.FunctionSnapshot] with `is_os_function` set, and it is
     `resume_auto()` that offers the call to the mounts and then to `os=`.
     Answering such a snapshot with an explicit `resume(...)` bypasses the mount
     entirely; the value you supply is what the sandbox sees.
@@ -333,7 +333,7 @@ properties that real CPython does not provide, per the caveat above.
     present in both is served by the `inputs` binding, so no lookup fires). A
     non-callable value that cannot be converted rejects the turn host-side:
     because `external_lookup` (and `inputs`) may hold untrusted values, an
-    unrepresentable *type* surfaces as a dedicated `MontyError` subclass (in
+    unrepresentable *type* surfaces as a dedicated [`MontyError`][pydantic_monty.MontyError] subclass (in
     `pydantic_monty`, `MontyConversionError`; its `exception()` reconstructs a
     native `TypeError`), **never** as a masquerading `NameError`; other converter
     failures, such as exceeding the max input nesting depth, keep their own type
@@ -368,8 +368,8 @@ properties that real CPython does not provide, per the caveat above.
     `uv run`. The Monty sandbox worker has no such behavior: a `# /// script`
     block is just a comment and its dependencies are never installed.
 - **`dump()`** bytes carry monty's own versioned session format and can only be
-    restored into a worker built with the same `DUMP_VERSION`, via
-    `session.load_session` / `session.load_snapshot` (Rust `Checkout::restore`).
+    restored into a worker built with the same [`DUMP_VERSION`](../api/rust/monty.md#dump_version), via
+    `session.load_session` / `session.load_snapshot` (Rust [`Checkout::restore`](../api/rust/monty-pool.md#checkout)).
     A version mismatch is reported as such, naming both versions, so a stale
     snapshot is distinguishable from a corrupt one.
 - **`feed_start` snapshots are live cursors, not owned state.** The execution
@@ -390,11 +390,11 @@ properties that real CPython does not provide, per the caveat above.
     its own `script_name` / limits / type-check state (the `checkout()` config
     for those is not applied). The session's class-instance store is host-side
     and NOT part of the dump: restoring into a fresh session/process starts with
-    an empty store, so a returned host instance becomes a `MontyClassProxy`
+    an empty store, so a returned host instance becomes a [`MontyClassProxy`][pydantic_monty.MontyClassProxy]
     stand-in (a returned host class, `type(x)` included, a
-    `MontyClassTypeProxy`), a lazy attribute lookup raises `AttributeError`,
+    [`MontyClassTypeProxy`][pydantic_monty.MontyClassTypeProxy]), a lazy attribute lookup raises `AttributeError`,
     and a method call on it — as well as a construction or classmethod call on a
-    `ClassType`-granted class — raises `RuntimeError` ("no host object
+    [`ClassType`][pydantic_monty.ClassType]-granted class — raises `RuntimeError` ("no host object
     registered for method call '...' (id ...) — the instance store is empty
     after loading a dump into a fresh session").
 - **The class-instance store retains every wrapper sent into the sandbox until
@@ -438,7 +438,7 @@ properties that real CPython does not provide, per the caveat above.
     subprocess boundary as structured protocol values; the old
     `MontyComplete.output_json()` / `FunctionSnapshot.args_json()` /
     `kwargs_json()` helper format is not part of the pool API. (`feed_start`
-    snapshots and `MontyComplete` expose `args` / `kwargs` / `output` as
+    snapshots and [`MontyComplete`][pydantic_monty.MontyComplete] expose `args` / `kwargs` / `output` as
     converted Python objects only.)
 
 ## JavaScript client (`@pydantic/monty`)
@@ -453,8 +453,8 @@ same protocol in TypeScript over a WASM worker. Everything above applies, plus:
     (`TypeError`, `ValueError`, `KeyError`, ...); anything else becomes
     `RuntimeError`. Tracebacks of host errors are not preserved.
 - **Snapshots mirror `pydantic_monty`.** `session.feedStart(code, opts)`
-    returns a `FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot` (or a
-    `MontyComplete`); `session.dump()` / `snapshot.dump()` serialize the worker,
+    returns a [`FunctionSnapshot`][pydantic_monty.FunctionSnapshot] / [`NameLookupSnapshot`][pydantic_monty.NameLookupSnapshot] / [`FutureSnapshot`][pydantic_monty.FutureSnapshot] (or a
+    [`MontyComplete`][pydantic_monty.MontyComplete]); `session.dump()` / `snapshot.dump()` serialize the worker,
     and `session.loadSnapshot(bytes, opts)` restores it (fresh-session-only,
     returning the re-announced snapshot or `null`). Differences from Python: a
     name lookup resolves only to an external *function* (`resume(functionName?)`,
@@ -465,7 +465,7 @@ same protocol in TypeScript over a WASM worker. Everything above applies, plus:
     `FutureSnapshot.resume([{callId, value}|{callId, error}])`).
 - **Wrapper policies never reach JS object machinery.** `constructor`,
     `__proto__`, `prototype`, `arguments` and `caller` are refused under every
-    `ClassInstance` / `ClassType` policy, explicit lists included, and members
+    [`ClassInstance`][pydantic_monty.ClassInstance] / [`ClassType`][pydantic_monty.ClassType] policy, explicit lists included, and members
     found on `Object.prototype` / `Function.prototype` (`toString`,
     `hasOwnProperty`, `call`, `bind`, ...) count as absent. A string policy
     other than `'all'` throws `TypeError` at construction. Keyword arguments

--- a/docs/limitations/pool-architecture.md
+++ b/docs/limitations/pool-architecture.md
@@ -453,8 +453,8 @@ same protocol in TypeScript over a WASM worker. Everything above applies, plus:
     (`TypeError`, `ValueError`, `KeyError`, ...); anything else becomes
     `RuntimeError`. Tracebacks of host errors are not preserved.
 - **Snapshots mirror `pydantic_monty`.** `session.feedStart(code, opts)`
-    returns a [`FunctionSnapshot`][pydantic_monty.FunctionSnapshot] / [`NameLookupSnapshot`][pydantic_monty.NameLookupSnapshot] / [`FutureSnapshot`][pydantic_monty.FutureSnapshot] (or a
-    [`MontyComplete`][pydantic_monty.MontyComplete]); `session.dump()` / `snapshot.dump()` serialize the worker,
+    returns a `FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot` (or a
+    `MontyComplete`); `session.dump()` / `snapshot.dump()` serialize the worker,
     and `session.loadSnapshot(bytes, opts)` restores it (fresh-session-only,
     returning the re-announced snapshot or `null`). Differences from Python: a
     name lookup resolves only to an external *function* (`resume(functionName?)`,
@@ -465,7 +465,7 @@ same protocol in TypeScript over a WASM worker. Everything above applies, plus:
     `FutureSnapshot.resume([{callId, value}|{callId, error}])`).
 - **Wrapper policies never reach JS object machinery.** `constructor`,
     `__proto__`, `prototype`, `arguments` and `caller` are refused under every
-    [`ClassInstance`][pydantic_monty.ClassInstance] / [`ClassType`][pydantic_monty.ClassType] policy, explicit lists included, and members
+    `ClassInstance` / `ClassType` policy, explicit lists included, and members
     found on `Object.prototype` / `Function.prototype` (`toString`,
     `hasOwnProperty`, `call`, `bind`, ...) count as absent. A string policy
     other than `'all'` throws `TypeError` at construction. Keyword arguments

--- a/docs/limitations/resource_limits.md
+++ b/docs/limitations/resource_limits.md
@@ -93,7 +93,7 @@ without one is unlimited.
     comparable limit to `checkout()`.
 - **The wasm worker cannot classify a hard breach.** A soft breach is a normal
     `MemoryError`, but exceeding the hard limit traps the instance and the host
-    reports `MontyCrashedError`. Its `usize` is also 32 bits, so a limit near
+    reports [`MontyCrashedError`][pydantic_monty.MontyCrashedError]. Its `usize` is also 32 bits, so a limit near
     4 GiB leaves the module uncapped.
 - WebSocket workers get no allocator-enforced limit at all: they are remote
     processes this pool does not spawn.
@@ -171,7 +171,7 @@ indistinguishable from a stack overflow.
 ## Time
 
 - The host can set a `max_duration` budget; if exceeded the VM stops with a
-    `ResourceError` at its next checkpoint.
+    [`ResourceError`](../api/rust/monty-types.md#resourceerror) at its next checkpoint.
 - Enforcement is polled, not preemptive: a single bytecode instruction may
     run a long native operation (a `bytes` substring scan, a sort, an iterator
     drain), and those poll the clock at a coarse granularity. A run can

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -53,7 +53,7 @@ with Monty() as pool:
         #> 11
 ```
 
-`Monty()` configures the pool; the workers are spawned by `with`.
+[`Monty()`][pydantic_monty.Monty] configures the pool; the workers are spawned by `with`.
 `pool.checkout()` dedicates one worker to one REPL session.
 `feed_run` executes a snippet and returns the value of its trailing expression.
 `inputs` are values the snippet can read; `external_lookup` holds the host functions it can call.
@@ -95,8 +95,8 @@ A name present in both is served by the eager `inputs` binding.
 `Ellipsis`, `NotImplemented`, `datetime.date`, `datetime.datetime`, `datetime.timedelta`, `datetime.timezone`, named
 tuples, exception instances, and the type objects Monty models (`int`, `str`, `datetime.date`, ...) all convert in both
 directions.
-Class instances differ in each direction: a host instance enters only wrapped in `ClassInstance`, and a sandbox-defined
-instance comes out as a read-only `MontyClassProxy`.
+Class instances differ in each direction: a host instance enters only wrapped in [`ClassInstance`][pydantic_monty.ClassInstance], and a sandbox-defined
+instance comes out as a read-only [`MontyClassProxy`][pydantic_monty.MontyClassProxy].
 See [host objects](../host-objects.md).
 Put callables in `external_lookup`, where they become [host functions](../host-functions.md); a callable in `inputs`
 binds only a reference the sandbox still resolves through `external_lookup` when it is called.
@@ -106,7 +106,7 @@ macOS.
 They come back as `PurePosixPath`, and a `PureWindowsPath` / `WindowsPath` is rejected, because paths inside the sandbox
 are always POSIX.
 
-Anything else is rejected with `MontyConversionError` before it reaches the sandbox:
+Anything else is rejected with [`MontyConversionError`][pydantic_monty.MontyConversionError] before it reaches the sandbox:
 
 ```python
 from decimal import Decimal
@@ -155,7 +155,7 @@ with Monty() as pool:
             #> MemoryError
 ```
 
-An infinite loop hits `max_duration_secs` the same way, raising a `MontyRuntimeError` whose `exception()` is a
+An infinite loop hits `max_duration_secs` the same way, raising a [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError] whose `exception()` is a
 `TimeoutError`.
 Type checking is also configured on `checkout()`:
 
@@ -176,7 +176,7 @@ model](../security.md).
 
 ## Async
 
-`AsyncMonty` is the asyncio counterpart.
+[`AsyncMonty`][pydantic_monty.AsyncMonty] is the asyncio counterpart.
 Worker I/O runs off the event loop, and host functions may be coroutines:
 
 ```python
@@ -250,12 +250,12 @@ with Monty() as pool:
         #> 'from the sandbox\n'
 ```
 
-`CollectStreams` collects `(stream, text)` tuples instead, so you can tell stdout from stderr.
+[`CollectStreams`][pydantic_monty.CollectStreams] collects `(stream, text)` tuples instead, so you can tell stdout from stderr.
 Both cap collected output at 10 MiB by default; pass `max_bytes=None` to disable the cap.
 That cap is separate from [`max_memory`](../resource-limits.md), and it is enforced in your process as the output
 arrives, not by the worker.
 
-Exceeding it fails the feed with `MontyRuntimeError` wrapping a `MemoryError`; call `exc.exception()` for the
+Exceeding it fails the feed with [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError] wrapping a `MemoryError`; call `exc.exception()` for the
 `MemoryError` itself.
 Sandboxed code cannot catch it, so a `print()` loop cannot swallow the cap.
 
@@ -283,15 +283,15 @@ Whatever the interval, output is flushed before a host call and before a feed en
 
 ## Errors
 
-Every Monty error subclasses `MontyError`:
+Every Monty error subclasses [`MontyError`][pydantic_monty.MontyError]:
 
-| Exception              | Raised when                               | Session survives                             |
-| ---------------------- | ----------------------------------------- | -------------------------------------------- |
-| `MontySyntaxError`     | The snippet does not parse                | yes                                          |
-| `MontyTypingError`     | Type checking rejected the snippet        | yes                                          |
-| `MontyRuntimeError`    | The code raised at runtime                | yes — but discard it after a resource limit  |
-| `MontyConversionError` | A host value cannot cross the boundary    | from `inputs` yes, from `external_lookup` no |
-| `MontyCrashedError`    | The worker died, or hit `request_timeout` | no                                           |
+| Exception                                                     | Raised when                               | Session survives                             |
+| ------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------- |
+| [`MontySyntaxError`][pydantic_monty.MontySyntaxError]         | The snippet does not parse                | yes                                          |
+| [`MontyTypingError`][pydantic_monty.MontyTypingError]         | Type checking rejected the snippet        | yes                                          |
+| [`MontyRuntimeError`][pydantic_monty.MontyRuntimeError]       | The code raised at runtime                | yes — but discard it after a resource limit  |
+| [`MontyConversionError`][pydantic_monty.MontyConversionError] | A host value cannot cross the boundary    | from `inputs` yes, from `external_lookup` no |
+| [`MontyCrashedError`][pydantic_monty.MontyCrashedError]       | The worker died, or hit `request_timeout` | no                                           |
 
 `inputs` are converted before the snippet runs, so a rejected value leaves the session untouched.
 An `external_lookup` value is converted mid-execution, while the worker is suspended on the name read, so the checkout
@@ -371,11 +371,11 @@ pool = Monty(
 ```
 
 `request_timeout` is a per-turn host-side backstop: a worker that exceeds it is killed and the call raises
-`MontyCrashedError` with `timed_out=True`.
+[`MontyCrashedError`][pydantic_monty.MontyCrashedError] with `timed_out=True`.
 It catches hangs the in-sandbox limits cannot see, because those are only checked at interpreter checkpoints.
 A loop of quick host calls resets it each turn; set [`max_duration_secs`](../resource-limits.md) as well.
 
-`AsyncMonty` takes the same arguments.
+[`AsyncMonty`][pydantic_monty.AsyncMonty] takes the same arguments.
 
 ## Where next
 

--- a/docs/quickstart/rust.md
+++ b/docs/quickstart/rust.md
@@ -81,41 +81,41 @@ async fn main() -> Result<(), PoolError> {
 }
 ```
 
-`Checkout::feed` takes the code, inputs (host values bound as sandbox globals), per-feed filesystem mounts
-(`MountSpec`), a `skip_type_check` flag and a print sink.
-It returns a `TurnEvent`:
+[`Checkout::feed`](../api/rust/monty-pool.md#checkout) takes the code, inputs (host values bound as sandbox globals), per-feed filesystem mounts
+([`MountSpec`](../api/rust/monty-pool.md#mountspec)), a `skip_type_check` flag and a print sink.
+It returns a [`TurnEvent`](../api/rust/monty-pool.md#turnevent):
 
-| `TurnEvent`                      | Meaning                                                                                                                                                                | Answer with                                |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `Complete(value)`                | The snippet finished                                                                                                                                                   | nothing; feed again                        |
-| `FunctionCall { object_id, .. }` | The sandbox called a host function, or with `object_id` (the wrapper's uuid) `Some`, a method on a host object or a host class's construction (arriving as `__call__`) | `Checkout::resume`                         |
-| `OsCall { .. }`                  | The sandbox performed an OS operation                                                                                                                                  | `Checkout::resume_from_mounts` or `resume` |
-| `NameLookup { name, object_id }` | The sandbox read an undefined name, or a lazy attribute of a host object when `object_id` is `Some`                                                                    | `Checkout::resume_name_lookup`             |
-| `ResolveFutures { .. }`          | Every sandbox task is blocked on host futures                                                                                                                          | `Checkout::resume_futures`                 |
+| `TurnEvent`                                                             | Meaning                                                                                                                                                                | Answer with                                                                      |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`Complete(value)`](../api/rust/monty-pool.md#turnevent)                | The snippet finished                                                                                                                                                   | nothing; feed again                                                              |
+| [`FunctionCall { object_id, .. }`](../api/rust/monty-pool.md#turnevent) | The sandbox called a host function, or with `object_id` (the wrapper's uuid) `Some`, a method on a host object or a host class's construction (arriving as `__call__`) | [`Checkout::resume`](../api/rust/monty-pool.md#checkout)                         |
+| [`OsCall { .. }`](../api/rust/monty-pool.md#turnevent)                  | The sandbox performed an OS operation                                                                                                                                  | [`Checkout::resume_from_mounts`](../api/rust/monty-pool.md#checkout) or `resume` |
+| [`NameLookup { name, object_id }`](../api/rust/monty-pool.md#turnevent) | The sandbox read an undefined name, or a lazy attribute of a host object when `object_id` is `Some`                                                                    | [`Checkout::resume_name_lookup`](../api/rust/monty-pool.md#checkout)             |
+| [`ResolveFutures { .. }`](../api/rust/monty-pool.md#turnevent)          | Every sandbox task is blocked on host futures                                                                                                                          | [`Checkout::resume_futures`](../api/rust/monty-pool.md#checkout)                 |
 
-A `Checkout` dropped without `finish()` kills its worker rather than returning it — mid-execution state cannot be
+A [`Checkout`](../api/rust/monty-pool.md#checkout) dropped without `finish()` kills its worker rather than returning it — mid-execution state cannot be
 trusted back into the pool.
 
-`ReplConfig` carries the per-session sandbox `ResourceLimits` and type-checking options.
-`Checkout::dump` and `Checkout::restore` snapshot and restore a session, including onto a different worker or machine.
+[`ReplConfig`](../api/rust/monty-pool.md#replconfig) carries the per-session sandbox [`ResourceLimits`](../api/rust/monty-types.md#resourcelimits) and type-checking options.
+[`Checkout::dump`](../api/rust/monty-pool.md#checkout) and [`Checkout::restore`](../api/rust/monty-pool.md#checkout) snapshot and restore a session, including onto a different worker or machine.
 
 ### What the pool adds over in-process execution
 
-- **Crash isolation** — a segfault, stack-overflow abort or allocator abort in the sandbox becomes `PoolError::Crashed`;
+- **Crash isolation** — a segfault, stack-overflow abort or allocator abort in the sandbox becomes [`PoolError::Crashed`](../api/rust/monty-pool.md#poolerror);
     the pool discards the worker and spawns a replacement.
 - **Hard timeouts** — a parent-side deadline kills any worker whose turn exceeds `request_timeout`
-    (`PoolError::Timeout`), catching hangs the in-sandbox limits cannot see.
+    ([`PoolError::Timeout`](../api/rust/monty-pool.md#poolerror)), catching hangs the in-sandbox limits cannot see.
     With a `max_duration` budget the deadline also enforces that from outside the child, plus `duration_limit_grace`.
-    `PoolConfig::subprocess` sets neither `request_timeout` nor `checkout_timeout` by default; set `request_timeout`
+    [`PoolConfig::subprocess`](../api/rust/monty-pool.md#poolconfig) sets neither `request_timeout` nor `checkout_timeout` by default; set `request_timeout`
     yourself for untrusted code.
 - **Suspension limits** — the pool counts external calls, OS calls, name lookups and future-resolution turns against
-    `ResourceLimits::max_suspensions`.
+    [`ResourceLimits::max_suspensions`](../api/rust/monty-types.md#resourcelimits).
     The first suspension over the limit ends the feed with an uncatchable `RuntimeError`.
 - **Untrusted children** — every frame from a possibly compromised worker is validated; wire decoding never panics, and
     a protocol violation discards the worker.
 - **Worker recycling** — `max_checkouts_per_worker` bounds the impact of a slow leak.
 
-Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its session stay alive and
+Runtime errors inside the sandbox ([`PoolError::Runtime`](../api/rust/monty-pool.md#poolerror)) are not crashes: the worker and its session stay alive and
 usable.
 Memory and time limits return `PoolError::Runtime` with a `MemoryError` or `TimeoutError`, but
 [no guarantees hold about heap state afterwards](../resource-limits.md#after-a-limit-fires).
@@ -127,18 +127,18 @@ Later feeds run until they suspend; the count remains spent.
 
 ### Transports
 
-`PoolConfig::subprocess` spawns local `monty subprocess` children over framed stdio.
+[`PoolConfig::subprocess`](../api/rust/monty-pool.md#poolconfig) spawns local `monty subprocess` children over framed stdio.
 These are the poolable workers: prewarmed, reused across checkouts, replaced on crash.
 
-`PoolConfig::websocket` dials a remote child over `ws://`/`wss://`.
+[`PoolConfig::websocket`](../api/rust/monty-pool.md#poolconfig) dials a remote child over `ws://`/`wss://`.
 Those workers are single-use, never prewarmed or returned to the pool, and isolation becomes the remote host's
 responsibility.
 See [the security model](../security.md#remote-workers) before using it.
 
 ## The in-process interpreter
 
-`MontyRun` parses and compiles code once; `run` executes it with input values and returns the value of the final
-expression as a `MontyObject`:
+[`MontyRun`](../api/rust/monty.md#montyrun) parses and compiles code once; `run` executes it with input values and returns the value of the final
+expression as a [`MontyObject`](../api/rust/monty-types.md#montyobject):
 
 ```rust
 use monty::MontyRun;
@@ -158,8 +158,8 @@ let result = runner.run(vec![MontyObject::Int(10)], ResourceTracker::default(), 
 assert_eq!(result, MontyObject::Int(55));
 ```
 
-Errors come back as `MontyException`, with a traceback matching what CPython would produce.
-`PrintWriter` controls where `print()` output goes: `Stdout`, `Disabled`, or collected into a `String` or `(stream, text)` tuples.
+Errors come back as [`MontyException`](../api/rust/monty-types.md#montyexception), with a traceback matching what CPython would produce.
+[`PrintWriter`](../api/rust/monty-types.md#printwriter) controls where `print()` output goes: `Stdout`, `Disabled`, or collected into a `String` or `(stream, text)` tuples.
 
 ### Resource limits
 
@@ -182,7 +182,7 @@ assert!(err.to_string().contains("time limit exceeded"));
 
 ### Host functions and pausing
 
-`MontyRun::start` returns a `RunProgress` that pauses whenever the sandboxed code calls a function the host provides.
+[`MontyRun::start`](../api/rust/monty.md#montyrun) returns a [`RunProgress`](../api/rust/monty.md#runprogress) that pauses whenever the sandboxed code calls a function the host provides.
 The host runs the real function and resumes with the result:
 
 ```rust
@@ -207,19 +207,19 @@ let RunProgress::Complete(result) = progress else { panic!("expected completion"
 assert_eq!(result, MontyObject::Int(42));
 ```
 
-Async host functions work the same way: `FunctionCall::resume_pending` continues with a pending future the sandboxed
-code can `await`, and when every task is blocked the run yields `RunProgress::ResolveFutures` for the host to settle.
+Async host functions work the same way: [`FunctionCall::resume_pending`](../api/rust/monty.md#functioncall) continues with a pending future the sandboxed
+code can `await`, and when every task is blocked the run yields [`RunProgress::ResolveFutures`](../api/rust/monty.md#runprogress) for the host to settle.
 
-`FunctionCall`, `OsCall`, `NameLookup` and `ResolveFutures` expose `abort`, which raises a host-supplied
-`MontyException` uncatchably at the suspension point and unwinds the run with a traceback.
+[`FunctionCall`](../api/rust/monty.md#functioncall), [`OsCall`](../api/rust/monty.md#oscall), [`NameLookup`](../api/rust/monty.md#namelookup) and [`ResolveFutures`](../api/rust/monty.md#resolvefutures) expose `abort`, which raises a host-supplied
+[`MontyException`](../api/rust/monty-types.md#montyexception) uncatchably at the suspension point and unwinds the run with a traceback.
 A host driving the interpreter directly must count suspensions and call `abort` to enforce `max_suspensions`;
-`ResourceTracker` stores that limit but does not enforce it.
+[`ResourceTracker`](../api/rust/monty-types.md#resourcetracker) stores that limit but does not enforce it.
 
 ### Serialization
 
-The free function `monty::dump` serializes a session — idle between feeds (`SessionRef::Idle`) or suspended mid-run
-(`SessionRef::Suspended`) — together with its script name and type-check state.
-`Dump::load` restores it, in the same process or a different one:
+The free function `monty::dump` serializes a session — idle between feeds ([`SessionRef::Idle`](../api/rust/monty.md#sessionref)) or suspended mid-run
+([`SessionRef::Suspended`](../api/rust/monty.md#sessionref)) — together with its script name and type-check state.
+[`Dump::load`](../api/rust/monty.md#dump) restores it, in the same process or a different one:
 
 ```rust
 use monty::{Dump, MontyRepl, Session, SessionRef, dump};
@@ -239,11 +239,11 @@ assert_eq!(result, MontyObject::Int(42));
 
 ### Other pieces
 
-- `MontyRepl` — feed code snippet by snippet with state persisting between snippets.
+- [`MontyRepl`](../api/rust/monty.md#montyrepl) — feed code snippet by snippet with state persisting between snippets.
 - The `fs` module — mount host directories into the sandbox at virtual paths, with path resolution hardened against
     escapes.
     See [filesystem access](../filesystem.md).
-- `RunProgress::OsCall` and `RunProgress::NameLookup` — the filesystem/`os` operations and undefined-name reads the host
+- [`RunProgress::OsCall`](../api/rust/monty.md#runprogress) and [`RunProgress::NameLookup`](../api/rust/monty.md#runprogress) — the filesystem/`os` operations and undefined-name reads the host
     intercepts.
-- `FunctionCall::object_id` and `NameLookup::object_id` — set for method calls and lazy attribute lookups routed to a
-    host object sent as `MontyObject::ClassInstance` or `MontyObject::Type`; the receiver is not in `args`.
+- [`FunctionCall::object_id`](../api/rust/monty.md#functioncall) and [`NameLookup::object_id`](../api/rust/monty.md#namelookup) — set for method calls and lazy attribute lookups routed to a
+    host object sent as [`MontyObject::ClassInstance`](../api/rust/monty-types.md#montyobject) or [`MontyObject::Type`](../api/rust/monty-types.md#montyobject); the receiver is not in `args`.

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -63,7 +63,7 @@ off.
 
 In JavaScript the same fields are `maxMemory`, `maxDurationSecs`, `maxRecursionDepth`, `gcInterval` and
 `maxSuspensions`, passed as `limits` to `pool.checkout()`.
-In Rust they are the fields of `monty_types::ResourceLimits`, where the duration is a `Duration` named `max_duration`.
+In Rust they are the fields of [`monty_types::ResourceLimits`](api/rust/monty-types.md#resourcelimits), where the duration is a `Duration` named `max_duration`.
 
 ## Memory
 
@@ -103,7 +103,7 @@ The in-sandbox check runs at interpreter checkpoints, so it cannot catch code th
 Two host-side backstops cover that:
 
 - **`request_timeout`** on the pool is a hard per-turn deadline.
-    A worker that exceeds it is killed and the call raises `MontyCrashedError` with `timed_out=True`.
+    A worker that exceeds it is killed and the call raises [`MontyCrashedError`][pydantic_monty.MontyCrashedError] with `timed_out=True`.
     Each resume after a host-function or mount call starts a new deadline, so a program that suspends often can outlive
     any single timeout.
 - **The duration backstop.** For sessions with a `max_duration_secs` limit, the worker reports its execution time on
@@ -137,7 +137,7 @@ Because `max_duration_secs` pauses during suspensions, a snippet could otherwise
 
 The pool enforces the limit per checkout; the default is 1000, and a host that needs more sets a larger number.
 A host driving the interpreter directly counts suspensions and calls `abort` itself; the limit only travels in the
-`ResourceTracker`, see the [Rust quickstart](quickstart/rust.md).
+[`ResourceTracker`](api/rust/monty-types.md#resourcetracker), see the [Rust quickstart](quickstart/rust.md).
 The first suspension over the budget aborts the feed with an uncatchable
 `RuntimeError: suspension limit 3 exceeded` at the call site.
 The session stays consistent and can be dumped; later feeds run until they suspend.
@@ -151,12 +151,12 @@ caps the dump's, so a worker cannot report a looser one.
     Compilation has its own structural caps (AST nesting at 200 levels, bytecode operand sizes, comprehension nesting, and
     a 1,024-copy cap on `finally` expansion that raises `SyntaxError`).
     A host accepting untrusted source should still isolate compilation, as the subprocess and WebAssembly runtimes do.
-- **Print collectors.** `CollectString` and `CollectStreams` live in the host process, so their 10 MiB default cap is
+- **Print collectors.** [`CollectString`][pydantic_monty.CollectString] and [`CollectStreams`][pydantic_monty.CollectStreams] live in the host process, so their 10 MiB default cap is
     separate from `max_memory`.
 - **Mount memory.** Each [mount](filesystem.md) has its own `memory_usage_limit`, defaulting to 100 MB, shared between
     retained overlay data and transient results.
 - **`json.loads` nesting**, capped at 200 levels independently of the recursion limit.
-- **The host instance store.** Every `ClassInstance`/`ClassType` wrapper sent into a session (nested wrappers,
+- **The host instance store.** Every [`ClassInstance`][pydantic_monty.ClassInstance]/[`ClassType`][pydantic_monty.ClassType] wrapper sent into a session (nested wrappers,
     `init=True` constructions and `convert_value` wraps included) is retained in the host process until the session
     ends; re-sending a wrapper with the same id reuses its entry, distinct wrappers accumulate; see
     [host objects](host-objects.md#values-returned-by-methods).

--- a/docs/security.md
+++ b/docs/security.md
@@ -85,7 +85,7 @@ Validate arguments in the host function as you would validate any untrusted inpu
 
 ### Host objects and classes
 
-`ClassInstance` and `ClassType` wrappers put a host object, or a host class, in front of the sandbox.
+[`ClassInstance`][pydantic_monty.ClassInstance] and [`ClassType`][pydantic_monty.ClassType] wrappers put a host object, or a host class, in front of the sandbox.
 Every method call, lazy attribute read and `init=True` construction the wrapper allows runs **your** code on the host,
 with the same authority as a host function.
 `eager_attrs`, `lazy_attrs` and `allowed_methods` are name allow-lists that default to nothing, and `init` is a
@@ -199,7 +199,7 @@ anything.
 
 A separate `os=` callback handles operations no mount covers: the remaining `pathlib` operations, `os.getenv`,
 `os.environ`, `date.today()` and `datetime.now()`.
-`AbstractOS` is the typed form of that callback; `OSAccess` implements it over in-memory files and an `environ` mapping
+[`AbstractOS`][pydantic_monty.AbstractOS] is the typed form of that callback; [`OSAccess`][pydantic_monty.OSAccess] implements it over in-memory files and an `environ` mapping
 you supply, and overriding one of its methods replaces one operation.
 JavaScript has only the callback form, so the TypeScript tab answers the same three operations by hand:
 
@@ -298,7 +298,7 @@ in-process outright.
 See [in-process execution](#in-process-execution).
 
 When a worker dies, the pool observes the death, discards the worker, spawns a replacement, and the call raises
-`MontyCrashedError` (`PoolError::Crashed` in Rust).
+[`MontyCrashedError`][pydantic_monty.MontyCrashedError] ([`PoolError::Crashed`](api/rust/monty-pool.md#poolerror) in Rust).
 The session is lost; your process is not.
 
 Two more properties of the worker boundary matter:
@@ -327,8 +327,8 @@ See [resource limits](resource-limits.md) for the full picture; the security-rel
     Two host-side backstops cover a wedged worker: `request_timeout` (a per-turn deadline; a loop of quick host calls
     resets it) and `duration_limit_grace` (fires only if the session also set `max_duration_secs`).
     Set both `request_timeout` and `max_duration_secs` for untrusted code.
-    Every local pool (`Monty`, `AsyncMonty`, JavaScript `Monty.create()`, `PoolConfig::subprocess`) defaults
-    `request_timeout` to no deadline; only `AsyncMontyWebsocket` sets one, at 10 seconds.
+    Every local pool ([`Monty`][pydantic_monty.Monty], [`AsyncMonty`][pydantic_monty.AsyncMonty], JavaScript `Monty.create()`, [`PoolConfig::subprocess`](api/rust/monty-pool.md#poolconfig)) defaults
+    `request_timeout` to no deadline; only [`AsyncMontyWebsocket`][pydantic_monty.AsyncMontyWebsocket] sets one, at 10 seconds.
 - **After a memory or time limit fires, no guarantees are made about heap state or reference counts.** Discard the
     session rather than continuing to run code in it.
     The pool does not do this for you, and the two limits do not even fail alike: a spent `max_duration_secs` budget is
@@ -346,9 +346,9 @@ See [resource limits](resource-limits.md) for the full picture; the security-rel
 
 ### Your own callbacks
 
-Host functions, the methods, lazy attributes and constructors exposed through `ClassInstance`/`ClassType`, the `os=`
-callback, and `CallbackFile` in the Python `OSAccess` helper all execute in the host process.
-`OSAccess` backed by `MemoryFile` objects is fully sandboxed; `OSAccess` backed by `CallbackFile` is exactly as
+Host functions, the methods, lazy attributes and constructors exposed through [`ClassInstance`][pydantic_monty.ClassInstance]/[`ClassType`][pydantic_monty.ClassType], the `os=`
+callback, and [`CallbackFile`][pydantic_monty.CallbackFile] in the Python [`OSAccess`][pydantic_monty.OSAccess] helper all execute in the host process.
+`OSAccess` backed by [`MemoryFile`][pydantic_monty.MemoryFile] objects is fully sandboxed; `OSAccess` backed by `CallbackFile` is exactly as
 sandboxed as the callback you wrote.
 
 ### In-process execution
@@ -361,7 +361,7 @@ In the browser, a real `Worker` restores isolation and gives the watchdog a hard
 
 ### Remote workers
 
-`AsyncMontyWebsocket` (Python) and `PoolConfig::websocket` (Rust) dial a remote worker instead of spawning a local one.
+[`AsyncMontyWebsocket`][pydantic_monty.AsyncMontyWebsocket] (Python) and [`PoolConfig::websocket`](api/rust/monty-pool.md#poolconfig) (Rust) dial a remote worker instead of spawning a local one.
 **A remote peer need not be a Monty sandbox at all.** It may be real CPython with no sandbox, no resource limits and
 full host access, relying on deployment isolation — a container or VM per session — rather than on the interpreter.
 None of the guarantees on this page transfer across that boundary; they become properties of whatever is running on the

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -56,14 +56,14 @@ Instead of driving a snippet to completion it hands control back at every suspen
 
 ### The snapshot kinds
 
-| Kind                 | Why execution stopped                                                                                                                      | Resume with                                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `FunctionSnapshot`   | A host function or OS call, or with `object_id` set a method call on a [host object](host-objects.md) (construction arrives as `__call__`) | `resume(result)`, `resume_not_handled()`, `resume_auto()`                                                        |
-| `NameLookupSnapshot` | An undefined name was read, or with `object_id` set a lazy attribute of a host object                                                      | `resume(value=...)`, `resume()` to raise `NameError` (`AttributeError` when `object_id` is set), `resume_auto()` |
-| `FutureSnapshot`     | Every sandbox task is blocked on host futures                                                                                              | `resume({call_id: result})`                                                                                      |
-| `MontyComplete`      | Nothing — the snippet finished                                                                                                             | nothing; read `.output`                                                                                          |
+| Kind                                                      | Why execution stopped                                                                                                                      | Resume with                                                                                                      |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| [`FunctionSnapshot`][pydantic_monty.FunctionSnapshot]     | A host function or OS call, or with `object_id` set a method call on a [host object](host-objects.md) (construction arrives as `__call__`) | `resume(result)`, `resume_not_handled()`, `resume_auto()`                                                        |
+| [`NameLookupSnapshot`][pydantic_monty.NameLookupSnapshot] | An undefined name was read, or with `object_id` set a lazy attribute of a host object                                                      | `resume(value=...)`, `resume()` to raise `NameError` (`AttributeError` when `object_id` is set), `resume_auto()` |
+| [`FutureSnapshot`][pydantic_monty.FutureSnapshot]         | Every sandbox task is blocked on host futures                                                                                              | `resume({call_id: result})`                                                                                      |
+| [`MontyComplete`][pydantic_monty.MontyComplete]           | Nothing — the snippet finished                                                                                                             | nothing; read `.output`                                                                                          |
 
-`FunctionSnapshot.resume` accepts four shapes of answer:
+[`FunctionSnapshot.resume`][pydantic_monty.FunctionSnapshot.resume] accepts four shapes of answer:
 
 - `{'return_value': value}` — the call returned this.
 - `{'exception': ValueError('...')}` — the call raised this exception instance.
@@ -219,9 +219,9 @@ feeding:
 - **The dump carries its own configuration.** `script_name`, resource limits and type-check state come from the dump,
     not from the `checkout()` that restored it.
 - **The instance store does not travel.** Host objects sent before the dump are unknown to the restored session: they
-    come back as `MontyClassProxy` (a host class, `type(x)` included, as `MontyClassTypeProxy` in Python and as a plain
+    come back as [`MontyClassProxy`][pydantic_monty.MontyClassProxy] (a host class, `type(x)` included, as [`MontyClassTypeProxy`][pydantic_monty.MontyClassTypeProxy] in Python and as a plain
     `{ __monty_type__: 'Type', ... }` marker in JavaScript), method calls on them
-    raise `RuntimeError`, lazy attributes raise `AttributeError`, and `ClassType` construction raises `RuntimeError`.
+    raise `RuntimeError`, lazy attributes raise `AttributeError`, and [`ClassType`][pydantic_monty.ClassType] construction raises `RuntimeError`.
     See [`limitations/pool-architecture.md`](limitations/pool-architecture.md#host-api-behaviour-notes).
 - **The accumulated time budget travels with the dump**, so a restored session resumes where it left off rather than
     getting a fresh budget.
@@ -230,7 +230,7 @@ feeding:
 - **Mounts do not travel.** Host paths are never part of a dump.
     Pass the same `mount=` to `load_snapshot`, or the restored feed's filesystem calls degrade into unhandled OS calls.
     Any `'overlay'` writes made before the dump are gone — the restored overlay starts empty.
-- **A restored `FutureSnapshot` cannot be driven with `resume_auto()`.** Its pending coroutines lived in the previous
+- **A restored [`FutureSnapshot`][pydantic_monty.FutureSnapshot] cannot be driven with `resume_auto()`.** Its pending coroutines lived in the previous
     process.
     Resolve them by hand with `resume({call_id: ...})`.
 - **Dumps are version-specific.** The bytes are Monty's own dump format, a `MONTY\0` magic followed by a dump-format
@@ -240,18 +240,18 @@ feeding:
 
 ## Async
 
-`AsyncMonty` sessions expose the same `feed_start`, `load_session`, `load_snapshot` and `dump`, with awaitable
+[`AsyncMonty`][pydantic_monty.AsyncMonty] sessions expose the same `feed_start`, `load_session`, `load_snapshot` and `dump`, with awaitable
 `resume(...)` and `resume_auto()`.
-A coroutine host function answered by `resume_auto()` is awaited concurrently: it yields an `AsyncFutureSnapshot` whose
+A coroutine host function answered by `resume_auto()` is awaited concurrently: it yields an [`AsyncFutureSnapshot`][pydantic_monty.AsyncFutureSnapshot] whose
 `resume_auto()` settles the pending coroutines.
 
-The sync `FutureSnapshot.resume_auto()` always raises — a sync session cannot drive coroutine host functions.
+The sync [`FutureSnapshot.resume_auto()`][pydantic_monty.FutureSnapshot.resume_auto] always raises — a sync session cannot drive coroutine host functions.
 
 ## Rust
 
 In Rust the in-process API serializes through the free function `monty::dump`, which takes an idle or suspended session
-by reference, and `Dump::load`, which returns the session plus its script name and type-check state.
-Through `monty-pool` it is `Checkout::dump` and `Checkout::restore`.
+by reference, and [`Dump::load`](api/rust/monty.md#dump), which returns the session plus its script name and type-check state.
+Through `monty-pool` it is [`Checkout::dump`](api/rust/monty-pool.md#checkout) and [`Checkout::restore`](api/rust/monty-pool.md#checkout).
 See the [Rust quickstart](quickstart/rust.md#serialization).
 
 ## Uses

--- a/docs/type-checking.md
+++ b/docs/type-checking.md
@@ -156,7 +156,7 @@ checking for that feed only.
 
 ## Reading the diagnostics
 
-`MontyTypingError.display()` returns ty's rendered output — source context, underlines and rule names, one diagnostic
+[`MontyTypingError.display()`][pydantic_monty.MontyTypingError.display] returns ty's rendered output — source context, underlines and rule names, one diagnostic
 per block:
 
 ```text
@@ -180,9 +180,9 @@ the flag is `--type-check-format`.
 
 ## Elsewhere
 
-- **JavaScript**: `pool.checkout({ typeCheck: true, typeCheckStubs: '...' })`, raising `MontyTypingError` with the same
+- **JavaScript**: `pool.checkout({ typeCheck: true, typeCheckStubs: '...' })`, raising [`MontyTypingError`][pydantic_monty.MontyTypingError] with the same
     `.display()`.
-- **Rust**: `ReplConfig` on `monty-pool`, or the [`monty-type-checking`](https://crates.io/crates/monty-type-checking)
+- **Rust**: [`ReplConfig`](api/rust/monty-pool.md#replconfig) on `monty-pool`, or the [`monty-type-checking`](https://crates.io/crates/monty-type-checking)
     crate directly.
 - **CLI**: `monty --type-check file.py`.
     See [command line](cli.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
           - Pools: 'api/python/pools.md'
           - Websocket Client: 'api/python/websocket.md'
           - Suspend & Resume: 'api/python/suspend_resume.md'
+          - Host Objects: 'api/python/host_objects.md'
           - Filesystem & OS: 'api/python/os.md'
           - Errors: 'api/python/errors.md'
       - Rust:


### PR DESCRIPTION
Links the first mention of each host-side type per section to its API page, so readers can get from the concept and quickstart pages to the reference.

- **Python**: `[`Monty`][pydantic_monty.Monty]` (also methods and attributes, e.g. `pydantic_monty.MountDir.close`). mkdocs-autorefs resolves it in `make docs`; the pydantic.dev pipeline resolves it from the symbol map built from the `::: pydantic_monty` blocks. An unknown name fails the strict build.
- **Rust**: explicit `[`Pool`](api/rust/monty-pool.md#pool)` links. The anchor is the lowercased top-level item; methods, fields and variants share their parent's anchor.
- **JavaScript** types have no API pages and stay as plain code spans.

Also:

- `.mdformat.toml` now sets `ignore_missing_references`. Without it `make format-md` rewrote every autoref to `\[...\]`, breaking the links while the strict build still passed.
- New `docs/api/python/host_objects.md` for `ClassInstance`, `ClassType`, `MontyClassProxy` and `MontyClassTypeProxy`, which were exported but on no API page.
- The linking convention is documented in the `docs/` rules in `CLAUDE.md` and `docs/limitations/AGENTS.md`.

Known, not addressed here:

- Anchor collisions in the generated Rust pages: `Pool::checkout` / `Checkout` both slug to `#checkout` on the monty-pool page, and `dump` / `Dump` to `#dump` on the monty page, so those links land a few lines above the target. That is a `monty-apidoc` fix.
- The local mkdocs render does not parse the ```` ```rust,no_run ```` fence in the Rust quickstart (pre-existing at `main`).
- `docs/limitations/pool-architecture.md` mentions `MontyComplete.output_json()` and `FunctionSnapshot.args_json()`, which do not exist in the package; left unlinked.

`make lint-md` and `make docs` (strict) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXjM4nojQQwqqDkPazkx8M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links the first mention of each host-side type per docs section to its API page, so concept and quickstart pages now lead to the reference.

- Python types link with mkdocs-autorefs (`[`Monty`][pydantic_monty.Monty]`); Rust items link explicitly to `api/rust/<crate>.md#<item>`.
- JavaScript types have no API pages and stay as plain code spans; the `pool-architecture.md` JS section no longer links to `pydantic_monty` symbols.
- `.mdformat.toml` sets `ignore_missing_references` so `make format-md` no longer escapes autorefs into broken link definitions.
- Adds `docs/api/python/host_objects.md` for `ClassInstance`, `ClassType`, `MontyClassProxy` and `MontyClassTypeProxy`, which were exported but on no API page.
- Some Rust links land a few lines above their target where generated anchors collide (`Pool::checkout` / `Checkout`, `dump` / `Dump`).
- Titles the commercial support tip on the landing page.

<sup>Written for commit af6faaaed4f1d458d03dabf2f6ef0697ddab39dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

