### PR TITLE
bump to 0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "ahash",
  "chrono",
@@ -2445,14 +2445,14 @@ dependencies = [
 
 [[package]]
 name = "monty-alloc"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "monty-types",
 ]
 
 [[package]]
 name = "monty-apidoc"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "insta",
  "rustdoc-types",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "ahash",
  "chrono",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "monty-doctest"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "monty",
  "monty-pool",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fs"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "ahash",
  "cap-std",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "monty-pool",
  "monty-types",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "futures-util",
  "insta",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "insta",
  "monty",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "monty-types"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "chrono",
  "monty-macros",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "monty-alloc",
  "monty-proto",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty-client"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "ahash",
  "monty-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.22"
+version = "0.0.23"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -60,15 +60,15 @@ strip = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.22" }
-monty-types = { path = "crates/monty-types", version = "0.0.22" }
-monty-alloc = { path = "crates/monty-alloc", version = "0.0.22" }
-monty-fs = { path = "crates/monty-fs", version = "0.0.22" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.22" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.22" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.22" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.22" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.22" }
+monty = { path = "crates/monty", version = "0.0.23" }
+monty-types = { path = "crates/monty-types", version = "0.0.23" }
+monty-alloc = { path = "crates/monty-alloc", version = "0.0.23" }
+monty-fs = { path = "crates/monty-fs", version = "0.0.23" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.23" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.23" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.23" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.23" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.23" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.9"
 ruff_python_stdlib = "0.0.9"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "^0.19.0",
@@ -40,11 +40,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.22",
-        "@pydantic/monty-darwin-x64": "0.0.22",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.22",
-        "@pydantic/monty-linux-x64-gnu": "0.0.22",
-        "@pydantic/monty-win32-x64-msvc": "0.0.22"
+        "@pydantic/monty-darwin-arm64": "0.0.23",
+        "@pydantic/monty-darwin-x64": "0.0.23",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.23",
+        "@pydantic/monty-linux-x64-gnu": "0.0.23",
+        "@pydantic/monty-win32-x64-msvc": "0.0.23"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4071,92 +4071,6 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.22.tgz",
-      "integrity": "sha512-fFrXuda8qdjF8q5IA/gDdwCAhAOHxUcfgPExDFm36HeUIRyLQNvtnJtcHHGzWlKcB/nDgGxbI28fTmbmXBD2HQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.22.tgz",
-      "integrity": "sha512-gruB3m9H/rpf6dmQxK9JgkaBF/YatOBxkPsq66JdHBcvZkzbQ4K41wTlM0CnHCYIHknkAKdyCZAnutSIJkVTcg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.22.tgz",
-      "integrity": "sha512-BpKi89mc/pdIVWX1GMC3bh61MNXGUBuzwABCnMJBtjzYLxyH3NcH4uxhbFbEUAc6/EWYSPHlpldL+Su4QWPqXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.22.tgz",
-      "integrity": "sha512-hEAtkr0qTIyrCsW79WMlmk4QpUdHnrqIy4BMKMS2fj4RbDLNQD0l74hLv8bnFtYfN8a3gD1P81s6DfEjTYn7mQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.22.tgz",
-      "integrity": "sha512-1w0yA1DkHR+WDyan4B3hsRrWrub0UpLCDz14FjuN4NrwNs8wj58VAcLLcy1wtJ6cuzJq8ZH5BQrRbhTYLeY46w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -105,10 +105,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-arm64": "0.0.23",
     "@pydantic/monty-darwin-x64": "0.0.23",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.23",
+    "@pydantic/monty-darwin-arm64": "0.0.23",
     "@pydantic/monty-linux-x64-gnu": "0.0.23",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.23",
     "@pydantic/monty-win32-x64-msvc": "0.0.23"
   }
 }

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -105,10 +105,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-arm64": "0.0.22",
-    "@pydantic/monty-darwin-x64": "0.0.22",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.22",
-    "@pydantic/monty-linux-x64-gnu": "0.0.22",
-    "@pydantic/monty-win32-x64-msvc": "0.0.22"
+    "@pydantic/monty-darwin-arm64": "0.0.23",
+    "@pydantic/monty-darwin-x64": "0.0.23",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.23",
+    "@pydantic/monty-linux-x64-gnu": "0.0.23",
+    "@pydantic/monty-win32-x64-msvc": "0.0.23"
   }
 }

--- a/packages/pydantic-monty/pyproject.toml
+++ b/packages/pydantic-monty/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 ]
 # version and both pins are rewritten from the Cargo workspace version by
 # `crates/monty-python/build.rs` — don't edit them by hand
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
-    "pydantic-monty-client==0.0.22",
-    "pydantic-monty-runtime==0.0.22",
+    "pydantic-monty-client==0.0.23",
+    "pydantic-monty-runtime==0.0.23",
 ]
 
 [project.optional-dependencies]

--- a/scripts/startup_performance.py
+++ b/scripts/startup_performance.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "daytona>=0.136.0",
 #     "mcp-run-python>=0.0.22",
-#     "pydantic-monty>=0.0.22",
+#     "pydantic-monty>=0.0.23",
 #     "starlark-pyo3>=2025.2.5",
 #     "wasmtime>=38",
 # ]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "monty-workspace",

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "monty-workspace",
@@ -1757,7 +1753,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "packages/pydantic-monty" }
 dependencies = [
     { name = "pydantic-monty-client" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the workspace version from 0.0.22 to 0.0.23 across all Rust crates, the JS package, and the Python package. Also reorders the JS optional platform dependencies to match the expected order, which fixes the deps check.

<sup>Written for commit fec9b5e6318c89ad5292d2a1083abf03885f2e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

