### PR TITLE
Implement the `format()` builtin

### DIFF
--- a/crates/monty-types/src/builtins.rs
+++ b/crates/monty-types/src/builtins.rs
@@ -1,7 +1,7 @@
 //! [`BuiltinsFunctions`] — the name-level identity of every interpreter-native
 //! Python builtin, carried by [`MontyObject::BuiltinFunction`](crate::object::MontyObject).
 
-use strum::{Display, EnumString, FromRepr, IntoStaticStr};
+use strum::{Display, EnumString, FromRepr, IntoStaticStr, VariantNames};
 /// Enumerates every interpreter-native Python builtin function.
 ///
 /// Listed alphabetically per <https://docs.python.org/3/library/functions.html>
@@ -19,6 +19,7 @@ use strum::{Display, EnumString, FromRepr, IntoStaticStr};
     EnumString,
     FromRepr,
     IntoStaticStr,
+    VariantNames,
     PartialEq,
     Eq,
     Hash,
@@ -54,7 +55,7 @@ pub enum BuiltinsFunctions {
     // Exec,
     Filter,
     // float - handled by Type enum
-    Format,
+    // Format - appended below
     // frozenset - handled by Type enum
     Getattr,
     // Globals,
@@ -112,4 +113,6 @@ pub enum BuiltinsFunctions {
     #[strum(serialize = "object.__setattr__")]
     #[serde(rename = "object.__setattr__")]
     ObjectSetattr,
+    /// `format(value, format_spec='')`, appended after [`Self::ObjectSetattr`].
+    Format,
 }

--- a/crates/monty-types/src/builtins.rs
+++ b/crates/monty-types/src/builtins.rs
@@ -54,7 +54,7 @@ pub enum BuiltinsFunctions {
     // Exec,
     Filter,
     // float - handled by Type enum
-    // Format,
+    Format,
     // frozenset - handled by Type enum
     Getattr,
     // Globals,

--- a/crates/monty/src/builtins/format.rs
+++ b/crates/monty/src/builtins/format.rs
@@ -1,0 +1,41 @@
+//! Implementation of the format() builtin function.
+
+use crate::{
+    args::{ArgValues, FromArgs, StrArg},
+    bytecode::VM,
+    defer_drop,
+    exception_private::RunResult,
+    types::str::allocate_string,
+    value::Value,
+};
+
+/// Argument shape for `format(value, format_spec='', /)`.
+///
+/// CPython parses it with `PyArg_ParseTuple`, so `style = unpack` gives the
+/// `format expected at most 2 arguments` arity wording and the blanket
+/// `format() takes no keyword arguments` rejection; `bad_arg` supplies
+/// `format() argument 2 must be str, not int`.
+#[derive(FromArgs)]
+#[from_args(name = "format", style = unpack, bad_arg)]
+struct FormatArgs {
+    #[from_args(pos_only)]
+    value: Value,
+    #[from_args(pos_only, default)]
+    format_spec: Option<StrArg>,
+}
+
+/// Implementation of the format() builtin function.
+///
+/// Applies a format-spec mini-language string to a value, sharing the runtime
+/// path f-strings and `str.format()` use, so every spec and error behaves the
+/// same across all three entry points.
+pub fn builtin_format(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let FormatArgs { value, format_spec } = FormatArgs::from_args(args, vm)?;
+    defer_drop!(value, vm);
+    defer_drop!(format_spec, vm);
+    // The spec borrows `vm`, which the formatter needs mutably; it is already
+    // tracked so copying it out is bounded.
+    let spec = format_spec.as_ref().map(|spec| spec.as_str(vm).to_owned());
+    let formatted = vm.format_runtime_value(value, 0, spec.as_deref())?;
+    Ok(allocate_string(formatted, vm.heap))
+}

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -11,6 +11,7 @@ mod chr;
 mod divmod;
 mod enumerate;
 mod filter;
+mod format;
 mod getattr;
 mod hasattr;
 mod hash;
@@ -140,6 +141,7 @@ impl BuiltinsFunctionsExt for BuiltinsFunctions {
             Self::Divmod => divmod::builtin_divmod(vm, args),
             Self::Enumerate => enumerate::builtin_enumerate(vm, args),
             Self::Filter => filter::builtin_filter(vm, args),
+            Self::Format => format::builtin_format(vm, args),
             // `getattr()` / `hasattr()` may suspend a lazy host attribute lookup.
             Self::Getattr => return getattr::builtin_getattr(vm, args),
             Self::Hasattr => return hasattr::builtin_hasattr(vm, args),

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -174,7 +174,7 @@ impl Error for DumpError {}
 
 #[cfg(test)]
 mod tests {
-    use monty_types::{MontyType, TypeCheckingFormat};
+    use monty_types::{BuiltinsFunctions, MontyType, TypeCheckingFormat};
     use strum::VariantNames;
 
     use super::DUMP_VERSION;
@@ -223,13 +223,21 @@ mod tests {
             0x091c_2e22_e9b8_f5ee,
             "MontyType variants changed for dump version {DUMP_VERSION}"
         );
+        // Builtin discriminants are `CallBuiltinFunction` operands, so the enum
+        // is append-only: a new builtin goes after the last variant.
+        assert_eq!(
+            variant_order_fingerprint(BuiltinsFunctions::VARIANTS),
+            0xd5ef_68ff_fc6b_f752,
+            "BuiltinsFunctions variants changed for dump version {DUMP_VERSION}"
+        );
     }
 
     /// FNV-1a over variant names in declaration order.
     ///
     /// `Type` and `MontyType` are postcard-encoded by variant index inside a
-    /// `Dump`, so inserting a variant rewrites what older dumps decode to rather
-    /// than failing the version check. Appending leaves this unchanged for every
+    /// `Dump`, and `BuiltinsFunctions` discriminants are bytecode operands, so
+    /// inserting a variant rewrites what older dumps decode to rather than
+    /// failing the version check. Appending leaves this unchanged for every
     /// existing variant; inserting or reordering does not.
     ///
     /// The list covers the `#[strum(disabled)]` variants too — `Type::Instance`,

--- a/crates/monty/test_cases/builtins__format.py
+++ b/crates/monty/test_cases/builtins__format.py
@@ -1,0 +1,79 @@
+# === Basic values ===
+assert format(3) == '3'
+assert format(3, '') == '3'
+assert format(12.5, '>8.1f') == '    12.5'
+assert format('a', '^5') == '  a  '
+assert format(None) == 'None'
+assert format([1, 2], '') == '[1, 2]'
+assert format(True) == 'True'
+assert format(True, 'd') == '1'
+assert format(1e100, 'e') == '1.000000e+100'
+assert format(2**70, 'x') == '400000000000000000'
+assert format(255, '#010b') == '0b11111111'
+assert format(1234567, ',') == '1,234,567'
+assert format(0.5, '.0%') == '50%'
+assert format('x', '*<4') == 'x***'
+
+# === Same output as f-strings and str.format ===
+spec = '>+8.2f'
+assert format(3.14159, spec) == f'{3.14159:{spec}}' == '{:>+8.2f}'.format(3.14159)
+assert format('hi', '5') == f'{"hi":5}'
+
+# === Heap spec strings ===
+assert format(7, ''.join(['0', '3', 'd'])) == '007'
+assert format(7, '0' + '5d') == '00007'
+
+# === Errors ===
+try:
+    format()
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'format expected at least 1 argument, got 0'
+
+try:
+    format(1, '', 3)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'format expected at most 2 arguments, got 3'
+
+try:
+    format(1, 2)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'format() argument 2 must be str, not int'
+
+try:
+    format(1, None)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'format() argument 2 must be str, not None'
+
+try:
+    format(1, b'd')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'format() argument 2 must be str, not bytes'
+
+try:
+    format(1, format_spec='d')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'format() takes no keyword arguments'
+
+try:
+    format('x', 'd')
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "Unknown format code 'd' for object of type 'str'"
+
+try:
+    format(1, 'q')
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "Unknown format code 'q' for object of type 'int'"
+
+try:
+    format(1.5, '.')
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'Format specifier missing precision'

--- a/crates/monty/test_cases/datetime__format.py
+++ b/crates/monty/test_cases/datetime__format.py
@@ -88,3 +88,9 @@ _empty = ''
 assert f'{_dt:{_empty}}' == '2024-06-15 10:30:45'
 # a conversion flag converts to a string first, so the spec formats that string
 assert f'{_d!s:>12}' == '  2024-06-15'
+# the format() builtin takes the same path
+assert format(_d, '%Y/%m/%d') == '2024/06/15'
+assert format(_dt, '%H:%M') == '10:30'
+assert format(datetime.time(10, 30, 45), '%H-%M-%S') == '10-30-45'
+assert format(_d) == '2024-06-15'
+assert format(_dt, '') == '2024-06-15 10:30:45'

--- a/docs/limitations/builtins.md
+++ b/docs/limitations/builtins.md
@@ -7,8 +7,8 @@ Python.
 ## Implemented builtin functions
 
 `abs`, `all`, `any`, `bin`, `chr`, `divmod`, `enumerate`, `filter`,
-`getattr`, `hasattr`, `hash`, `hex`, `id`, `isinstance`, `iter`, `len`, `map`,
-`max`, `min`, `next`, `oct`, `open`, `ord`, `pow`, `print`, `repr`,
+`format`, `getattr`, `hasattr`, `hash`, `hex`, `id`, `isinstance`, `iter`, `len`,
+`map`, `max`, `min`, `next`, `oct`, `open`, `ord`, `pow`, `print`, `repr`,
 `reversed`, `round`, `setattr`, `sorted`, `sum`, `type`, `zip`.
 
 ## Implemented type constructors (also builtins)
@@ -28,7 +28,7 @@ These raise `NameError`:
 - **Decorators / descriptors**: `classmethod`, `staticmethod`, `property`,
     `super`. (`@property` on functions is not recognized; use a method.)
 - **Construction / coercion**: `bytearray`, `complex`, `memoryview`,
-    `object`, `format`, `ascii`.
+    `object`, `ascii`.
 - **Other**: `callable`, `delattr`, `issubclass`, `aiter`, `anext`.
 
 `super()` is the biggest practical omission: with no class inheritance either

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -1,7 +1,7 @@
 # String formatting
 
 Monty implements CPython 3.14's format mini-language for f-string
-interpolations and `str.format()` replacement fields. `str.format()` supports
+interpolations, `str.format()` replacement fields and the `format()` builtin. `str.format()` supports
 positional and keyword fields, automatic and manual numbering, attribute and
 item access, `!s` / `!r` / `!a` conversions, nested replacement fields in
 format specs, and escaped braces.
@@ -12,10 +12,7 @@ If a replacement field needs a host operation, such as
 `NotImplementedError: str.format attribute access cannot suspend` instead of
 returning the attribute as CPython does.
 
-The other CPython formatting entry points are not implemented:
-
-- The `format()` builtin raises `NameError`, and `str.format_map()` raises
-    `AttributeError` (see [builtins.md](builtins.md)).
+`str.format_map()` is not implemented and raises `AttributeError`.
 
 ## Printf-style `%` formatting
 
@@ -50,9 +47,9 @@ modifiers. The divergences:
 
 ## Custom `__format__`
 
-f-strings and `str.format()` dispatch to a type's `__format__` only for
+f-strings, `str.format()` and `format()` dispatch to a type's `__format__` only for
 `date`, `datetime` and `time`, which interpret the spec as a `strftime` string
-(`f'{dt:%Y-%m-%d}'` or `'{:%Y-%m-%d}'.format(dt)`); see
+(`f'{dt:%Y-%m-%d}'`, `'{:%Y-%m-%d}'.format(dt)` or `format(dt, '%Y-%m-%d')`); see
 [datetime.md](datetime.md). There is no general `__format__` protocol: user
 classes can't customise formatting (see [classes.md](classes.md)), and all
 other types use the builtin mini-language formatter. A format spec on a
@@ -77,7 +74,7 @@ CPython prints it literally, or the reverse. Common text is unaffected.
 
 - A `width` or `precision` whose decimal value overflows `usize` raises
     `SyntaxError: Invalid format specifier '...': width or precision overflows usize` in a literal f-string spec.
-    Runtime specs, including `str.format()`, raise `ValueError` instead, with an additional
+    Runtime specs, including `str.format()` and `format()`, raise `ValueError` instead, with an additional
     `for object of type '...'` suffix.
 - Very large widths/precisions are additionally bounded by the resource
     tracker; see [resource_limits.md](resource_limits.md).
@@ -94,4 +91,4 @@ message text otherwise matches, minus CPython's `for object of type '...'`
 suffix, which needs the runtime value type. Specs whose error *is*
 value-type-dependent or only resolvable at format time (`Unknown format code 'k'`, the `Cannot specify …` grouping conflicts, and `Format specifier missing precision`) are deferred to runtime and raise the exact CPython `ValueError`,
 as do all dynamically-built specs (`f'{1:{spec}}'`) and all `str.format()`
-specs.
+and `format()` specs.

--- a/docs/limitations/format.md
+++ b/docs/limitations/format.md
@@ -1,7 +1,8 @@
 # String formatting
 
 Monty implements CPython 3.14's format mini-language for f-string
-interpolations, `str.format()` replacement fields and the `format()` builtin. `str.format()` supports
+interpolations, `str.format()` replacement fields and the `format()`
+builtin. `str.format()` supports
 positional and keyword fields, automatic and manual numbering, attribute and
 item access, `!s` / `!r` / `!a` conversions, nested replacement fields in
 format specs, and escaped braces.
@@ -47,9 +48,10 @@ modifiers. The divergences:
 
 ## Custom `__format__`
 
-f-strings, `str.format()` and `format()` dispatch to a type's `__format__` only for
-`date`, `datetime` and `time`, which interpret the spec as a `strftime` string
-(`f'{dt:%Y-%m-%d}'`, `'{:%Y-%m-%d}'.format(dt)` or `format(dt, '%Y-%m-%d')`); see
+f-strings, `str.format()` and `format()` dispatch to a type's `__format__`
+only for `date`, `datetime` and `time`, which interpret the spec as a
+`strftime` string (`f'{dt:%Y-%m-%d}'`, `'{:%Y-%m-%d}'.format(dt)` or
+`format(dt, '%Y-%m-%d')`); see
 [datetime.md](datetime.md). There is no general `__format__` protocol: user
 classes can't customise formatting (see [classes.md](classes.md)), and all
 other types use the builtin mini-language formatter. A format spec on a
@@ -74,8 +76,8 @@ CPython prints it literally, or the reverse. Common text is unaffected.
 
 - A `width` or `precision` whose decimal value overflows `usize` raises
     `SyntaxError: Invalid format specifier '...': width or precision overflows usize` in a literal f-string spec.
-    Runtime specs, including `str.format()` and `format()`, raise `ValueError` instead, with an additional
-    `for object of type '...'` suffix.
+    Runtime specs, including `str.format()` and `format()`, raise `ValueError`
+    instead, with an additional `for object of type '...'` suffix.
 - Very large widths/precisions are additionally bounded by the resource
     tracker; see [resource_limits.md](resource_limits.md).
 

--- a/docs/limitations/index.md
+++ b/docs/limitations/index.md
@@ -31,8 +31,8 @@ They exist for development and for agents debugging code that runs on Monty; mos
 - `try` / `except` / `else` / `finally`, `raise ... from ...`
 - `for`, `while`, `if` / `elif` / `else`, `break`, `continue`, `pass`, `assert`, `global`, `nonlocal`, `return`
 - `with` statements, for files and for classes implementing `__enter__` / `__exit__`
-- f-strings (including the `=` debug form) and `str.format()`, with `!r` / `!s` / `!a` conversions, format specs and
-    nested replacement fields
+- f-strings (including the `=` debug form), `str.format()` and `format()`, with `!r` / `!s` / `!a` conversions,
+    format specs and nested replacement fields
 - `async` / `await`, and `asyncio.run` / `asyncio.gather`
 - `import x`, `import x.y`, `from x import y, z as w`
 - Starred unpacking everywhere CPython allows it
@@ -117,8 +117,6 @@ Each links to the page that owns it, which is where the full account lives:
     `run` and `gather`, the latter running host calls concurrently.
     `create_task`, `sleep` and everything else do not exist
     ([asyncio.md](asyncio.md)).
-- **The `format()` builtin is not implemented.** Use `str.format()`, `%`-formatting or
-    f-strings ([format.md](format.md)).
 - **Only UTF-8, ASCII, UTF-16 and UTF-32 codecs exist.** `latin-1` and friends raise `LookupError`
     ([encoding.md](encoding.md)).
 


### PR DESCRIPTION
`format(value, format_spec='', /)` shares the runtime path f-strings and `str.format()` already use, so every spec, temporal `__format__` dispatch and error message behaves the same across all three entry points. Argument parsing uses `FromArgs` in `unpack` style with `bad_arg` to match CPython's arity, keyword and `argument 2 must be str` wording.


Claude-Session: https://claude.ai/code/session_01RjHeHvpHnUYzNbjAuz5oCJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `format()` builtin as `format(value, format_spec='', /)`. It reuses the runtime path f-strings and `str.format()` already use, so format specs, `__format__` dispatch, and error messages behave the same across all three entry points, and argument parsing matches CPython's arity, keyword-rejection, and `argument 2 must be str` wording. `Format` is appended to the `BuiltinsFunctions` enum (its discriminants are `CallBuiltinFunction` bytecode operands, so the enum is append-only), guarded by a fingerprint in the dump-version test, and the docs move `format()` from unimplemented to implemented.

<sup>Written for commit e1f0db24478bd599aed34cd0ac50820c18b502c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

