### PR TITLE
Carry the WebSocket close frame through pool disconnects

### DIFF
--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -101,7 +101,10 @@ and restored later — including on a different worker or machine — with `Chec
 
 Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its
 session remain alive and usable — the one exception being the `MemoryError` above, raised for
-a worker that has already exited.
+a worker that has already exited. A WebSocket server reports the same kill with close code
+`CloseCause::OutOfMemory`, which the pool maps onto that `MemoryError`; every other
+`CloseCause` (idle/session/turn timeout, oversize request, eviction) is a
+`PoolError::Disconnected` carrying the frame.
 
 ## Observability
 

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -102,8 +102,9 @@ and restored later — including on a different worker or machine — with `Chec
 Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its
 session remain alive and usable — the one exception being the `MemoryError` above, raised for
 a worker that has already exited. A WebSocket server reports the same kill with close code
-`CloseCause::OutOfMemory`, which the pool maps onto that `MemoryError`; every other
-`CloseCause` (idle/session/turn timeout, oversize request, eviction) is a
+`CloseCause::OutOfMemory`, which the pool maps onto that `MemoryError`. A server draining
+while a session sits idle closes with `CloseCause::ServerShutdown`, reported as
+`PoolError::Shutdown` without a dump; the timeouts (idle, session, turn) are a
 `PoolError::Disconnected` carrying the frame.
 
 ## Observability

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -17,15 +17,15 @@ use std::{
 use monty_fs::{MountCallOutcome, MountMode, MountRoot, MountTable, OverlayState};
 use monty_proto::{FrameError, PROTOCOL_VERSION, exceeds_max_value_depth, pb, validate_requirement};
 use monty_types::{
-    AssertMessageAnnotations, DEFAULT_MAX_SUSPENSIONS, ExcType, MONTY_VERSION, MontyException, MontyObject, MontyUuid,
-    NameLookupResult, OsFunctionCall, PrintStream, ResourceLimits, TypeCheckingConfig,
+    AssertMessageAnnotations, CloseCause, DEFAULT_MAX_SUSPENSIONS, ExcType, MONTY_VERSION, MontyException, MontyObject,
+    MontyUuid, NameLookupResult, OsFunctionCall, PrintStream, ResourceLimits, TypeCheckingConfig,
 };
 use tokio::{task::spawn_blocking, time::timeout};
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{TelemetryContext, metrics::outcome};
 use crate::{
-    CrashCause, PoolError,
+    CloseFrame, CrashCause, PoolError,
     pool::{CapacityGuard, PoolInner},
     worker::Worker,
 };
@@ -1514,6 +1514,8 @@ impl Checkout {
         // status, so a cancelled reap of an out-of-memory worker is the one
         // case counted as a plain crash.
         let mut capacity = CapacityGuard::terminating(&self.pool, if websocket { "disconnected" } else { "crash" });
+        // read before teardown aborts the reader task holding it
+        let close = worker.peer_close().await;
         // A worker that exits deliberately (an allocation refused, see
         // `OOM_EXIT_CODE`) is racing us: SIGKILLing it mid-exit would replace
         // its code with `signal: 9` and lose the classification. Give it the
@@ -1523,18 +1525,25 @@ impl Checkout {
         // is waiting on this grace that should have been killed outright.
         let status = worker.reap_or_kill(FATAL_EXIT_GRACE).await;
         drop(worker);
-        if websocket {
-            PoolError::Disconnected {
-                context: context.to_owned(),
-            }
-        } else if status.and_then(|status| status.code()) == Some(monty_types::OOM_EXIT_CODE) {
-            // the worker is gone, unlike every other `Runtime` error — the
-            // checkout is already finished, so later calls report `Finished`
+        // an out-of-memory kill is the one death reported the same way on both
+        // transports: the worker is gone, unlike every other `Runtime` error —
+        // the checkout is already finished, so later calls report `Finished`
+        let out_of_memory = if websocket {
+            close.as_ref().and_then(CloseFrame::cause) == Some(CloseCause::OutOfMemory)
+        } else {
+            status.and_then(|status| status.code()) == Some(monty_types::OOM_EXIT_CODE)
+        };
+        if out_of_memory {
             capacity.set_reason("oom");
             PoolError::Runtime(MontyException::new(
                 ExcType::MemoryError,
-                Some("the worker exceeded its memory limit and was terminated".to_owned()),
+                Some(CloseCause::OutOfMemory.description().to_owned()),
             ))
+        } else if websocket {
+            PoolError::Disconnected {
+                context: context.to_owned(),
+                close,
+            }
         } else {
             PoolError::Crashed {
                 status,

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -1528,8 +1528,9 @@ impl Checkout {
         // an out-of-memory kill is the one death reported the same way on both
         // transports: the worker is gone, unlike every other `Runtime` error —
         // the checkout is already finished, so later calls report `Finished`
+        let cause = close.as_ref().and_then(CloseFrame::cause);
         let out_of_memory = if websocket {
-            close.as_ref().and_then(CloseFrame::cause) == Some(CloseCause::OutOfMemory)
+            cause == Some(CloseCause::OutOfMemory)
         } else {
             status.and_then(|status| status.code()) == Some(monty_types::OOM_EXIT_CODE)
         };
@@ -1539,6 +1540,11 @@ impl Checkout {
                 ExcType::MemoryError,
                 Some(CloseCause::OutOfMemory.description().to_owned()),
             ))
+        } else if cause == Some(CloseCause::ServerShutdown) {
+            // the server drained while the session sat idle: the same outcome
+            // as its `ShutdownDump` reply to an in-flight request, minus the
+            // state, and the request (if any) equally never ran
+            PoolError::Shutdown { dump: None }
         } else if websocket {
             PoolError::Disconnected {
                 context: context.to_owned(),

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -12,7 +12,7 @@ mod worker;
 use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
 
 pub use monty_proto::{DEFAULT_PRINT_FLUSH_INTERVAL, MAX_VALUE_DEPTH, exceeds_max_value_depth};
-use monty_types::MontyException;
+use monty_types::{CloseCause, MontyException};
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::Metrics;
@@ -164,12 +164,16 @@ pub enum PoolError {
     /// The remote worker's connection dropped without a turn-ending event
     /// (WebSocket transport only — the local analogue is [`Self::Crashed`]).
     /// The sandbox may have died, or the server may have dropped the session
-    /// by policy (idle/session/turn timeout, capacity); the two are
-    /// indistinguishable to a client that only learns of the close, so this
-    /// deliberately says no more than "the connection went away".
+    /// by policy (idle/session/turn timeout, capacity). A bare disconnect
+    /// cannot tell those apart; a server that closed deliberately says why in
+    /// `close`, whose [`CloseFrame::cause`] names the policy. The one cause
+    /// not reported this way is [`CloseCause::OutOfMemory`], which surfaces as
+    /// the same session-ending `MemoryError` the subprocess transport raises.
     Disconnected {
         /// What the pool was doing when the disconnect was observed.
         context: String,
+        /// The Close frame the server sent, when it sent one before going away.
+        close: Option<CloseFrame>,
     },
     /// The remote server is shutting down and did **not** run the request —
     /// re-running it on a fresh session is safe. `dump` carries the session
@@ -231,7 +235,13 @@ impl fmt::Display for PoolError {
             Self::Exhausted => f.write_str("no monty worker became available within the checkout timeout"),
             Self::Spawn(msg) => write!(f, "failed to spawn monty worker: {msg}"),
             Self::Finished => f.write_str("this checkout has already been finished"),
-            Self::Disconnected { context } => write!(f, "monty worker connection closed while {context}"),
+            Self::Disconnected { context, close: None } => {
+                write!(f, "monty worker connection closed while {context}")
+            }
+            Self::Disconnected {
+                context,
+                close: Some(close),
+            } => write!(f, "monty worker connection closed while {context}: {close}"),
             Self::Shutdown { dump } => match dump {
                 Some(_) => {
                     f.write_str("monty server is shutting down; the request did not run (session dump attached)")
@@ -247,6 +257,39 @@ impl error::Error for PoolError {
         match self {
             Self::Runtime(exc) => Some(exc),
             _ => None,
+        }
+    }
+}
+
+/// The WebSocket Close frame a server sent before ending a session, carried by
+/// [`PoolError::Disconnected`].
+///
+/// The code is the frame's status code (RFC 6455 §7.4), which [`Self::cause`]
+/// reads back into a [`CloseCause`] when it is one of monty's; the reason is
+/// the frame's text, at most 123 bytes, empty when the server gave none.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloseFrame {
+    /// The close status code.
+    pub code: u16,
+    /// The human-readable reason, empty when the server sent none.
+    pub reason: String,
+}
+
+impl CloseFrame {
+    /// Why the server ended the session, when its code is one of
+    /// [`CloseCause`]'s; `None` for any other code.
+    #[must_use]
+    pub fn cause(&self) -> Option<CloseCause> {
+        CloseCause::from_code(self.code)
+    }
+}
+
+impl fmt::Display for CloseFrame {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.reason.is_empty() {
+            write!(f, "close code {}", self.code)
+        } else {
+            write!(f, "{} (close code {})", self.reason, self.code)
         }
     }
 }

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -164,11 +164,12 @@ pub enum PoolError {
     /// The remote worker's connection dropped without a turn-ending event
     /// (WebSocket transport only — the local analogue is [`Self::Crashed`]).
     /// The sandbox may have died, or the server may have dropped the session
-    /// by policy (idle/session/turn timeout, capacity). A bare disconnect
-    /// cannot tell those apart; a server that closed deliberately says why in
-    /// `close`, whose [`CloseFrame::cause`] names the policy. The one cause
-    /// not reported this way is [`CloseCause::OutOfMemory`], which surfaces as
-    /// the same session-ending `MemoryError` the subprocess transport raises.
+    /// by policy (an idle, session or turn timeout). A bare disconnect cannot
+    /// tell those apart; a server that closed deliberately says why in
+    /// `close`, whose [`CloseFrame::cause`] names the policy. Two causes are
+    /// not reported this way: [`CloseCause::OutOfMemory`] surfaces as the same
+    /// session-ending `MemoryError` the subprocess transport raises, and
+    /// [`CloseCause::ServerShutdown`] as [`Self::Shutdown`].
     Disconnected {
         /// What the pool was doing when the disconnect was observed.
         context: String,
@@ -178,7 +179,9 @@ pub enum PoolError {
     /// The remote server is shutting down and did **not** run the request —
     /// re-running it on a fresh session is safe. `dump` carries the session
     /// state captured just before shutdown, restorable via
-    /// [`Checkout::restore`] on a fresh checkout.
+    /// [`Checkout::restore`] on a fresh checkout. A server draining while the
+    /// session sat idle drops it without a dump and says so in its Close
+    /// frame ([`CloseCause::ServerShutdown`]), which lands here too.
     Shutdown {
         /// Restorable session dump, absent when there was no session yet or
         /// the server's dump failed.

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -284,12 +284,15 @@ impl CloseFrame {
     }
 }
 
+/// Names the cause where the code is one of monty's, falling back to the
+/// bare number; a frame with no reason text prints the cause's description.
 impl fmt::Display for CloseFrame {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.reason.is_empty() {
-            write!(f, "close code {}", self.code)
-        } else {
-            write!(f, "{} (close code {})", self.reason, self.code)
+        match (self.cause(), self.reason.is_empty()) {
+            (Some(cause), true) => write!(f, "{cause} ({})", cause.name()),
+            (Some(cause), false) => write!(f, "{} ({})", self.reason, cause.name()),
+            (None, true) => write!(f, "close code {}", self.code),
+            (None, false) => write!(f, "{} (close code {})", self.reason, self.code),
         }
     }
 }

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -47,13 +47,13 @@ use tokio_tungstenite::{
         Bytes, Error as WsError, Message,
         client::IntoClientRequest,
         http::{HeaderName, HeaderValue, header::USER_AGENT},
-        protocol::WebSocketConfig,
+        protocol::{CloseFrame as WsCloseFrame, WebSocketConfig},
     },
 };
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{TelemetryContext, metrics::TurnMetrics, tracing::Recorder};
-use crate::{MontyTransport, PoolConfig, PoolError};
+use crate::{CloseFrame, MontyTransport, PoolConfig, PoolError};
 
 /// The async WebSocket stream type for a remote worker.
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -102,8 +102,9 @@ struct WebSocketWorker {
     sink: Option<SplitSink<WsStream, Message>>,
     /// Binary frames (or the terminal error) forwarded by the reader task.
     events: mpsc::Receiver<Result<Bytes, FrameError>>,
-    /// The task owning the read half; aborted on teardown/drop.
-    reader: JoinHandle<()>,
+    /// The task owning the read half, which resolves to the server's Close
+    /// frame; `None` once [`Self::peer_close`] took it. Aborted on teardown/drop.
+    reader: Option<JoinHandle<Option<CloseFrame>>>,
 }
 
 impl WebSocketWorker {
@@ -118,8 +119,29 @@ impl WebSocketWorker {
         if let Some(sink) = &mut self.sink {
             send_close(sink).await;
         }
-        self.reader.abort();
+        if let Some(reader) = &self.reader {
+            reader.abort();
+        }
         self.sink = None;
+    }
+
+    /// The Close frame the server sent, for a connection that has just failed.
+    ///
+    /// The reader task exits on the Close it read, so it is finished or about
+    /// to be. The bound is for a connection that failed without one (I/O
+    /// error, vanished peer), whose reader may sit in a read that never
+    /// returns; it is then aborted, as teardown would.
+    async fn peer_close(&mut self) -> Option<CloseFrame> {
+        let mut reader = self.reader.take()?;
+        match timeout(PEER_CLOSE_WAIT, &mut reader).await {
+            Ok(Ok(close)) => close,
+            // panicked or already aborted
+            Ok(Err(_)) => None,
+            Err(_elapsed) => {
+                reader.abort();
+                None
+            }
+        }
     }
 }
 
@@ -132,7 +154,9 @@ impl WebSocketWorker {
 /// notices the worker is gone, and would hold the socket open forever.
 impl Drop for WebSocketWorker {
     fn drop(&mut self) {
-        self.reader.abort();
+        if let Some(reader) = &self.reader {
+            reader.abort();
+        }
         if let Some(mut sink) = self.sink.take()
             && let Ok(handle) = Handle::try_current()
         {
@@ -267,7 +291,7 @@ impl Worker {
             kind: WorkerKind::WebSocket(Box::new(WebSocketWorker {
                 sink: Some(sink),
                 events,
-                reader,
+                reader: Some(reader),
             })),
             checkouts_served: 0,
             #[cfg(feature = "telemetry")]
@@ -445,7 +469,22 @@ impl Worker {
             w.close().await;
         }
     }
+
+    /// The Close frame a WebSocket server sent before its connection failed,
+    /// for the disconnect error being built; `None` for a subprocess worker.
+    /// Call once, after the failing send or receive and before teardown.
+    pub(crate) async fn peer_close(&mut self) -> Option<CloseFrame> {
+        match &mut self.kind {
+            WorkerKind::Subprocess(_) => None,
+            WorkerKind::WebSocket(w) => w.peer_close().await,
+        }
+    }
 }
+
+/// How long [`WebSocketWorker::peer_close`] waits for the reader task to hand
+/// over the server's Close frame. Only a connection that failed *without* a
+/// Close ever waits this long; one that closed properly resolves at once.
+const PEER_CLOSE_WAIT: Duration = Duration::from_millis(100);
 
 /// How long teardown gives a WebSocket Close frame to reach the OS. Not a
 /// latency budget (no ACK or Close echo is awaited) — it only rides out
@@ -585,32 +624,50 @@ const WS_EVENT_CHANNEL_DEPTH: usize = 1;
 /// The WebSocket reader task: polls the read half continuously so
 /// tokio-tungstenite pongs even while the worker is idle (see the module
 /// docs), forwarding each binary frame — or the terminal error — to `recv`.
+/// Resolves to the server's Close frame, which `recv` cannot carry (its
+/// channel speaks `FrameError`, shared with the subprocess transport) and the
+/// disconnect error wants — see [`WebSocketWorker::peer_close`].
 ///
 /// Reserving the slot before polling keeps the reader polling (and ponging)
 /// rather than blocked holding a frame.
-async fn read_ws_events(mut read_half: SplitStream<WsStream>, events: mpsc::Sender<Result<Bytes, FrameError>>) {
+async fn read_ws_events(
+    mut read_half: SplitStream<WsStream>,
+    events: mpsc::Sender<Result<Bytes, FrameError>>,
+) -> Option<CloseFrame> {
     // an Err from reserve means the receiver dropped: the worker is gone
     while let Ok(permit) = events.reserve().await {
-        let result = loop {
+        let (result, close) = loop {
             match read_half.next().await {
-                Some(Ok(Message::Binary(data))) => break Ok(data),
+                Some(Ok(Message::Binary(data))) => break (Ok(data), None),
                 // polling is itself what pongs: tungstenite queues the pong on
                 // read and flushes it during read polling
                 Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
-                // a clean close, or text/raw frames the protocol never uses
-                Some(Ok(Message::Close(_) | Message::Text(_) | Message::Frame(_))) | None => {
-                    break Err(FrameError::Truncated);
+                // the server closed: a bare disconnect to `recv`, the frame
+                // (a policy drop's code and reason) to the caller
+                Some(Ok(Message::Close(frame))) => break (Err(FrameError::Truncated), frame.as_ref().map(close_frame)),
+                // text/raw frames the protocol never uses, or a vanished peer
+                Some(Ok(Message::Text(_) | Message::Frame(_))) | None => {
+                    break (Err(FrameError::Truncated), None);
                 }
-                Some(Err(WsError::Io(err))) => break Err(FrameError::Io(err)),
-                Some(Err(_)) => break Err(FrameError::Truncated),
+                Some(Err(WsError::Io(err))) => break (Err(FrameError::Io(err)), None),
+                Some(Err(_)) => break (Err(FrameError::Truncated), None),
             }
         };
         // any error is terminal: deliver it and exit
         let stop = result.is_err();
         permit.send(result);
         if stop {
-            return;
+            return close;
         }
+    }
+    None
+}
+
+/// Copies a tungstenite Close frame into the pool's public [`CloseFrame`].
+fn close_frame(frame: &WsCloseFrame) -> CloseFrame {
+    CloseFrame {
+        code: frame.code.into(),
+        reason: frame.reason.to_string(),
     }
 }
 

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -130,17 +130,18 @@ impl WebSocketWorker {
     /// The reader task exits on the Close it read, so it is finished or about
     /// to be. The bound is for a connection that failed without one (I/O
     /// error, vanished peer), whose reader may sit in a read that never
-    /// returns; it is then aborted, as teardown would.
+    /// returns; the teardown that follows aborts it. The handle stays in
+    /// `self.reader` across the await so a caller cancelled mid-wait leaves a
+    /// task that `close`/`Drop` still abort, not a detached one.
     async fn peer_close(&mut self) -> Option<CloseFrame> {
-        let mut reader = self.reader.take()?;
-        match timeout(PEER_CLOSE_WAIT, &mut reader).await {
-            Ok(Ok(close)) => close,
-            // panicked or already aborted
-            Ok(Err(_)) => None,
-            Err(_elapsed) => {
-                reader.abort();
-                None
+        match timeout(PEER_CLOSE_WAIT, self.reader.as_mut()?).await {
+            // a finished handle must not be polled again; a panicked or
+            // aborted task has no frame
+            Ok(joined) => {
+                self.reader = None;
+                joined.ok().flatten()
             }
+            Err(_elapsed) => None,
         }
     }
 }

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -17,11 +17,11 @@ use std::{
 #[cfg(feature = "telemetry")]
 use monty_pool::telemetry::{TelemetryAdapter, configure_telemetry_adapter};
 use monty_pool::{
-    Checkout, CheckoutOptions, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig,
-    ResumeValue, TurnEvent,
+    Checkout, CheckoutOptions, CloseFrame, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture,
+    ReplConfig, ResumeValue, TurnEvent,
 };
 use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, WireObject, decode_frame, encode_to_capped_vec, pb};
-use monty_types::{MontyObject, PrintStream, ResourceLimits};
+use monty_types::{CloseCause, ExcType, MontyObject, PrintStream, ResourceLimits};
 #[cfg(feature = "telemetry")]
 use opentelemetry::trace::{SpanId, TraceId};
 #[cfg(feature = "telemetry")]
@@ -32,6 +32,7 @@ use tokio::time::timeout;
 use tungstenite::{
     Message, WebSocket,
     handshake::server::{Request, Response},
+    protocol::{CloseFrame as WsCloseFrame, frame::coding::CloseCode},
 };
 
 /// A mock child: accepts one WebSocket connection and answers each request with
@@ -1942,5 +1943,160 @@ async fn a_dropped_connection_is_a_disconnect() {
         .feed("x", vec![], vec![], false, &mut no_print)
         .await
         .expect_err("a closed connection must fail the turn");
-    assert!(matches!(err, PoolError::Disconnected { .. }), "got {err:?}");
+    // a Close with no body carries nothing to report
+    assert!(
+        matches!(err, PoolError::Disconnected { close: None, .. }),
+        "got {err:?}"
+    );
+    assert_eq!(
+        err.to_string(),
+        "monty worker connection closed while sending a request"
+    );
+}
+
+/// A server ending a session by policy, the way `monty-server` does: a Close
+/// frame whose code is the cause and whose reason is free text.
+fn close_with(socket: &mut WebSocket<TcpStream>, code: u16, reason: &str) {
+    let _ = socket.close(Some(WsCloseFrame {
+        code: CloseCode::from(code),
+        reason: reason.into(),
+    }));
+}
+
+/// Scripts a mock child that answers `Configure`, then closes with `code`
+/// either instead of answering the first feed or after answering it.
+fn serve_then_close(listener: &TcpListener, answer_first_feed: bool, code: u16, reason: &str) {
+    let mut socket = accept_ws(listener);
+    expect_configure(&mut socket);
+    expect_feed(&mut socket, "1 + 1");
+    if answer_first_feed {
+        send_kind(
+            &mut socket,
+            pb::child_event::Kind::Complete(pb::Complete {
+                value: Some(MontyObject::Int(42).into()),
+            }),
+        );
+    }
+    close_with(&mut socket, code, reason);
+}
+
+#[tokio::test]
+async fn a_close_frame_sent_while_idle_reaches_the_next_turn() {
+    // The idle case: the server drops the session between turns. The reader
+    // task sees the Close while the client sits idle, and the next request
+    // fails on the send — which must still report what the server said.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || serve_then_close(&listener, true, 4000, "session idle timeout"));
+
+    let (_pool, mut checkout) = websocket_checkout(port).await;
+    checkout
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    join_server(server).await;
+    let err = checkout
+        .feed("x", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("a closed connection must fail the turn");
+    let PoolError::Disconnected { context, close } = &err else {
+        panic!("expected Disconnected, got {err:?}");
+    };
+    assert_eq!(context, "sending a request");
+    assert_eq!(
+        *close,
+        Some(CloseFrame {
+            code: 4000,
+            reason: "session idle timeout".to_owned(),
+        })
+    );
+    assert_eq!(
+        close.as_ref().and_then(CloseFrame::cause),
+        Some(CloseCause::IdleTimeout)
+    );
+    assert_eq!(
+        err.to_string(),
+        "monty worker connection closed while sending a request: session idle timeout (close code 4000)"
+    );
+}
+
+#[tokio::test]
+async fn a_close_frame_sent_mid_turn_fails_that_turn() {
+    // The server drops the session instead of answering a request.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || serve_then_close(&listener, false, 4002, "turn timeout"));
+
+    let (_pool, mut checkout) = websocket_checkout(port).await;
+    let err = checkout
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("a closed connection must fail the turn");
+    join_server(server).await;
+    let PoolError::Disconnected { context, close } = &err else {
+        panic!("expected Disconnected, got {err:?}");
+    };
+    assert_eq!(context, "waiting for a reply");
+    assert_eq!(
+        *close,
+        Some(CloseFrame {
+            code: 4002,
+            reason: "turn timeout".to_owned(),
+        })
+    );
+    assert_eq!(
+        close.as_ref().and_then(CloseFrame::cause),
+        Some(CloseCause::TurnTimeout)
+    );
+}
+
+#[tokio::test]
+async fn an_out_of_memory_close_is_the_session_ending_memory_error() {
+    // Parity with the subprocess transport, where the worker's OOM exit code
+    // becomes a `MemoryError` whose checkout is already finished.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || serve_then_close(&listener, false, 4003, "memory limit exceeded"));
+
+    let (_pool, mut checkout) = websocket_checkout(port).await;
+    let err = checkout
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("a closed connection must fail the turn");
+    join_server(server).await;
+    let PoolError::Runtime(exc) = &err else {
+        panic!("expected Runtime, got {err:?}");
+    };
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert_eq!(
+        exc.message(),
+        Some("the worker exceeded its memory limit and was terminated")
+    );
+    let err = checkout
+        .feed("x", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("the checkout is finished");
+    assert!(matches!(err, PoolError::Finished), "got {err:?}");
+}
+
+#[tokio::test]
+async fn an_unknown_close_code_is_still_a_disconnect() {
+    // a code a newer server defined: the number and text still come through,
+    // just without a cause
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || serve_then_close(&listener, false, 4999, "something new"));
+
+    let (_pool, mut checkout) = websocket_checkout(port).await;
+    let err = checkout
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("a closed connection must fail the turn");
+    join_server(server).await;
+    let PoolError::Disconnected { close: Some(close), .. } = &err else {
+        panic!("expected Disconnected with a frame, got {err:?}");
+    };
+    assert_eq!(close.code, 4999);
+    assert_eq!(close.reason, "something new");
+    assert_eq!(close.cause(), None);
 }

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -2080,6 +2080,34 @@ async fn an_out_of_memory_close_is_the_session_ending_memory_error() {
 }
 
 #[tokio::test]
+async fn a_server_shutdown_close_is_a_shutdown_without_a_dump() {
+    // The server drained while the session sat idle past its grace period:
+    // the same outcome as its `ShutdownDump` reply to an in-flight request,
+    // minus the state, so a caller handling `Shutdown` covers both.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || serve_then_close(&listener, true, 4004, "server shutting down"));
+
+    let (_pool, mut checkout) = websocket_checkout(port).await;
+    checkout
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    join_server(server).await;
+    let err = checkout
+        .feed("x", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("a closed connection must fail the turn");
+    assert!(matches!(err, PoolError::Shutdown { dump: None }), "got {err:?}");
+    // the session is gone: a fresh checkout is the only way forward
+    let err = checkout
+        .feed("x", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("the checkout is finished");
+    assert!(matches!(err, PoolError::Finished), "got {err:?}");
+}
+
+#[tokio::test]
 async fn an_unknown_close_code_is_still_a_disconnect() {
     // a code a newer server defined: the number and text still come through,
     // just without a cause

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -2016,7 +2016,7 @@ async fn a_close_frame_sent_while_idle_reaches_the_next_turn() {
     );
     assert_eq!(
         err.to_string(),
-        "monty worker connection closed while sending a request: session idle timeout (close code 4000)"
+        "monty worker connection closed while sending a request: session idle timeout (idle_timeout)"
     );
 }
 
@@ -2099,4 +2099,8 @@ async fn an_unknown_close_code_is_still_a_disconnect() {
     assert_eq!(close.code, 4999);
     assert_eq!(close.reason, "something new");
     assert_eq!(close.cause(), None);
+    assert_eq!(
+        err.to_string(),
+        "monty worker connection closed while waiting for a reply: something new (close code 4999)"
+    );
 }

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -60,6 +60,7 @@ __all__ = (
     'ExcType',
     'PrintCallback',
     'TypeCheckFormat',
+    'CloseCause',
     'OsHandler',
     'SyncSnapshot',
     'AsyncSnapshot',
@@ -239,6 +240,23 @@ instance or by type name), or a pending `future`."""
 
 PrintCallback: TypeAlias = Callable[[Literal['stdout', 'stderr'], str], None] | CollectStreams | CollectString
 """Print sink accepted by `feed_run` / `feed_start` / `load_snapshot`."""
+
+CloseCause: TypeAlias = Literal[
+    'idle_timeout', 'session_timeout', 'turn_timeout', 'out_of_memory', 'request_too_large', 'evicted'
+]
+"""Why a `monty-server` ended a session, read from the code of its WebSocket Close frame.
+
+| code | cause                 |
+|------|-----------------------|
+| 4000 | `'idle_timeout'`      |
+| 4001 | `'session_timeout'`   |
+| 4002 | `'turn_timeout'`      |
+| 4003 | `'out_of_memory'`     |
+| 4004 | `'request_too_large'` |
+| 4005 | `'evicted'`           |
+
+Exposed as `MontyDisconnectError.close_cause`, except `'out_of_memory'`, which
+raises `MemoryError` instead."""
 
 TypeCheckFormat: TypeAlias = Literal[
     'full', 'concise', 'azure', 'json', 'jsonlines', 'rdjson', 'pylint', 'gitlab', 'github'

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -241,9 +241,7 @@ instance or by type name), or a pending `future`."""
 PrintCallback: TypeAlias = Callable[[Literal['stdout', 'stderr'], str], None] | CollectStreams | CollectString
 """Print sink accepted by `feed_run` / `feed_start` / `load_snapshot`."""
 
-CloseCause: TypeAlias = Literal[
-    'idle_timeout', 'session_timeout', 'turn_timeout', 'out_of_memory', 'request_too_large', 'evicted'
-]
+CloseCause: TypeAlias = Literal['idle_timeout', 'session_timeout', 'turn_timeout', 'out_of_memory', 'server_shutdown']
 """Why a `monty-server` ended a session, read from the code of its WebSocket Close frame.
 
 | code | cause                 |
@@ -252,11 +250,11 @@ CloseCause: TypeAlias = Literal[
 | 4001 | `'session_timeout'`   |
 | 4002 | `'turn_timeout'`      |
 | 4003 | `'out_of_memory'`     |
-| 4004 | `'request_too_large'` |
-| 4005 | `'evicted'`           |
+| 4004 | `'server_shutdown'`   |
 
-Exposed as `MontyDisconnectError.close_cause`, except `'out_of_memory'`, which
-raises `MemoryError` instead."""
+Exposed as `MontyDisconnectError.close_cause` for the three timeouts;
+`'out_of_memory'` raises `MemoryError` and `'server_shutdown'` raises
+`MontyShutdown` instead."""
 
 TypeCheckFormat: TypeAlias = Literal[
     'full', 'concise', 'azure', 'json', 'jsonlines', 'rdjson', 'pylint', 'gitlab', 'github'

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -7,6 +7,7 @@ from typing_extensions import Self
 
 from . import (
     AsyncSnapshot,
+    CloseCause,
     ExternalResult,
     ExternalSettledResult,
     OsHandler,
@@ -444,12 +445,29 @@ class MontyDisconnectError(MontyError):
 
     The local analogue is `MontyCrashedError`. The sandbox may have died, or
     the server may have dropped the session by policy — an idle, session, or
-    turn timeout, or being over capacity. A client that only sees the
-    connection go away cannot tell those apart, so this error claims no more
-    than that. Retry on a fresh session.
+    turn timeout, or being over capacity. A bare disconnect cannot tell those
+    apart; a server that closed deliberately says why in its WebSocket Close
+    frame, exposed here as `close_code`, `close_reason` and `close_cause` and
+    repeated in the message. Retry on a fresh session.
+
+    One policy drop is not reported this way: a worker killed for exceeding
+    its memory limit raises the same session-ending `MemoryError` a local
+    pool does.
 
     Cannot be constructed directly from Python.
     """
+
+    @property
+    def close_code(self) -> int | None:
+        """The server's WebSocket close code, `None` when it sent no Close frame."""
+
+    @property
+    def close_reason(self) -> str | None:
+        """The server's close reason; `None` without a Close frame, `''` for a frame that gave none."""
+
+    @property
+    def close_cause(self) -> CloseCause | None:
+        """What `close_code` stands for when it is a code monty defines (see `CloseCause`), else `None`."""
 
 @final
 class MontyShutdown(MontyError):
@@ -851,7 +869,8 @@ class AsyncMontyWebsocket:
     drain it answers the session's next request with `MontyShutdown`, whose
     `dump` restores the session onto another server; every other server-side
     drop (idle, session or turn timeout, capacity) closes the connection and
-    raises `MontyDisconnectError`.
+    raises `MontyDisconnectError`, whose `close_cause` names the policy —
+    except a memory-limit kill, which raises `MemoryError` as a local pool does.
 
     ```python
     async with AsyncMontyWebsocket('ws://127.0.0.1:8799') as pool:

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -445,14 +445,15 @@ class MontyDisconnectError(MontyError):
 
     The local analogue is `MontyCrashedError`. The sandbox may have died, or
     the server may have dropped the session by policy — an idle, session, or
-    turn timeout, or being over capacity. A bare disconnect cannot tell those
-    apart; a server that closed deliberately says why in its WebSocket Close
-    frame, exposed here as `close_code`, `close_reason` and `close_cause` and
-    repeated in the message. Retry on a fresh session.
+    turn timeout. A bare disconnect cannot tell those apart; a server that
+    closed deliberately says why in its WebSocket Close frame, exposed here as
+    `close_code`, `close_reason` and `close_cause` and repeated in the
+    message. Retry on a fresh session.
 
-    One policy drop is not reported this way: a worker killed for exceeding
+    Two policy drops are not reported this way: a worker killed for exceeding
     its memory limit raises the same session-ending `MemoryError` a local
-    pool does.
+    pool does, and a server that drained while the session sat idle raises
+    `MontyShutdown`.
 
     Cannot be constructed directly from Python.
     """
@@ -481,7 +482,9 @@ class MontyShutdown(MontyError):
     `dump` carries the session state captured just before shutdown — restore
     it on a new session to carry the session across a server restart, with
     `session.load_session` (idle, between feeds) or `session.load_snapshot`
-    (suspended mid-feed).
+    (suspended mid-feed). A server that drained while the session sat idle
+    past its grace period drops it without a dump (`close_cause`
+    `'server_shutdown'`), so `dump` is `None` and the session starts over.
 
     One caveat: if the interrupted request was answering a suspension (an
     external function or `os` callback), the host already ran that call and
@@ -868,9 +871,10 @@ class AsyncMontyWebsocket:
     A `monty-server` enforces its own policy on top of the pool's. On SIGTERM
     drain it answers the session's next request with `MontyShutdown`, whose
     `dump` restores the session onto another server; every other server-side
-    drop (idle, session or turn timeout, capacity) closes the connection and
-    raises `MontyDisconnectError`, whose `close_cause` names the policy —
-    except a memory-limit kill, which raises `MemoryError` as a local pool does.
+    drop closes the connection with a `CloseCause`: the timeouts (idle,
+    session, turn) raise `MontyDisconnectError` naming it in `close_cause`, a
+    memory-limit kill raises `MemoryError` as a local pool does, and an idle
+    session dropped during drain raises `MontyShutdown` without a `dump`.
 
     ```python
     async with AsyncMontyWebsocket('ws://127.0.0.1:8799') as pool:

--- a/crates/monty-python/src/exceptions.rs
+++ b/crates/monty-python/src/exceptions.rs
@@ -20,8 +20,9 @@
 use std::sync::Arc;
 
 use ahash::AHashMap;
+use monty_pool::CloseFrame;
 use monty_proto::python::exc_monty_to_py;
-use monty_types::{ExcType, MontyException};
+use monty_types::{CloseCause, ExcType, MontyException};
 use pyo3::{
     PyClassInitializer,
     exceptions::{self},
@@ -388,18 +389,36 @@ impl MontyCrashedError {
 /// (WebSocket transport only — the local analogue is `MontyCrashedError`).
 ///
 /// The sandbox may have died, or the server may have dropped the session by
-/// policy: an idle/session/turn timeout, or being over capacity. A client that
-/// only sees the connection go away cannot tell those apart, so this error
-/// deliberately claims no more than that. Retry on a fresh session.
+/// policy: an idle/session/turn timeout, or being over capacity. A bare
+/// disconnect cannot tell those apart; a server that closed deliberately says
+/// why in its Close frame, exposed as `close_code`, `close_reason` and — for
+/// a code monty defines — `close_cause`. Retry on a fresh session.
 #[pyclass(extends=MontyError, module="pydantic_monty")]
-pub struct MontyDisconnectError {}
+pub struct MontyDisconnectError {
+    /// The server's WebSocket close code, `None` when it sent no Close frame.
+    #[pyo3(get, name = "close_code")]
+    code: Option<u16>,
+    /// The server's close reason; `None` without a Close frame, and `''` for
+    /// a frame that gave none.
+    #[pyo3(get, name = "close_reason")]
+    reason: Option<String>,
+    /// `CloseCause::name()` for a close code monty defines, else `None`.
+    #[pyo3(get, name = "close_cause")]
+    cause: Option<&'static str>,
+}
 
 impl MontyDisconnectError {
-    /// Creates a `MontyDisconnectError` with the given description.
+    /// Creates a `MontyDisconnectError` with the given description and the
+    /// server's Close frame, when it sent one.
     #[must_use]
-    pub fn new_err(py: Python<'_>, message: String) -> PyErr {
+    pub fn new_err(py: Python<'_>, message: String, close: Option<CloseFrame>) -> PyErr {
         let base = MontyError::new(MontyException::new(ExcType::RuntimeError, Some(message)));
-        let init = PyClassInitializer::from(base).add_subclass(Self {});
+        let cause = close.as_ref().and_then(CloseFrame::cause).map(CloseCause::name);
+        let (code, reason) = match close {
+            Some(close) => (Some(close.code), Some(close.reason)),
+            None => (None, None),
+        };
+        let init = PyClassInitializer::from(base).add_subclass(Self { code, reason, cause });
         match Py::new(py, init) {
             Ok(err) => PyErr::from_value(err.into_bound(py).into_any()),
             Err(e) => e,

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -1819,7 +1819,7 @@ pub(crate) fn pool_err_to_py(py: Python<'_>, err: PoolError) -> PyErr {
             MontyCrashedError::new_err(py, message, false, status.and_then(|s| s.code()))
         }
         PoolError::Timeout { .. } => MontyCrashedError::new_err(py, message, true, None),
-        PoolError::Disconnected { .. } => MontyDisconnectError::new_err(py, message),
+        PoolError::Disconnected { close, .. } => MontyDisconnectError::new_err(py, message, close),
         PoolError::Shutdown { dump } => MontyShutdown::new_err(py, message, dump),
         PoolError::Exhausted => PyTimeoutError::new_err(message),
         PoolError::Protocol(_) | PoolError::Spawn(_) | PoolError::Finished => PyRuntimeError::new_err(message),

--- a/crates/monty-python/tests/test_websocket.py
+++ b/crates/monty-python/tests/test_websocket.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import sys
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from types import MappingProxyType, ModuleType
@@ -25,7 +26,7 @@ from websockets.asyncio.server import ServerConnection, serve
 from websockets.datastructures import Headers
 from websockets.http11 import Request
 
-from pydantic_monty import AsyncMontyWebsocket, MontyRuntimeError
+from pydantic_monty import AsyncMontyWebsocket, MontyDisconnectError, MontyRuntimeError
 from pydantic_monty._binary import find_monty_binary
 
 _RELAY_SCRIPT = Path(__file__).resolve().parents[3] / 'scripts' / 'websocket_relay.py'
@@ -281,3 +282,50 @@ async def test_checkout_rejects_unknown_limits():
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key 'max_memroy'; accepted keys are 'max_duration_secs', 'max_memory', 'gc_interval', 'max_recursion_depth', 'max_suspensions'"
     )
+
+
+@asynccontextmanager
+async def serve_closing_with(code: int, reason: str) -> AsyncGenerator[str, None]:
+    """Serves a mock that drops every session the way a server enforcing a
+    policy limit does: a Close frame whose code is the cause and whose reason is text."""
+
+    async def handler(websocket: ServerConnection) -> None:
+        await websocket.close(code, reason)
+
+    async with serve(handler, '127.0.0.1', 0) as server:
+        host, port = server.sockets[0].getsockname()[:2]
+        yield f'ws://{host}:{port}'
+
+
+async def test_close_frame_is_carried_by_disconnect_error():
+    async with serve_closing_with(4000, 'session idle timeout') as ws_url:
+        async with AsyncMontyWebsocket(ws_url, request_timeout=30.0) as pool:
+            with pytest.raises(MontyDisconnectError) as exc_info:
+                async with pool.checkout():
+                    pass
+    assert exc_info.value.close_code == snapshot(4000)
+    assert exc_info.value.close_reason == snapshot('session idle timeout')
+    assert exc_info.value.close_cause == snapshot('idle_timeout')
+    assert str(exc_info.value) == snapshot(
+        'monty worker connection closed while waiting for a reply: session idle timeout (close code 4000)'
+    )
+
+
+async def test_unknown_close_code_has_no_cause():
+    async with serve_closing_with(4999, 'something new') as ws_url:
+        async with AsyncMontyWebsocket(ws_url, request_timeout=30.0) as pool:
+            with pytest.raises(MontyDisconnectError) as exc_info:
+                async with pool.checkout():
+                    pass
+    assert exc_info.value.close_code == snapshot(4999)
+    assert exc_info.value.close_cause == snapshot(None)
+
+
+async def test_out_of_memory_close_is_a_memory_error():
+    # parity with a local pool, where a memory-limit kill is a session-ending MemoryError
+    async with serve_closing_with(4003, 'memory limit exceeded') as ws_url:
+        async with AsyncMontyWebsocket(ws_url, request_timeout=30.0) as pool:
+            with pytest.raises(MontyRuntimeError) as exc_info:
+                async with pool.checkout():
+                    pass
+    assert exc_info.value.display(format='msg') == snapshot('the worker exceeded its memory limit and was terminated')

--- a/crates/monty-python/tests/test_websocket.py
+++ b/crates/monty-python/tests/test_websocket.py
@@ -26,7 +26,7 @@ from websockets.asyncio.server import ServerConnection, serve
 from websockets.datastructures import Headers
 from websockets.http11 import Request
 
-from pydantic_monty import AsyncMontyWebsocket, MontyDisconnectError, MontyRuntimeError
+from pydantic_monty import AsyncMontyWebsocket, MontyDisconnectError, MontyRuntimeError, MontyShutdown
 from pydantic_monty._binary import find_monty_binary
 
 _RELAY_SCRIPT = Path(__file__).resolve().parents[3] / 'scripts' / 'websocket_relay.py'
@@ -319,6 +319,18 @@ async def test_unknown_close_code_has_no_cause():
                     pass
     assert exc_info.value.close_code == snapshot(4999)
     assert exc_info.value.close_cause == snapshot(None)
+
+
+async def test_server_shutdown_close_is_a_shutdown_without_a_dump():
+    # the server drained while the session sat idle: the same exception as its
+    # in-flight ShutdownDump reply, so one handler covers both, but no state
+    async with serve_closing_with(4004, 'server shutting down') as ws_url:
+        async with AsyncMontyWebsocket(ws_url, request_timeout=30.0) as pool:
+            with pytest.raises(MontyShutdown) as exc_info:
+                async with pool.checkout():
+                    pass
+    assert exc_info.value.dump is None
+    assert str(exc_info.value) == snapshot('monty server is shutting down; the request did not run')
 
 
 async def test_out_of_memory_close_is_a_memory_error():

--- a/crates/monty-python/tests/test_websocket.py
+++ b/crates/monty-python/tests/test_websocket.py
@@ -307,7 +307,7 @@ async def test_close_frame_is_carried_by_disconnect_error():
     assert exc_info.value.close_reason == snapshot('session idle timeout')
     assert exc_info.value.close_cause == snapshot('idle_timeout')
     assert str(exc_info.value) == snapshot(
-        'monty worker connection closed while waiting for a reply: session idle timeout (close code 4000)'
+        'monty worker connection closed while waiting for a reply: session idle timeout (idle_timeout)'
     )
 
 

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -19,6 +19,8 @@ implementation**.
   interpreter uses to enforce time/memory/recursion limits, plus the
   `max_suspensions` budget hosts enforce themselves.
 - `PrintStream` / `PrintWriter` — `print()` output capture.
+- `CloseCause` — the WebSocket close codes a server uses to say why it ended
+  a session, and what a client reads them back into.
 - `CompileOptions`, `ExtFunctionResult`, `NameLookupResult`, `FileMode`, and
   the CPython-compatible formatting helpers behind their `repr()`s.
 

--- a/crates/monty-types/src/close_cause.rs
+++ b/crates/monty-types/src/close_cause.rs
@@ -1,0 +1,85 @@
+//! The WebSocket close codes a server uses to say why it ended a session.
+
+use std::fmt;
+
+/// Why a WebSocket server ended a session, as the status code of the Close
+/// frame it sent.
+///
+/// The codes are wire contract: a client maps them back to causes without
+/// parsing the frame's free-text reason, so renumbering one makes older
+/// clients misreport. They sit in RFC 6455's private-use range (4000–4999);
+/// no registered code describes a policy limit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum CloseCause {
+    /// No request arrived within the server's idle timeout.
+    IdleTimeout = 4000,
+    /// The session outlived the server's session lifetime limit.
+    SessionTimeout = 4001,
+    /// One request outlived the server's turn timeout.
+    TurnTimeout = 4002,
+    /// The worker exceeded its memory limit and was terminated.
+    OutOfMemory = 4003,
+    /// A request frame exceeded the server's size cap.
+    RequestTooLarge = 4004,
+    /// The server reclaimed the session's capacity.
+    Evicted = 4005,
+}
+
+impl CloseCause {
+    /// Every cause, in code order.
+    pub const ALL: [Self; 6] = [
+        Self::IdleTimeout,
+        Self::SessionTimeout,
+        Self::TurnTimeout,
+        Self::OutOfMemory,
+        Self::RequestTooLarge,
+        Self::Evicted,
+    ];
+
+    /// The close status code standing for this cause.
+    #[must_use]
+    pub fn code(self) -> u16 {
+        self as u16
+    }
+
+    /// The cause a close status code stands for; `None` for any other code,
+    /// including one a newer server defined.
+    #[must_use]
+    pub fn from_code(code: u16) -> Option<Self> {
+        Self::ALL.into_iter().find(|cause| cause.code() == code)
+    }
+
+    /// The cause's stable snake_case name, e.g. `idle_timeout`, for bindings
+    /// that expose it as a string.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::IdleTimeout => "idle_timeout",
+            Self::SessionTimeout => "session_timeout",
+            Self::TurnTimeout => "turn_timeout",
+            Self::OutOfMemory => "out_of_memory",
+            Self::RequestTooLarge => "request_too_large",
+            Self::Evicted => "evicted",
+        }
+    }
+
+    /// A one-line description, suitable as the Close frame's reason text.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::IdleTimeout => "the session was idle for longer than the server allows",
+            Self::SessionTimeout => "the session outlived the server's session lifetime limit",
+            Self::TurnTimeout => "the request outlived the server's turn timeout",
+            Self::OutOfMemory => "the worker exceeded its memory limit and was terminated",
+            Self::RequestTooLarge => "the request frame exceeded the server's size cap",
+            Self::Evicted => "the server reclaimed the session's capacity",
+        }
+    }
+}
+
+impl fmt::Display for CloseCause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}

--- a/crates/monty-types/src/close_cause.rs
+++ b/crates/monty-types/src/close_cause.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use strum::{FromRepr, IntoStaticStr, VariantArray};
+
 /// Why a WebSocket server ended a session, as the status code of the Close
 /// frame it sent.
 ///
@@ -9,7 +11,8 @@ use std::fmt;
 /// parsing the frame's free-text reason, so renumbering one makes older
 /// clients misreport. They sit in RFC 6455's private-use range (4000–4999);
 /// no registered code describes a policy limit.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, FromRepr, IntoStaticStr, VariantArray)]
+#[strum(serialize_all = "snake_case")]
 #[repr(u16)]
 pub enum CloseCause {
     /// No request arrived within the server's idle timeout.
@@ -27,16 +30,6 @@ pub enum CloseCause {
 }
 
 impl CloseCause {
-    /// Every cause, in code order.
-    pub const ALL: [Self; 6] = [
-        Self::IdleTimeout,
-        Self::SessionTimeout,
-        Self::TurnTimeout,
-        Self::OutOfMemory,
-        Self::RequestTooLarge,
-        Self::Evicted,
-    ];
-
     /// The close status code standing for this cause.
     #[must_use]
     pub fn code(self) -> u16 {
@@ -47,21 +40,14 @@ impl CloseCause {
     /// including one a newer server defined.
     #[must_use]
     pub fn from_code(code: u16) -> Option<Self> {
-        Self::ALL.into_iter().find(|cause| cause.code() == code)
+        Self::from_repr(code)
     }
 
     /// The cause's stable snake_case name, e.g. `idle_timeout`, for bindings
     /// that expose it as a string.
     #[must_use]
     pub fn name(self) -> &'static str {
-        match self {
-            Self::IdleTimeout => "idle_timeout",
-            Self::SessionTimeout => "session_timeout",
-            Self::TurnTimeout => "turn_timeout",
-            Self::OutOfMemory => "out_of_memory",
-            Self::RequestTooLarge => "request_too_large",
-            Self::Evicted => "evicted",
-        }
+        self.into()
     }
 
     /// A one-line description, suitable as the Close frame's reason text.

--- a/crates/monty-types/src/close_cause.rs
+++ b/crates/monty-types/src/close_cause.rs
@@ -23,10 +23,9 @@ pub enum CloseCause {
     TurnTimeout = 4002,
     /// The worker exceeded its memory limit and was terminated.
     OutOfMemory = 4003,
-    /// A request frame exceeded the server's size cap.
-    RequestTooLarge = 4004,
-    /// The server reclaimed the session's capacity.
-    Evicted = 4005,
+    /// The server is shutting down and dropped the session while it sat
+    /// idle, without state: no request of it was run.
+    ServerShutdown = 4004,
 }
 
 impl CloseCause {
@@ -58,8 +57,7 @@ impl CloseCause {
             Self::SessionTimeout => "the session outlived the server's session lifetime limit",
             Self::TurnTimeout => "the request outlived the server's turn timeout",
             Self::OutOfMemory => "the worker exceeded its memory limit and was terminated",
-            Self::RequestTooLarge => "the request frame exceeded the server's size cap",
-            Self::Evicted => "the server reclaimed the session's capacity",
+            Self::ServerShutdown => "the server is shutting down and dropped the idle session",
         }
     }
 }

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -5,6 +5,7 @@ pub const MONTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod args;
 mod builtins;
+mod close_cause;
 mod exceptions;
 mod file_mode;
 pub mod format;
@@ -19,6 +20,7 @@ mod uuid;
 
 pub use crate::{
     builtins::BuiltinsFunctions,
+    close_cause::CloseCause,
     exceptions::{
         CodeLoc, ExcData, ExcType, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject,
         unicode_decode_error_msg,

--- a/crates/monty-types/tests/close_cause.rs
+++ b/crates/monty-types/tests/close_cause.rs
@@ -1,0 +1,66 @@
+//! Tests for `CloseCause`: the close codes are a wire contract, so they are
+//! pinned as literal numbers, and every conversion round-trips.
+
+use monty_types::CloseCause;
+
+// === codes are literal wire constants ===
+
+#[test]
+fn codes_are_pinned() {
+    assert_eq!(CloseCause::IdleTimeout.code(), 4000);
+    assert_eq!(CloseCause::SessionTimeout.code(), 4001);
+    assert_eq!(CloseCause::TurnTimeout.code(), 4002);
+    assert_eq!(CloseCause::OutOfMemory.code(), 4003);
+    assert_eq!(CloseCause::RequestTooLarge.code(), 4004);
+    assert_eq!(CloseCause::Evicted.code(), 4005);
+}
+
+#[test]
+fn all_lists_every_cause_in_code_order() {
+    let codes: Vec<u16> = CloseCause::ALL.iter().map(|cause| cause.code()).collect();
+    assert_eq!(codes, vec![4000, 4001, 4002, 4003, 4004, 4005]);
+}
+
+// === round trips ===
+
+#[test]
+fn every_cause_round_trips_through_its_code() {
+    for cause in CloseCause::ALL {
+        assert_eq!(CloseCause::from_code(cause.code()), Some(cause));
+    }
+}
+
+#[test]
+fn names_are_distinct_snake_case() {
+    let names: Vec<&str> = CloseCause::ALL.iter().map(|cause| cause.name()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "idle_timeout",
+            "session_timeout",
+            "turn_timeout",
+            "out_of_memory",
+            "request_too_large",
+            "evicted"
+        ]
+    );
+}
+
+#[test]
+fn display_is_the_description() {
+    assert_eq!(
+        CloseCause::OutOfMemory.to_string(),
+        "the worker exceeded its memory limit and was terminated"
+    );
+}
+
+// === unknown codes ===
+
+#[test]
+fn unknown_codes_are_none() {
+    // registered codes, and a private-use code a newer server might define
+    assert_eq!(CloseCause::from_code(1000), None);
+    assert_eq!(CloseCause::from_code(1011), None);
+    assert_eq!(CloseCause::from_code(4006), None);
+    assert_eq!(CloseCause::from_code(4999), None);
+}

--- a/crates/monty-types/tests/close_cause.rs
+++ b/crates/monty-types/tests/close_cause.rs
@@ -12,14 +12,13 @@ fn codes_are_pinned() {
     assert_eq!(CloseCause::SessionTimeout.code(), 4001);
     assert_eq!(CloseCause::TurnTimeout.code(), 4002);
     assert_eq!(CloseCause::OutOfMemory.code(), 4003);
-    assert_eq!(CloseCause::RequestTooLarge.code(), 4004);
-    assert_eq!(CloseCause::Evicted.code(), 4005);
+    assert_eq!(CloseCause::ServerShutdown.code(), 4004);
 }
 
 #[test]
 fn variants_are_in_code_order() {
     let codes: Vec<u16> = CloseCause::VARIANTS.iter().map(|cause| cause.code()).collect();
-    assert_eq!(codes, vec![4000, 4001, 4002, 4003, 4004, 4005]);
+    assert_eq!(codes, vec![4000, 4001, 4002, 4003, 4004]);
 }
 
 // === round trips ===
@@ -41,8 +40,7 @@ fn names_are_distinct_snake_case() {
             "session_timeout",
             "turn_timeout",
             "out_of_memory",
-            "request_too_large",
-            "evicted"
+            "server_shutdown"
         ]
     );
 }
@@ -62,6 +60,6 @@ fn unknown_codes_are_none() {
     // registered codes, and a private-use code a newer server might define
     assert_eq!(CloseCause::from_code(1000), None);
     assert_eq!(CloseCause::from_code(1011), None);
-    assert_eq!(CloseCause::from_code(4006), None);
+    assert_eq!(CloseCause::from_code(4005), None);
     assert_eq!(CloseCause::from_code(4999), None);
 }

--- a/crates/monty-types/tests/close_cause.rs
+++ b/crates/monty-types/tests/close_cause.rs
@@ -2,6 +2,7 @@
 //! pinned as literal numbers, and every conversion round-trips.
 
 use monty_types::CloseCause;
+use strum::VariantArray;
 
 // === codes are literal wire constants ===
 
@@ -16,8 +17,8 @@ fn codes_are_pinned() {
 }
 
 #[test]
-fn all_lists_every_cause_in_code_order() {
-    let codes: Vec<u16> = CloseCause::ALL.iter().map(|cause| cause.code()).collect();
+fn variants_are_in_code_order() {
+    let codes: Vec<u16> = CloseCause::VARIANTS.iter().map(|cause| cause.code()).collect();
     assert_eq!(codes, vec![4000, 4001, 4002, 4003, 4004, 4005]);
 }
 
@@ -25,14 +26,14 @@ fn all_lists_every_cause_in_code_order() {
 
 #[test]
 fn every_cause_round_trips_through_its_code() {
-    for cause in CloseCause::ALL {
+    for &cause in CloseCause::VARIANTS {
         assert_eq!(CloseCause::from_code(cause.code()), Some(cause));
     }
 }
 
 #[test]
 fn names_are_distinct_snake_case() {
-    let names: Vec<&str> = CloseCause::ALL.iter().map(|cause| cause.name()).collect();
+    let names: Vec<&str> = CloseCause::VARIANTS.iter().map(|cause| cause.name()).collect();
     assert_eq!(
         names,
         vec![

--- a/docs/limitations/pool-architecture.md
+++ b/docs/limitations/pool-architecture.md
@@ -45,8 +45,13 @@ properties that real CPython does not provide, per the caveat above.
 - **WebSocket sessions are lost in two additional ways.** A connection that
     closes mid-session raises [`MontyDisconnectError`][pydantic_monty.MontyDisconnectError]: the client cannot tell a
     dead remote sandbox from a server-side policy drop (idle/session/turn
-    timeout, over capacity), so the error claims no more than that the
-    connection went away. A server that is shutting down instead answers the
+    timeout, over capacity) on its own, so the error carries what the
+    server put in its WebSocket Close frame: `close_code` and `close_reason`,
+    `None` when the connection dropped without one, and `close_cause` naming the
+    policy when the code is one monty defines (`'idle_timeout'`,
+    `'session_timeout'`, `'turn_timeout'`, `'request_too_large'`, `'evicted'`).
+    A server's memory-limit kill (close code 4003) raises the same
+    session-ending `MemoryError` a local pool does instead. A server that is shutting down instead answers the
     session's next request with [`MontyShutdown`][pydantic_monty.MontyShutdown]. That request did **not** run,
     and its `dump` (when present) restores the session onto a fresh checkout
     via `session.load_session` / `session.load_snapshot`. If the interrupted

--- a/docs/limitations/pool-architecture.md
+++ b/docs/limitations/pool-architecture.md
@@ -49,9 +49,11 @@ properties that real CPython does not provide, per the caveat above.
     server put in its WebSocket Close frame: `close_code` and `close_reason`,
     `None` when the connection dropped without one, and `close_cause` naming the
     policy when the code is one monty defines (`'idle_timeout'`,
-    `'session_timeout'`, `'turn_timeout'`, `'request_too_large'`, `'evicted'`).
-    A server's memory-limit kill (close code 4003) raises the same
-    session-ending `MemoryError` a local pool does instead. A server that is shutting down instead answers the
+    `'session_timeout'`, `'turn_timeout'`).
+    Two codes raise something else: a memory-limit kill (4003) raises the same
+    session-ending `MemoryError` a local pool does, and a server that drained
+    while the session sat idle (4004) raises [`MontyShutdown`][pydantic_monty.MontyShutdown]
+    with no `dump`. A server that is shutting down instead answers the
     session's next request with [`MontyShutdown`][pydantic_monty.MontyShutdown]. That request did **not** run,
     and its `dump` (when present) restores the session onto a fresh checkout
     via `session.load_session` / `session.load_snapshot`. If the interrupted

--- a/docs/limitations/pool-architecture.md
+++ b/docs/limitations/pool-architecture.md
@@ -44,17 +44,19 @@ properties that real CPython does not provide, per the caveat above.
     itself recovers by replacing the worker.
 - **WebSocket sessions are lost in two additional ways.** A connection that
     closes mid-session raises [`MontyDisconnectError`][pydantic_monty.MontyDisconnectError]: the client cannot tell a
-    dead remote sandbox from a server-side policy drop (idle/session/turn
-    timeout, over capacity) on its own, so the error carries what the
-    server put in its WebSocket Close frame: `close_code` and `close_reason`,
-    `None` when the connection dropped without one, and `close_cause` naming the
-    policy when the code is one monty defines (`'idle_timeout'`,
-    `'session_timeout'`, `'turn_timeout'`).
-    Two codes raise something else: a memory-limit kill (4003) raises the same
-    session-ending `MemoryError` a local pool does, and a server that drained
-    while the session sat idle (4004) raises [`MontyShutdown`][pydantic_monty.MontyShutdown]
-    with no `dump`. A server that is shutting down instead answers the
-    session's next request with [`MontyShutdown`][pydantic_monty.MontyShutdown]. That request did **not** run,
+    dead remote sandbox from a server-side policy drop (an idle, session or
+    turn timeout) on its own, so the error carries what the server put in its
+    WebSocket Close frame: `close_code` and `close_reason`, `None` when the
+    connection dropped without one, and `close_cause` naming the policy when
+    the code is one monty defines (`'idle_timeout'`, `'session_timeout'`,
+    `'turn_timeout'`).
+    Two codes raise something else.
+    A memory-limit kill (4003) raises the same session-ending `MemoryError` a
+    local pool does.
+    A server that drained while the session sat idle (4004) raises
+    [`MontyShutdown`][pydantic_monty.MontyShutdown] with no `dump`.
+    A server that is shutting down with a request in flight instead answers
+    that request with [`MontyShutdown`][pydantic_monty.MontyShutdown]. That request did **not** run,
     and its `dump` (when present) restores the session onto a fresh checkout
     via `session.load_session` / `session.load_snapshot`. If the interrupted
     request was answering a suspension (external function or `os` callback),


### PR DESCRIPTION
The pool's reader task discarded a server's Close frame, so a session ended by policy surfaced as a bare disconnect. The frame's code and reason now ride on `PoolError::Disconnected` (and the Python `MontyDisconnectError`), and `CloseCause` in monty-types defines the private-range codes a server uses for each policy drop. An out-of-memory close maps onto the session-ending `MemoryError` the subprocess transport already raises.

Claude-Session: https://claude.ai/code/session_01VgYb8MP7Hs64wMLEXtdM26

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries the WebSocket Close frame through pool disconnects so a session ended by server policy no longer surfaces as a bare disconnect. `PoolError::Disconnected` now carries the frame (breaking its pattern match), and Python `MontyDisconnectError` exposes `close_code`, `close_reason`, and `close_cause`.

**New Features**
- `CloseCause` defines codes 4000–4004 for the five policy drops, and `close_cause` maps them to snake_case names (`idle_timeout`, `session_timeout`, etc.).
- `close_code` and `close_reason` are `None` when the server sent no Close frame; unknown codes yield `close_cause = None`.

**Bug Fixes**
- An out-of-memory close (4003) raises the same session-ending `MemoryError` as a local pool, and a server draining an idle session (4004) raises `MontyShutdown` without a dump.

<sup>Written for commit af9e936c81228230a7612a9644b63c5dd64d10f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

