### PR TITLE
fix flakey js test

### DIFF
--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -135,7 +135,7 @@ for i in range(3):
 test('print mixed types', async () => {
   const { output, callback } = makePrintCollector()
   await run('print("Value:", 3.14, True, None, [1, 2, 3])', { printCallback: callback })
-  t.deepEqual(output, ['Value: 3.14 True None [1, 2, 3]\n'])
+  t.is(output.join(''), 'Value: 3.14 True None [1, 2, 3]\n')
 })
 
 // =============================================================================

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -4072,6 +4072,92 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@pydantic/monty-darwin-arm64": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.23.tgz",
+      "integrity": "sha512-SrYZQMyoSh1m8oPgGgzUCI4QYzeS9Bqg+cp7b1lZ1iNqW7O9fvJCH5MbNeWVkPZvEaRFmff/Ru8NkRJGyLfjVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@pydantic/monty-darwin-x64": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.23.tgz",
+      "integrity": "sha512-zrTEKa9N2vufpz57NN0w4ZCzR7oXwWwheXSOjTIz0hkVlO2MZbK7+cXi04VD0uIghcxQa+x7UWo3lJzrjFFv+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@pydantic/monty-linux-arm64-gnu": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.23.tgz",
+      "integrity": "sha512-lpD0ojDvrR2WlEVkWMoQLzSIBky3ZKg6r/rmgfSBrwQkYclG6S0aw0itbYjuD87MWiBTfx3tXPXGllDQmvgWgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@pydantic/monty-linux-x64-gnu": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.23.tgz",
+      "integrity": "sha512-4+Y4WYPLGixP2+2AFtY4IUGwAXRRPvhixjoV6H6b1lCypd+Af5BiZ0a0vOARTfqGVGXLDtbzqFatfU2fWmwkzg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@pydantic/monty-win32-x64-msvc": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.23.tgz",
+      "integrity": "sha512-nYMNnaoYLFqbFFvv1sluwI7lb6ZNcKxKRG9H2lhpwv9gFZjBybp9/mCTveYfaNhVkyyLkcW/BHlkPrdj/yogMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -944,25 +944,28 @@ fn timeout_in_str_format_parser() {
     );
 }
 
+/// Copying the receiver is only a few milliseconds of work, so this compares
+/// the tracker's execution clock rather than wall time: compiling the feed and
+/// tearing down the 20 MB buffer would otherwise be a large share of both runs.
 #[test]
 fn timeout_in_str_format_receiver_snapshot() {
     let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
     repl.feed_run("template = '{missing}' + 'x' * 20_000_000", vec![], PrintWriter::Stdout)
         .unwrap();
 
-    let start = Instant::now();
+    let before = repl.tracker().elapsed();
     let exc = repl
         .feed_run("template.format()", vec![], PrintWriter::Stdout)
         .expect_err("the missing field must fail after snapshotting the receiver");
-    let full_snapshot = start.elapsed();
+    let full_snapshot = repl.tracker().elapsed().saturating_sub(before);
     assert_eq!(exc.exc_type(), ExcType::KeyError);
 
+    // resets the execution clock, so the next feed's elapsed time starts at zero
     repl.tracker_mut().set_max_duration(full_snapshot / 10);
-    let start = Instant::now();
     let exc = repl
         .feed_run("template.format()", vec![], PrintWriter::Stdout)
         .expect_err("the receiver snapshot must hit the time limit before field lookup");
-    let elapsed = start.elapsed();
+    let elapsed = repl.tracker().elapsed();
 
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
     assert!(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes two flaky tests: the JS print test now joins captured output before asserting, and the str.format receiver snapshot timeout test measures both phases with the tracker's execution clock instead of wall time.

- The JS test uses `t.is` on the joined output instead of `t.deepEqual` on the array.
- The Rust timeout test now compares execution-clock deltas, so compiling the feed and tearing down the 20 MB buffer no longer count against the time ratio.
- Updates `package-lock.json` to include optional platform binaries for `@pydantic/monty` v0.0.23.

<sup>Written for commit bc45a0384f725ae358b3afceb2e044d5756542f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

