### PR TITLE
fix telemetry context propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,7 @@ jobs:
           eval "$(cargo llvm-cov show-env --export-prefix)"
           cargo llvm-cov clean --workspace
           uv run maturin develop --uv -m crates/monty-python/Cargo.toml
+          cargo test -p pydantic-monty-client --lib
           uv run --package pydantic-monty-client --only-dev pytest crates/monty-python/tests
           cargo llvm-cov report --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
           cargo llvm-cov report --codecov --output-path=python-rust-coverage.json --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ pytest: ## Run Python tests with pytest
 
 .PHONY: test-py
 test-py: dev-py pytest ## Build the python package (debug profile) and run tests
+	cargo test -p pydantic-monty-client --lib
 
 .PHONY: test-docs
 test-docs: dev-py ## Test docs examples only (docs/, README.md, crates/monty-python/README.md)

--- a/crates/monty-js/__test__/node_callback_context.spec.ts
+++ b/crates/monty-js/__test__/node_callback_context.spec.ts
@@ -1,0 +1,207 @@
+import { execFileSync } from 'node:child_process'
+
+import { test } from 'vitest'
+
+function runChild(source: string): void {
+  execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `
+    import assert from 'node:assert/strict'
+    import { AsyncLocalStorage } from 'node:async_hooks'
+    import { context, trace, propagation } from '@opentelemetry/api'
+    import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+    import { AlwaysOffSampler, BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+    import { Monty, MontyComplete, instrumentTelemetry, flushTelemetry } from ${JSON.stringify(new URL('../dist/node.js', import.meta.url).href)}
+
+    const manager = new AsyncLocalStorageContextManager().enable()
+    context.setGlobalContextManager(manager)
+    const storage = new AsyncLocalStorage()
+    const exporter = new InMemorySpanExporter()
+    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
+    const tracer = provider.getTracer('callbacks')
+    ${source}
+    await flushTelemetry()
+    await provider.shutdown()
+    context.disable()
+    storage.disable()
+  `,
+    ],
+    { stdio: 'pipe', timeout: 30_000 },
+  )
+}
+
+test('concurrent host callbacks inherit their Monty span and caller async storage', () => {
+  runChild(`
+    instrumentTelemetry({ tracer })
+    const pool = await Monty.create({ minProcesses: 2, maxProcesses: 2 })
+    await Promise.all([1, 2].map(index => storage.run(index, () => {
+      const baggage = propagation.createBaggage({ request: { value: String(index) } })
+      return context.with(propagation.setBaggage(context.active(), baggage), () => tracer.startActiveSpan('host ' + index, async host => {
+        const check = () => {
+          assert.equal(storage.getStore(), index)
+          assert.equal(propagation.getBaggage(context.active()).getEntry('request').value, String(index))
+        }
+        const child = name => {
+          check()
+          tracer.startActiveSpan(name + ' ' + index, span => span.end())
+        }
+        try {
+          const session = await pool.checkout({ scriptName: String(index) })
+          assert.equal(await session.feedRun("print('hello'); sync_callback() + await async_callback()", {
+            printCallback() { child('print') },
+            externalLookup: {
+              sync_callback() { child('sync'); return 10 },
+              async async_callback() {
+                check()
+                return tracer.startActiveSpan('async ' + index, async span => {
+                  try {
+                    await new Promise(resolve => setTimeout(resolve, 10))
+                    check()
+                    assert.equal(trace.getSpan(context.active()), span)
+                    return 20
+                  } finally { span.end() }
+                })
+              },
+            },
+          }), 30)
+          assert.equal(await session.feedRun("from pathlib import Path; Path('/x').exists()", {
+            os() { child('os'); return true },
+          }), true)
+          assert.equal(await session.feedRun('lazy_value', {
+            externalLookup: { get lazy_value() { child('lookup'); return 7 } },
+          }), 7)
+          assert.equal(trace.getSpan(context.active()), host)
+          check()
+          await session.close()
+        } finally { host.end() }
+      }))
+    })))
+    await pool.close()
+    await flushTelemetry()
+    assert.equal(storage.getStore(), undefined)
+    assert.equal(trace.getSpan(context.active()), undefined)
+    const spans = exporter.getFinishedSpans()
+    const byId = new Map(spans.map(span => [span.spanContext().spanId, span]))
+    for (const index of [1, 2]) {
+      for (const [kind, expected] of [['print', 'run code'], ['sync', 'call {function_name}'], ['async', 'call {function_name}'], ['os', 'os call {function}'], ['lookup', 'name lookup {name}']]) {
+        const span = spans.find(span => span.name === kind + ' ' + index)
+        assert.ok(span, kind)
+        let parent = byId.get(span.parentSpanContext.spanId)
+        assert.equal(parent.name, expected)
+        while (parent.parentSpanContext) parent = byId.get(parent.parentSpanContext.spanId)
+        assert.equal(parent.name, 'host ' + index)
+      }
+    }
+  `)
+})
+
+test.each(['disabled', 'broken-tracer', 'broken-context', 'sampled-out'])('callback context fallback: %s', (mode) => {
+  runChild(`
+    const mode = ${JSON.stringify(mode)}
+    const offProvider = new BasicTracerProvider({ sampler: new AlwaysOffSampler() })
+    const offTracer = offProvider.getTracer('not-recording')
+    let runSpan
+    if (mode !== 'disabled') instrumentTelemetry({ tracer: {
+      startSpan(name, ...args) {
+        if (mode === 'broken-tracer') throw new Error('tracer failed')
+        const span = (mode === 'sampled-out' ? offTracer : tracer).startSpan(name, ...args)
+        if (name === 'run code') runSpan = span
+        return span
+      },
+    } })
+    await storage.run('caller', () => tracer.startActiveSpan('host', async host => {
+      const originalWith = context.with
+      if (mode === 'broken-context') context.with = () => { throw new Error('context failed') }
+      let count = 0
+      try {
+        const pool = await Monty.create()
+        const session = await pool.checkout()
+        assert.equal(await session.feedRun("print('hello'); 42", { printCallback() {
+          count++
+          assert.equal(storage.getStore(), 'caller')
+          assert.equal(trace.getSpan(context.active()), mode === 'sampled-out' ? runSpan : host)
+          if (mode === 'sampled-out') assert.equal(runSpan.isRecording(), false)
+        } }), 42)
+        assert.equal(count, 1)
+        assert.equal(trace.getSpan(context.active()), host)
+        await session.close()
+        await pool.close()
+      } finally { context.with = originalWith; host.end() }
+    }))
+    await offProvider.shutdown()
+  `)
+})
+
+test('callback failures are not retried and do not leak context', () => {
+  runChild(`
+    instrumentTelemetry({ tracer })
+    await storage.run('caller', () => tracer.startActiveSpan('host', async host => {
+      const pool = await Monty.create()
+      let count = 0
+      try {
+        const session = await pool.checkout()
+        await assert.rejects(session.feedRun("print('hello')", { printCallback() {
+          count++
+          assert.equal(storage.getStore(), 'caller')
+          throw new Error('print failed')
+        } }), /print failed/)
+        assert.equal(trace.getSpan(context.active()), host)
+        await session.close()
+        const second = await pool.checkout()
+        await assert.rejects(second.feedRun('fail()', { externalLookup: { fail() {
+          count++
+          throw new Error('function failed')
+        } } }), /function failed/)
+        assert.equal(trace.getSpan(context.active()), host)
+        await assert.rejects(second.feedRun('await fail()', { externalLookup: { async fail() {
+          count++
+          await Promise.resolve()
+          throw new Error('async failed')
+        } } }), /async failed/)
+        assert.equal(trace.getSpan(context.active()), host)
+        assert.equal(count, 3)
+        await second.close()
+      } finally { await pool.close(); host.end() }
+    }))
+  `)
+})
+
+test('snapshot resumes capture the resuming caller storage and retain the Monty parent', () => {
+  runChild(`
+    instrumentTelemetry({ tracer })
+    const pool = await Monty.create()
+    const session = await pool.checkout()
+    let snapshot = await storage.run('feed', () => session.feedStart("value = await callback(); print(value); value", {
+      externalLookup: { async callback() {
+        assert.equal(storage.getStore(), 'resume')
+        return tracer.startActiveSpan('snapshot callback', async span => {
+          try {
+            await Promise.resolve()
+            assert.equal(storage.getStore(), 'resume')
+            return 42
+          } finally { span.end() }
+        })
+      } },
+      printCallback() {
+        assert.equal(storage.getStore(), 'resume')
+        tracer.startActiveSpan('snapshot print', span => span.end())
+      },
+    }))
+    await storage.run('resume', async () => {
+      while (!(snapshot instanceof MontyComplete)) snapshot = await snapshot.resumeAuto()
+    })
+    assert.equal(snapshot.output, 42)
+    await session.close()
+    await pool.close()
+    await flushTelemetry()
+    const spans = exporter.getFinishedSpans()
+    for (const [name, expected] of [['snapshot callback', 'call {function_name}'], ['snapshot print', 'run code']]) {
+      const span = spans.find(span => span.name === name)
+      const parent = spans.find(parent => parent.spanContext().spanId === span.parentSpanContext.spanId)
+      assert.equal(parent.name, expected)
+    }
+  `)
+})

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -47,6 +47,7 @@ use napi::{
     Env, Error, Result,
 };
 use napi_derive::napi;
+use opentelemetry::{trace::TraceContextExt, Context};
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::{
@@ -71,7 +72,14 @@ type SharedPool = Arc<Mutex<Option<Arc<Pool>>>>;
 type SharedCheckout = Arc<AsyncMutex<Option<Checkout>>>;
 /// The per-turn JS print callback, reached from the turn future through a
 /// threadsafe function.
-type PrintCallback<'env> = Function<'env, FnArgs<(String, String)>, UnknownReturnValue>;
+type PrintCallback<'env> = Function<'env, FnArgs<(String, String, Option<String>)>, UnknownReturnValue>;
+
+fn callback_span_key(context: &Context) -> Option<String> {
+    let span = context.span();
+    let span = span.span_context();
+    span.is_valid()
+        .then(|| format!("{}:{}", span.trace_id(), span.span_id()))
+}
 
 /// The boxed future a turn closure returns: one computation borrowing the
 /// locked checkout and the per-turn print callback.
@@ -734,8 +742,9 @@ impl NativeSession {
             async move {
                 let mut guard = slot.lock().await;
                 let Some(checkout) = guard.as_mut() else {
-                    return Ok(TurnOutcome::Protocol(
-                        "the session is closed — check out a new one".to_owned(),
+                    return Ok((
+                        TurnOutcome::Protocol("the session is closed — check out a new one".to_owned()),
+                        None,
                     ));
                 };
                 // Forward each print to JS and *await the callback having
@@ -750,12 +759,17 @@ impl NativeSession {
                         PrintStream::Stderr => "stderr",
                     };
                     let tsfn = Arc::clone(&tsfn);
-                    let args = FnArgs::from((stream.to_owned(), text.to_owned()));
+                    let args = FnArgs::from((
+                        stream.to_owned(),
+                        text.to_owned(),
+                        callback_span_key(&Context::current()),
+                    ));
                     Box::pin(async move {
                         let _ = tsfn.call_async(args).await;
                     })
                 };
-                Ok(compute(checkout, &mut on_print).await)
+                let outcome = compute(checkout, &mut on_print).await;
+                Ok((outcome, callback_span_key(&checkout.callback_context())))
             },
             turn_to_js,
         )
@@ -829,8 +843,11 @@ impl From<StdResult<TurnEvent, PoolError>> for TurnOutcome {
 /// `ts/session.ts`. All keys are fixed strings; sandbox-controlled data only
 /// ever appears in *values* (kwargs cross as `[key, value]` pairs so the
 /// TypeScript layer can build a null-prototype record safely).
-fn turn_to_js(env: &Env, outcome: TurnOutcome) -> Result<Object<'_>> {
+fn turn_to_js(env: &Env, (outcome, context): (TurnOutcome, Option<String>)) -> Result<Object<'_>> {
     let mut obj = Object::new(env)?;
+    if let Some(context) = context {
+        obj.set("callbackSpanKey", context)?;
+    }
     match outcome {
         TurnOutcome::Event(TurnEvent::Complete(value)) => {
             obj.set("kind", "complete")?;

--- a/crates/monty-js/ts/callbackContext.ts
+++ b/crates/monty-js/ts/callbackContext.ts
@@ -1,0 +1,22 @@
+// Node installs these handlers; browser transports use the direct callback path.
+
+type NativePrintCallback = (stream: 'stdout' | 'stderr', text: string, parent?: string | null) => void
+
+interface CallbackContextHandlers {
+  bindPrint(callback: NativePrintCallback): NativePrintCallback
+  run<T>(parent: string | undefined, callback: () => T): T
+}
+
+let handlers: CallbackContextHandlers | undefined
+
+export function setCallbackContextHandlers(value: CallbackContextHandlers): void {
+  handlers = value
+}
+
+export function bindPrintCallback(callback: NativePrintCallback): NativePrintCallback {
+  return handlers?.bindPrint(callback) ?? callback
+}
+
+export function runWithCallbackContext<T>(parent: string | undefined, callback: () => T): T {
+  return handlers === undefined ? callback() : handlers.run(parent, callback)
+}

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -34,8 +34,13 @@ export interface CompleteTurn {
   value: unknown
 }
 
+interface CallbackTurn {
+  /** Host-generated native span identity, resolved by the telemetry bridge. */
+  callbackSpanKey?: string
+}
+
 /** The sandbox called an external function — answer with a `resume*` call. */
-export interface FunctionCallTurn {
+export interface FunctionCallTurn extends CallbackTurn {
   kind: 'functionCall'
   functionName: string
   /** Positional arguments, already converted to JS values. */
@@ -54,7 +59,7 @@ export interface FunctionCallTurn {
 }
 
 /** The sandbox performed an OS operation no mount handled. */
-export interface OsCallTurn {
+export interface OsCallTurn extends CallbackTurn {
   kind: 'osCall'
   functionName: string
   args: unknown[]
@@ -63,7 +68,7 @@ export interface OsCallTurn {
 }
 
 /** The sandbox read an undefined name — answer with `resumeNameLookup`. */
-export interface NameLookupTurn {
+export interface NameLookupTurn extends CallbackTurn {
   kind: 'nameLookup'
   name: string
   /** Set for lazy attribute lookups on a host-backed object (a class
@@ -74,7 +79,7 @@ export interface NameLookupTurn {
 }
 
 /** Every sandbox task is blocked on external futures. */
-export interface ResolveFuturesTurn {
+export interface ResolveFuturesTurn extends CallbackTurn {
   kind: 'resolveFutures'
   pendingCallIds: number[]
 }

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -10,6 +10,7 @@
 // delivered when the worker reports everything is blocked (`resolveFutures`).
 
 import type { NativeSession } from '../native-addon.js'
+import { bindPrintCallback, runWithCallbackContext } from './callbackContext.js'
 import { AttrNotExposed, attributeErrorMessage, InstanceStore, prepare, restore } from './classInstance.js'
 import {
   MontyCrashedError,
@@ -172,12 +173,15 @@ export class MontySession {
    * Executes one snippet in the worker, driving external function calls
    * (which may return promises), OS callbacks, and print callbacks in this
    * process. Returns the snippet's trailing expression value.
+   *
+   * Node callbacks preserve the caller's async context. With telemetry enabled,
+   * spans created inside callbacks nest under the corresponding Monty operation.
    */
   async feedRun(code: string, options: FeedOptions = {}): Promise<unknown> {
     this.ensureUsable()
     this.driven = true
     const printTarget = new PrintTarget(options.printCallback)
-    const onPrint = printTarget.write.bind(printTarget)
+    const onPrint = bindPrintCallback(printTarget.write.bind(printTarget))
     // A fresh answerer (and its pending-future map) per feed, so promises the
     // worker never asks about again cannot accumulate across feeds.
     const answerer = new TurnAnswerer(this.native, this.instances, options.externalLookup, options.os)
@@ -457,7 +461,14 @@ class TurnAnswerer {
   ) {}
 
   /** Answers one suspension turn and returns the resume turn it produces. */
-  async answer(
+  answer(
+    turn: FunctionCallTurn | OsCallTurn | ResolveFuturesTurn | NameLookupTurn,
+    onPrint: PrintCallback,
+  ): Promise<NativeTurn> {
+    return runWithCallbackContext(turn.callbackSpanKey, () => this.answerInContext(turn, onPrint))
+  }
+
+  private async answerInContext(
     turn: FunctionCallTurn | OsCallTurn | ResolveFuturesTurn | NameLookupTurn,
     onPrint: PrintCallback,
   ): Promise<NativeTurn> {
@@ -763,7 +774,9 @@ class PrintTarget {
  */
 class SnapshotDriver {
   /** Exposed so the session's first turn can stream prints through it. */
-  readonly onPrint: PrintCallback
+  get onPrint(): PrintCallback {
+    return bindPrintCallback(this.printTarget.write.bind(this.printTarget))
+  }
 
   constructor(
     private readonly native: NativeSession,
@@ -773,9 +786,7 @@ class SnapshotDriver {
     private readonly printTarget: PrintTarget,
     private readonly answerer: TurnAnswerer,
     private readonly poison: (err: Error) => Error,
-  ) {
-    this.onPrint = printTarget.write.bind(printTarget)
-  }
+  ) {}
 
   /** Resolves a turn to the next snapshot, answering nothing automatically. */
   async advance(turn: NativeTurn): Promise<Snapshot> {

--- a/crates/monty-js/ts/telemetry.ts
+++ b/crates/monty-js/ts/telemetry.ts
@@ -1,3 +1,5 @@
+import { AsyncResource } from 'node:async_hooks'
+
 import type {
   Attributes,
   Context,
@@ -27,6 +29,7 @@ import {
   _montyVersion as montyVersion,
   _setTelemetryMetricsEnabled as setNativeMetricsEnabled,
 } from '../native-addon.js'
+import { setCallbackContextHandlers } from './callbackContext.js'
 
 const OTEL_SCOPE = '@pydantic/monty'
 const OTEL_VERSION = montyVersion()
@@ -129,6 +132,35 @@ let metricsDisabled = false
 const spans = new Map<string, SpanState>()
 const instruments = new Map<string, MetricHandle>()
 const directOwner = {}
+
+setCallbackContextHandlers({
+  bindPrint(callback) {
+    return AsyncResource.bind((stream, text, parent) =>
+      withCallbackContext(parent ?? undefined, () => callback(stream, text)),
+    )
+  },
+  run: withCallbackContext,
+})
+
+function withCallbackContext<T>(parent: string | undefined, callback: () => T): T {
+  const span = parent === undefined || spansDisabled ? undefined : spans.get(parent)?.span
+  if (span === undefined) {
+    return callback()
+  }
+  let invoked = false
+  try {
+    const context = TraceAPI.setSpan(ContextAPI.active(), span)
+    return ContextAPI.with(context, () => {
+      invoked = true
+      return callback()
+    })
+  } catch (error) {
+    if (invoked) {
+      throw error
+    }
+    return callback()
+  }
+}
 
 /**
  * Instrument Monty with standard OpenTelemetry components.

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -20,6 +20,8 @@ use monty_types::{
     AssertMessageAnnotations, DEFAULT_MAX_SUSPENSIONS, ExcType, MONTY_VERSION, MontyException, MontyObject, MontyUuid,
     NameLookupResult, OsFunctionCall, PrintStream, ResourceLimits, TypeCheckingConfig,
 };
+#[cfg(feature = "telemetry")]
+use opentelemetry::trace::{FutureExt, TraceContextExt};
 use tokio::{task::spawn_blocking, time::timeout};
 
 #[cfg(feature = "telemetry")]
@@ -1214,6 +1216,14 @@ impl Checkout {
         }
     }
 
+    /// The innermost telemetry context for host callbacks answering this checkout.
+    #[cfg(feature = "telemetry")]
+    pub fn callback_context(&self) -> opentelemetry::Context {
+        self.worker
+            .as_ref()
+            .map_or_else(opentelemetry::Context::new, Worker::callback_context)
+    }
+
     /// One request/reply exchange: send the request, stream prints, classify
     /// the turn-ending event. All failure paths discard the worker except
     /// `Runtime` / `Typing`, which are sandbox-level outcomes.
@@ -1267,7 +1277,21 @@ impl Checkout {
                         pb::PrintStream::Stderr => PrintStream::Stderr,
                         pb::PrintStream::Stdout | pb::PrintStream::Unspecified => PrintStream::Stdout,
                     };
-                    on_print(stream, &print.text).await;
+                    #[cfg(feature = "telemetry")]
+                    let context = self.callback_context();
+                    let future = {
+                        #[cfg(feature = "telemetry")]
+                        let _context = context.has_active_span().then(|| context.clone().attach());
+                        on_print(stream, &print.text)
+                    };
+                    #[cfg(feature = "telemetry")]
+                    if context.has_active_span() {
+                        future.with_context(context).await;
+                    } else {
+                        future.await;
+                    }
+                    #[cfg(not(feature = "telemetry"))]
+                    future.await;
                 }
                 Some(pb::child_event::Kind::FunctionCall(call)) => {
                     self.pending = Some(Pending::Call {

--- a/crates/monty-pool/src/telemetry/tracing.rs
+++ b/crates/monty-pool/src/telemetry/tracing.rs
@@ -428,6 +428,10 @@ impl Recorder {
 
     /// The innermost open span, used as the explicit parent for new spans and
     /// records; [`Span::none`] (a root record) when nothing is open.
+    pub(crate) fn callback_context(&self) -> opentelemetry::Context {
+        self.context_span().context()
+    }
+
     fn context_span(&self) -> Span {
         self.turn
             .as_ref()

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -277,6 +277,13 @@ impl Worker {
         })
     }
 
+    #[cfg(feature = "telemetry")]
+    pub(crate) fn callback_context(&self) -> opentelemetry::Context {
+        self.recorder
+            .as_ref()
+            .map_or_else(opentelemetry::Context::new, |recorder| recorder.callback_context())
+    }
+
     /// Sends one request, flushed to the wire — the protocol is strict
     /// alternation, so an unflushed frame would deadlock both sides. An
     /// oversize frame is rejected *before* any I/O so the stream stays synced

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -958,6 +958,11 @@ class AsyncMontySession:
         entries in `external_lookup`) may be coroutines, awaited concurrently.
         See `MontySession.feed_run` for the shared error types.
 
+        Host callbacks run in copies of the caller's Python context. With tracing
+        enabled, telemetry emitted inside callbacks is parented to the corresponding
+        Monty operation: the execution span for prints, or the host-call span for
+        external functions. Async external functions retain that context across awaits.
+
         Arguments:
             code: The Python snippet to execute; its trailing expression value
                 (if any) is converted to a Python object and returned.

--- a/crates/monty-python/src/async_dispatch.rs
+++ b/crates/monty-python/src/async_dispatch.rs
@@ -8,7 +8,7 @@
 use monty_proto::python::InstanceStore;
 use monty_types::{ExtFunctionResult, MontyObject, MontyUuid};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
-use pyo3_async_runtimes::tokio::into_future;
+use pyo3_async_runtimes::{into_future_with_locals, tokio::get_current_locals};
 use tokio::task::{JoinError, JoinSet};
 
 use crate::external::{
@@ -46,7 +46,10 @@ pub(crate) fn spawn_coroutine_task(
     instances: &InstanceStore,
 ) -> PyResult<()> {
     let instances = Python::attach(|py| instances.clone_ref(py));
-    let future = Python::attach(|py| into_future(coro.into_bound(py)))?;
+    let future = Python::attach(|py| {
+        let locals = get_current_locals(py)?.copy_context(py)?;
+        into_future_with_locals(&locals, coro.into_bound(py))
+    })?;
 
     join_set.spawn(async move {
         match future.await {

--- a/crates/monty-python/src/callback_context.rs
+++ b/crates/monty-python/src/callback_context.rs
@@ -1,0 +1,57 @@
+//! Python context restoration at host callback boundaries.
+
+// PyO3 does not yet expose safe wrappers for entering and exiting contextvars contexts.
+#![allow(unsafe_code)]
+
+use pyo3::{ffi, prelude::*};
+
+use crate::telemetry;
+
+#[derive(Debug)]
+pub(crate) struct CallbackContext(Py<PyAny>);
+
+impl CallbackContext {
+    pub(crate) fn capture(py: Python<'_>) -> PyResult<Self> {
+        // SAFETY: Python is attached; the API returns a new owned context reference.
+        unsafe { Bound::from_owned_ptr_or_err(py, ffi::PyContext_CopyCurrent()) }.map(|context| Self(context.unbind()))
+    }
+
+    pub(crate) fn enter<'py>(&self, py: Python<'py>, native: &opentelemetry::Context) -> PyResult<CallbackGuard<'py>> {
+        // Each invocation gets its own copy: callbacks may re-enter Monty or run concurrently.
+        // SAFETY: self.0 is a context created by PyContext_CopyCurrent, and Python is attached.
+        let context = unsafe { Bound::from_owned_ptr_or_err(py, ffi::PyContext_Copy(self.0.as_ptr())) }?;
+        // SAFETY: context is a fresh Python context and cannot already be entered.
+        if unsafe { ffi::PyContext_Enter(context.as_ptr()) } != 0 {
+            return Err(PyErr::fetch(py));
+        }
+        let mut guard = CallbackGuard { context, otel: None };
+        if let Some(parent) = telemetry::callback_context(py, native) {
+            // Telemetry failure must not prevent execution of the user's callback.
+            guard.otel = (|| {
+                let module = py.import("opentelemetry.context")?;
+                let token = module.call_method1("attach", (parent,))?;
+                Ok::<_, PyErr>((module.getattr("detach")?.unbind(), token.unbind()))
+            })()
+            .ok();
+        }
+        Ok(guard)
+    }
+}
+
+pub(crate) struct CallbackGuard<'py> {
+    context: Bound<'py, PyAny>,
+    otel: Option<(Py<PyAny>, Py<PyAny>)>,
+}
+
+impl Drop for CallbackGuard<'_> {
+    fn drop(&mut self) {
+        let py = self.context.py();
+        if let Some((detach, token)) = &self.otel {
+            let _ = detach.bind(py).call1((token,));
+        }
+        // SAFETY: this guard exits the context it entered on this thread, while Python is attached.
+        if unsafe { ffi::PyContext_Exit(self.context.as_ptr()) } != 0 {
+            PyErr::fetch(py).write_unraisable(py, Some(&self.context));
+        }
+    }
+}

--- a/crates/monty-python/src/callback_context.rs
+++ b/crates/monty-python/src/callback_context.rs
@@ -3,9 +3,43 @@
 // PyO3 does not yet expose safe wrappers for entering and exiting contextvars contexts.
 #![allow(unsafe_code)]
 
-use pyo3::{ffi, prelude::*};
+use pyo3::{ffi, prelude::*, types::PyDict};
 
 use crate::telemetry;
+
+pub(crate) const CALLBACK_SPAN_KEY: &str = "pydantic_monty.callback_span";
+
+/// Runs before callback exceptions are converted into sandbox exception values.
+pub(crate) fn call<T>(py: Python<'_>, callback: impl FnOnce() -> PyResult<T>) -> PyResult<T> {
+    let manager = (|| {
+        // An ambient caller span is not a substitute when Monty tracing is disabled.
+        let span = py
+            .import("opentelemetry.context")?
+            .call_method1("get_value", (CALLBACK_SPAN_KEY,))?;
+        if span.is_none() {
+            return Ok(None);
+        }
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("end_on_exit", false)?;
+        let manager = py
+            .import("opentelemetry.trace")?
+            .call_method("use_span", (span,), Some(&kwargs))?;
+        manager.call_method0("__enter__")?;
+        Ok::<_, PyErr>(Some(manager))
+    })()
+    .ok()
+    .flatten();
+
+    let result = callback();
+    if let Some(manager) = manager {
+        // Telemetry must neither replace the callback result nor cause it to be retried.
+        let _ = match &result {
+            Ok(_) => manager.call_method1("__exit__", (py.None(), py.None(), py.None())),
+            Err(err) => manager.call_method1("__exit__", (err.get_type(py), err.value(py), err.traceback(py))),
+        };
+    }
+    result
+}
 
 #[derive(Debug)]
 pub(crate) struct CallbackContext(Py<PyAny>);

--- a/crates/monty-python/src/callback_context.rs
+++ b/crates/monty-python/src/callback_context.rs
@@ -59,7 +59,15 @@ impl CallbackContext {
             return Err(PyErr::fetch(py));
         }
         let mut guard = CallbackGuard { context, otel: None };
-        if let Some(parent) = telemetry::callback_context(py, native) {
+        let parent = telemetry::callback_context(py, native).or_else(|| {
+            // Preserve caller context, but do not inherit an outer callback's private span selection.
+            py.import("opentelemetry.context")
+                .ok()?
+                .call_method1("set_value", (CALLBACK_SPAN_KEY, py.None()))
+                .ok()
+                .map(Bound::unbind)
+        });
+        if let Some(parent) = parent {
             // Telemetry failure must not prevent execution of the user's callback.
             guard.otel = (|| {
                 let module = py.import("opentelemetry.context")?;

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -18,7 +18,7 @@ use pyo3::{
     types::{PyDict, PyTuple},
 };
 
-use crate::exceptions::MontyConversionError;
+use crate::{callback_context, exceptions::MontyConversionError};
 
 /// Dispatches a host-routed call — a method on a host class instance, or on
 /// a host class type (a classmethod, or construction spelled `__call__`) —
@@ -64,9 +64,10 @@ fn call_object_method_raw<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     validate_host_method_name(function_name)?;
     let (py_args_tuple, py_kwargs) = wire_call_arguments(py, args, kwargs, instances)?;
-    instances
-        .call_method(py, object_id, function_name, &py_args_tuple, &py_kwargs)
-        .map(|obj| obj.into_bound(py))
+    callback_context::call(py, || {
+        instances.call_method(py, object_id, function_name, &py_args_tuple, &py_kwargs)
+    })
+    .map(|obj| obj.into_bound(py))
 }
 
 /// Converts wire args/kwargs into the Python tuple/dict a host call needs.
@@ -105,7 +106,7 @@ pub fn resolve_object_attr(
         // from a (possibly compromised) child are untrusted.
         NameLookupResult::Undefined
     } else {
-        match instances.lookup_lazy_attr(py, object_id, name) {
+        match callback_context::call(py, || instances.lookup_lazy_attr(py, object_id, name)) {
             Ok(Some(value)) => match py_to_monty_value(value.bind(py), instances) {
                 Ok(obj) => NameLookupResult::Value(obj),
                 Err(exc) => NameLookupResult::Error(exc),
@@ -202,7 +203,7 @@ impl<'a, 'py> ExternalLookup<'a, 'py> {
             return Ok(None);
         };
         let (py_args_tuple, py_kwargs) = wire_call_arguments(self.py, args, kwargs, self.instances)?;
-        let result = callable.call(&py_args_tuple, Some(&py_kwargs))?;
+        let result = callback_context::call(self.py, || callable.call(&py_args_tuple, Some(&py_kwargs)))?;
         py_to_monty(&result, self.instances, 0).map(Some)
     }
 
@@ -239,7 +240,7 @@ impl<'a, 'py> ExternalLookup<'a, 'py> {
             return Ok(None);
         };
         let (py_args_tuple, py_kwargs) = wire_call_arguments(self.py, args, kwargs, self.instances)?;
-        callable.call(&py_args_tuple, Some(&py_kwargs)).map(Some)
+        callback_context::call(self.py, || callable.call(&py_args_tuple, Some(&py_kwargs))).map(Some)
     }
 }
 

--- a/crates/monty-python/src/lib.rs
+++ b/crates/monty-python/src/lib.rs
@@ -11,6 +11,7 @@
 
 mod async_dispatch;
 mod build;
+mod callback_context;
 pub mod exceptions;
 mod external;
 mod limits;

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -64,7 +64,7 @@ use tokio::{
 use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
     build::{extract_connect_headers, extract_repl_inputs, extract_source_code, extract_type_check_stubs},
-    callback_context::CallbackContext,
+    callback_context::{self, CallbackContext},
     exceptions::{MontyCrashedError, MontyDisconnectError, MontyError, MontyShutdown, MontyTypingError},
     external::{CallResult, ExternalLookup, dispatch_object_call, resolve_object_attr},
     get_not_handled,
@@ -1808,7 +1808,7 @@ pub(crate) fn dispatch_os_parts(
         for (k, v) in kwargs {
             py_kwargs.set_item(monty_to_py(py, k, instances)?, monty_to_py(py, v, instances)?)?;
         }
-        let result = os_callback.bind(py).call1((function_name, py_args, py_kwargs))?;
+        let result = callback_context::call(py, || os_callback.bind(py).call1((function_name, py_args, py_kwargs)))?;
         if result.is(get_not_handled(py)?.bind(py)) {
             return Ok(ResumeValue::NotHandled);
         }

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -64,6 +64,7 @@ use tokio::{
 use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
     build::{extract_connect_headers, extract_repl_inputs, extract_source_code, extract_type_check_stubs},
+    callback_context::CallbackContext,
     exceptions::{MontyCrashedError, MontyDisconnectError, MontyError, MontyShutdown, MontyTypingError},
     external::{CallResult, ExternalLookup, dispatch_object_call, resolve_object_attr},
     get_not_handled,
@@ -1233,6 +1234,7 @@ async fn install_deps_checkout(checkout: &SharedCheckout, requirements: Vec<Stri
 /// Everything a feed needs, extracted from Python arguments up front so the
 /// sync and async drive loops share one validation path.
 pub(crate) struct FeedArgs {
+    pub(crate) callback_context: CallbackContext,
     pub(crate) code: String,
     pub(crate) inputs: Vec<(String, MontyObject)>,
     pub(crate) mounts: Vec<MountSpec>,
@@ -1258,6 +1260,7 @@ impl FeedArgs {
     ) -> PyResult<Self> {
         check_callable(py, os.as_ref())?;
         Ok(Self {
+            callback_context: CallbackContext::capture(py)?,
             code: extract_source_code(py, code)?,
             inputs: extract_repl_inputs(inputs, instances)?,
             mounts: extract_mount_specs(mount)?,
@@ -1278,6 +1281,7 @@ impl FeedArgs {
 /// released) via `block_on`; callbacks run between turns with the GIL held.
 fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_, PyDict>>) -> PyResult<Py<PyAny>> {
     let FeedArgs {
+        callback_context,
         code,
         inputs,
         mounts,
@@ -1298,6 +1302,17 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
     loop {
         // `Complete` ends the loop; on any other event a failure to compute the
         // answer discards the checkout (see `sync_turn_answer`).
+        let native = py.detach(|| {
+            block_on_sync(async {
+                checkout
+                    .lock()
+                    .await
+                    .as_ref()
+                    .map(monty_pool::Checkout::callback_context)
+                    .unwrap_or_default()
+            })
+        })?;
+        let callback_guard = callback_context.enter(py, &native)?;
         let resume_with = match event {
             TurnEvent::Complete(value) => return monty_to_py(py, &value, &instances),
             // This feed's mounts get first refusal on every OS call; only what
@@ -1337,6 +1352,7 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
                 }
             },
         };
+        drop(callback_guard);
         event = run_turn_sync(
             py,
             &checkout,
@@ -1459,6 +1475,7 @@ async fn drive_async_inner(
     started: Arc<AtomicBool>,
 ) -> PyResult<Py<PyAny>> {
     let FeedArgs {
+        callback_context,
         code,
         inputs,
         mounts,
@@ -1488,6 +1505,12 @@ async fn drive_async_inner(
         // futures `ResolveFutures` awaits erroring) discards the checkout.
         // `Complete` and `ResolveFutures` stay inline — the latter must await
         // the pending tasks.
+        let native = checkout
+            .lock()
+            .await
+            .as_ref()
+            .map(monty_pool::Checkout::callback_context)
+            .unwrap_or_default();
         let answer: TurnAnswer = match event {
             TurnEvent::Complete(value) => {
                 return Python::attach(|py| monty_to_py(py, &value, &instances));
@@ -1531,11 +1554,23 @@ async fn drive_async_inner(
                     event = next;
                     continue;
                 }
-                let value =
-                    Python::attach(|py| dispatch_os_parts(py, &function_name, &args, &kwargs, os.as_ref(), &instances));
+                let value = Python::attach(|py| {
+                    let _guard = callback_context.enter(py, &native)?;
+                    Ok::<_, PyErr>(dispatch_os_parts(
+                        py,
+                        &function_name,
+                        &args,
+                        &kwargs,
+                        os.as_ref(),
+                        &instances,
+                    ))
+                })?;
                 TurnAnswer::Call(value)
             }
-            event => match async_turn_answer(event, external_lookup.as_ref(), &instances, &mut join_set) {
+            event => match Python::attach(|py| {
+                let _guard = callback_context.enter(py, &native)?;
+                async_turn_answer(event, external_lookup.as_ref(), &instances, &mut join_set)
+            }) {
                 Ok(answer) => answer,
                 Err(err) => {
                     discard_checkout(&checkout).await;

--- a/crates/monty-python/src/print_target.rs
+++ b/crates/monty-python/src/print_target.rs
@@ -31,6 +31,8 @@ use pyo3::{
     types::{PyList, PyString},
 };
 
+use crate::callback_context::CallbackContext;
+
 /// Host bytes charged per retained `(stream, text)` entry beyond the payload.
 ///
 /// `String` / `Vec` bookkeeping is not free: many tiny prints can exhaust the
@@ -195,7 +197,7 @@ pub(crate) enum PrintTarget {
     #[default]
     Stdout,
     /// Each fragment is forwarded to a Python callable as `(stream_name, text)`.
-    Callback(Py<PyAny>),
+    Callback(Py<PyAny>, Arc<CallbackContext>),
     /// Each fragment accumulates into a shared buffer of `(stream, text)`
     /// tuples, surfaced as `list[tuple[str, str]]` in Python.
     CollectStreams(CollectStreamsBuffer),
@@ -219,7 +221,10 @@ impl PrintTarget {
         } else if let Ok(collector) = obj.extract::<PyRef<'_, PyCollectString>>() {
             Ok(Self::CollectString(collector.buffer()))
         } else if obj.is_callable() {
-            Ok(Self::Callback(obj.clone().unbind()))
+            Ok(Self::Callback(
+                obj.clone().unbind(),
+                Arc::new(CallbackContext::capture(obj.py())?),
+            ))
         } else {
             Err(PyTypeError::new_err(
                 "print_callback must be a callable, CollectStreams(), CollectString(), or None",
@@ -236,10 +241,17 @@ impl PrintTarget {
     pub fn clone_handle(&self, py: Python<'_>) -> Self {
         match self {
             Self::Stdout => Self::Stdout,
-            Self::Callback(cb) => Self::Callback(cb.clone_ref(py)),
+            Self::Callback(cb, context) => Self::Callback(cb.clone_ref(py), Arc::clone(context)),
             Self::CollectStreams(arc) => Self::CollectStreams(arc.clone()),
             Self::CollectString(arc) => Self::CollectString(arc.clone()),
         }
+    }
+
+    pub(crate) fn capture_context(&mut self, py: Python<'_>) -> PyResult<()> {
+        if let Self::Callback(_, context) = self {
+            *context = Arc::new(CallbackContext::capture(py)?);
+        }
+        Ok(())
     }
 
     /// Delivers one already-formatted output fragment to this target.
@@ -262,7 +274,8 @@ impl PrintTarget {
                 }
                 Ok(())
             }
-            Self::Callback(cb) => Python::attach(|py| {
+            Self::Callback(cb, context) => Python::attach(|py| {
+                let _guard = context.enter(py, &opentelemetry::Context::current())?;
                 let stream_name = match stream {
                     PrintStream::Stdout => "stdout",
                     PrintStream::Stderr => "stderr",

--- a/crates/monty-python/src/print_target.rs
+++ b/crates/monty-python/src/print_target.rs
@@ -31,7 +31,7 @@ use pyo3::{
     types::{PyList, PyString},
 };
 
-use crate::callback_context::CallbackContext;
+use crate::callback_context::{self, CallbackContext};
 
 /// Host bytes charged per retained `(stream, text)` entry beyond the payload.
 ///
@@ -280,7 +280,7 @@ impl PrintTarget {
                     PrintStream::Stdout => "stdout",
                     PrintStream::Stderr => "stderr",
                 };
-                cb.bind(py).call1((stream_name, text))?;
+                callback_context::call(py, || cb.bind(py).call1((stream_name, text)))?;
                 Ok::<_, PyErr>(())
             })
             .map_err(|e| Python::attach(|py| exc_py_to_monty(py, &e))),

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -45,6 +45,9 @@ use pyo3::{
 use pyo3_async_runtimes::tokio::future_into_py;
 use tokio::{sync::Mutex, task::JoinSet};
 
+#[cfg(test)]
+mod tests;
+
 use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
     callback_context::CallbackContext,
@@ -359,12 +362,25 @@ impl SnapshotState {
     /// Claims the single resume for this snapshot, returning a fresh
     /// [`DriveContext`] for the continuation. Errors if already resumed.
     fn claim(&self, py: Python<'_>) -> PyResult<DriveContext> {
+        self.claim_with(py, |_| Ok(())).map(|(ctx, ())| ctx)
+    }
+
+    fn claim_with<T>(
+        &self,
+        py: Python<'_>,
+        prepare: impl FnOnce(&DriveContext) -> PyResult<T>,
+    ) -> PyResult<(DriveContext, T)> {
+        if self.resumed.load(Ordering::SeqCst) {
+            return Err(PyRuntimeError::new_err("snapshot has already been resumed"));
+        }
+        let mut ctx = self.ctx.clone_ref(py);
+        ctx.print_target.capture_context(py)?;
+        let prepared = prepare(&ctx)?;
+        // Preparation can release Python or re-enter it, so another caller may have claimed meanwhile.
         if self.resumed.swap(true, Ordering::SeqCst) {
             Err(PyRuntimeError::new_err("snapshot has already been resumed"))
         } else {
-            let mut ctx = self.ctx.clone_ref(py);
-            ctx.print_target.capture_context(py)?;
-            Ok(ctx)
+            Ok((ctx, prepared))
         }
     }
 
@@ -616,20 +632,21 @@ impl PyFunctionSnapshot {
     /// matching `feed_run`. A coroutine external raises `RuntimeError` (async
     /// externals need `AsyncMonty`). Consumes the snapshot.
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let ctx = self.0.snapshot.claim(py)?;
-        let call = &self.0.call;
-        let native = py.detach(|| {
-            block_on_sync(async {
-                ctx.checkout
-                    .lock()
-                    .await
-                    .as_ref()
-                    .map(Checkout::callback_context)
-                    .unwrap_or_default()
-            })
-        })?;
         let context = CallbackContext::capture(py)?;
-        let guard = context.enter(py, &native)?;
+        let (ctx, guard) = self.0.snapshot.claim_with(py, |ctx| {
+            let native = py.detach(|| {
+                block_on_sync(async {
+                    ctx.checkout
+                        .lock()
+                        .await
+                        .as_ref()
+                        .map(Checkout::callback_context)
+                        .unwrap_or_default()
+                })
+            })?;
+            context.enter(py, &native)
+        })?;
+        let call = &self.0.call;
         let value = if call.is_os_function {
             if let Some(event) = try_mounts_sync(py, &ctx)? {
                 return build_snapshot(py, ctx, event, false);
@@ -741,10 +758,10 @@ impl PyAsyncFunctionSnapshot {
     /// pending future — so other sandbox tasks keep running — to be settled
     /// later by an [`PyAsyncFutureSnapshot::resume_auto`].
     fn resume_auto<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let context = CallbackContext::capture(py)?;
         let ctx = self.0.snapshot.claim(py)?;
         // owned copy: the snapshot is borrowed only for this synchronous prologue
         let call = self.0.call.clone();
-        let context = CallbackContext::capture(py)?;
         future_into_py(py, async move {
             let native = ctx
                 .checkout
@@ -909,19 +926,20 @@ impl PyNameLookupSnapshot {
     /// host error serving a lazy attribute is raised in the sandbox instead.
     /// Consumes the snapshot.
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let ctx = self.0.snapshot.claim(py)?;
-        let native = py.detach(|| {
-            block_on_sync(async {
-                ctx.checkout
-                    .lock()
-                    .await
-                    .as_ref()
-                    .map(Checkout::callback_context)
-                    .unwrap_or_default()
-            })
-        })?;
         let context = CallbackContext::capture(py)?;
-        let guard = context.enter(py, &native)?;
+        let (ctx, guard) = self.0.snapshot.claim_with(py, |ctx| {
+            let native = py.detach(|| {
+                block_on_sync(async {
+                    ctx.checkout
+                        .lock()
+                        .await
+                        .as_ref()
+                        .map(Checkout::callback_context)
+                        .unwrap_or_default()
+                })
+            })?;
+            context.enter(py, &native)
+        })?;
         let value = match resolve_captured_name(py, &ctx, &self.0.name, self.0.object_id) {
             Ok(value) => value,
             Err(err) => {
@@ -976,10 +994,10 @@ impl PyAsyncNameLookupSnapshot {
 
     /// Async sibling of [`PyNameLookupSnapshot::resume_auto`].
     fn resume_auto<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let context = CallbackContext::capture(py)?;
         let ctx = self.0.snapshot.claim(py)?;
         let name = self.0.name.clone();
         let object_id = self.0.object_id;
-        let context = CallbackContext::capture(py)?;
         future_into_py(py, async move {
             let native = ctx
                 .checkout

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -47,6 +47,7 @@ use tokio::{sync::Mutex, task::JoinSet};
 
 use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
+    callback_context::CallbackContext,
     exceptions::MontyError,
     external::{CallResult, ExternalLookup, resolve_object_attr, wire_call_arguments},
     pool::{
@@ -143,6 +144,7 @@ pub(crate) fn feed_start_sync(
         print_target,
         checkout,
         instances,
+        callback_context: _,
     } = args;
     let ctx = DriveContext::new(checkout, instances, print_target, script_name, external_lookup, os);
     drive_sync(
@@ -170,6 +172,7 @@ pub(crate) fn feed_start_async(
         print_target,
         checkout,
         instances,
+        callback_context: _,
     } = args;
     let ctx = DriveContext::new(checkout, instances, print_target, script_name, external_lookup, os);
     future_into_py(py, async move {
@@ -359,7 +362,9 @@ impl SnapshotState {
         if self.resumed.swap(true, Ordering::SeqCst) {
             Err(PyRuntimeError::new_err("snapshot has already been resumed"))
         } else {
-            Ok(self.ctx.clone_ref(py))
+            let mut ctx = self.ctx.clone_ref(py);
+            ctx.print_target.capture_context(py)?;
+            Ok(ctx)
         }
     }
 
@@ -613,6 +618,18 @@ impl PyFunctionSnapshot {
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let ctx = self.0.snapshot.claim(py)?;
         let call = &self.0.call;
+        let native = py.detach(|| {
+            block_on_sync(async {
+                ctx.checkout
+                    .lock()
+                    .await
+                    .as_ref()
+                    .map(Checkout::callback_context)
+                    .unwrap_or_default()
+            })
+        })?;
+        let context = CallbackContext::capture(py)?;
+        let guard = context.enter(py, &native)?;
         let value = if call.is_os_function {
             if let Some(event) = try_mounts_sync(py, &ctx)? {
                 return build_snapshot(py, ctx, event, false);
@@ -645,6 +662,7 @@ impl PyFunctionSnapshot {
                 }
             }
         };
+        drop(guard);
         drive_sync(py, ctx, turn_fn(move |c, p| Box::pin(c.resume(value, p))))
     }
 
@@ -726,7 +744,15 @@ impl PyAsyncFunctionSnapshot {
         let ctx = self.0.snapshot.claim(py)?;
         // owned copy: the snapshot is borrowed only for this synchronous prologue
         let call = self.0.call.clone();
+        let context = CallbackContext::capture(py)?;
         future_into_py(py, async move {
+            let native = ctx
+                .checkout
+                .lock()
+                .await
+                .as_ref()
+                .map(Checkout::callback_context)
+                .unwrap_or_default();
             // Dispatch inside the future: a coroutine's `into_future` needs the
             // asyncio task-locals that `future_into_py`'s scope establishes.
             let answer: PyResult<ResumeValue> = if call.is_os_function {
@@ -739,33 +765,37 @@ impl PyAsyncFunctionSnapshot {
                 .await?
                 {
                     Some(event) => return Python::attach(|py| build_snapshot(py, ctx, event, true)),
-                    None => Ok(Python::attach(|py| {
-                        dispatch_os_parts(
+                    None => Python::attach(|py| {
+                        let _guard = context.enter(py, &native)?;
+                        Ok(dispatch_os_parts(
                             py,
                             &call.function_name,
                             &call.args,
                             &call.kwargs,
                             ctx.os.as_ref(),
                             &ctx.instances,
-                        )
-                    })),
+                        ))
+                    }),
                 }
             } else {
-                match dispatch_function_call(
-                    &call.function_name,
-                    call.object_id,
-                    &call.args,
-                    &call.kwargs,
-                    ctx.external_lookup.as_ref(),
-                    &ctx.instances,
-                ) {
-                    CallResult::Sync(result) => Ok(ext_result_to_resume(result)),
-                    CallResult::Coroutine(coro) => {
-                        let mut join_set = ctx.pending_futures.lock().await;
-                        spawn_coroutine_task(&mut join_set, call.call_id, coro, &ctx.instances)
-                            .map(|()| ResumeValue::Future)
+                let mut join_set = ctx.pending_futures.lock().await;
+                Python::attach(|py| {
+                    let _guard = context.enter(py, &native)?;
+                    match dispatch_function_call(
+                        &call.function_name,
+                        call.object_id,
+                        &call.args,
+                        &call.kwargs,
+                        ctx.external_lookup.as_ref(),
+                        &ctx.instances,
+                    ) {
+                        CallResult::Sync(result) => Ok(ext_result_to_resume(result)),
+                        CallResult::Coroutine(coro) => {
+                            spawn_coroutine_task(&mut join_set, call.call_id, coro, &ctx.instances)
+                                .map(|()| ResumeValue::Future)
+                        }
                     }
-                }
+                })
             };
             let value = match answer {
                 Ok(value) => value,
@@ -880,6 +910,18 @@ impl PyNameLookupSnapshot {
     /// Consumes the snapshot.
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let ctx = self.0.snapshot.claim(py)?;
+        let native = py.detach(|| {
+            block_on_sync(async {
+                ctx.checkout
+                    .lock()
+                    .await
+                    .as_ref()
+                    .map(Checkout::callback_context)
+                    .unwrap_or_default()
+            })
+        })?;
+        let context = CallbackContext::capture(py)?;
+        let guard = context.enter(py, &native)?;
         let value = match resolve_captured_name(py, &ctx, &self.0.name, self.0.object_id) {
             Ok(value) => value,
             Err(err) => {
@@ -887,6 +929,7 @@ impl PyNameLookupSnapshot {
                 return Err(err);
             }
         };
+        drop(guard);
         drive_sync(py, ctx, turn_fn(move |c, p| Box::pin(c.resume_name_lookup(value, p))))
     }
 
@@ -936,8 +979,19 @@ impl PyAsyncNameLookupSnapshot {
         let ctx = self.0.snapshot.claim(py)?;
         let name = self.0.name.clone();
         let object_id = self.0.object_id;
+        let context = CallbackContext::capture(py)?;
         future_into_py(py, async move {
-            let value = match Python::attach(|py| resolve_captured_name(py, &ctx, &name, object_id)) {
+            let native = ctx
+                .checkout
+                .lock()
+                .await
+                .as_ref()
+                .map(Checkout::callback_context)
+                .unwrap_or_default();
+            let value = match Python::attach(|py| {
+                let _guard = context.enter(py, &native)?;
+                resolve_captured_name(py, &ctx, &name, object_id)
+            }) {
                 Ok(value) => value,
                 Err(err) => {
                     discard_checkout(&ctx.checkout).await;

--- a/crates/monty-python/src/snapshot/tests.rs
+++ b/crates/monty-python/src/snapshot/tests.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use monty_proto::python::InstanceStore;
+use pyo3::{exceptions::PyMemoryError, prelude::*};
+use tokio::sync::Mutex;
+
+use super::{DriveContext, SnapshotState};
+use crate::print_target::PrintTarget;
+
+fn snapshot(py: Python<'_>) -> SnapshotState {
+    let callback = py.eval(c"lambda stream, text: None", None, None).unwrap();
+    SnapshotState::new(DriveContext::new(
+        Arc::new(Mutex::new(None)),
+        InstanceStore::new(py),
+        PrintTarget::from_py(Some(&callback)).unwrap(),
+        "test.py".to_owned(),
+        None,
+        None,
+    ))
+}
+
+#[test]
+fn failed_claim_preparation_is_retryable() {
+    Python::initialize();
+    Python::attach(|py| {
+        let snapshot = snapshot(py);
+        let error = snapshot
+            .claim_with::<()>(py, |_| Err(PyMemoryError::new_err("context allocation failed")))
+            .err()
+            .expect("preparation must fail");
+        assert!(error.is_instance_of::<PyMemoryError>(py));
+        assert!(snapshot.claim(py).is_ok());
+        assert!(snapshot.claim(py).is_err());
+    });
+}
+
+#[test]
+fn reentrant_claim_wins_over_pending_preparation() {
+    Python::initialize();
+    Python::attach(|py| {
+        let snapshot = snapshot(py);
+        let error = snapshot
+            .claim_with(py, |_| snapshot.claim(py).map(|_| ()))
+            .err()
+            .expect("the inner claim consumed the snapshot");
+        assert_eq!(error.to_string(), "RuntimeError: snapshot has already been resumed");
+        assert!(snapshot.claim(py).is_err());
+    });
+}

--- a/crates/monty-python/src/telemetry.rs
+++ b/crates/monty-python/src/telemetry.rs
@@ -26,6 +26,8 @@ use pyo3::{
     types::{PyBytes, PyDict, PyList},
 };
 
+use crate::callback_context::CALLBACK_SPAN_KEY;
+
 /// Installed bridge and process-global Rust tracing pipeline.
 struct InstalledBridge {
     bridge: Arc<PythonBridge>,
@@ -138,11 +140,10 @@ pub(crate) fn callback_context(py: Python<'_>, context: &Context) -> Option<Py<P
         span_id: span.span_id(),
     };
     let span = lock(&bridge.spans).get(&key).map(|state| state.span.clone_ref(py))?;
-    bridge
-        .helpers
-        .set_span_in_context
-        .bind(py)
-        .call1((span,))
+    let parent = bridge.helpers.set_span_in_context.bind(py).call1((&span,)).ok()?;
+    py.import("opentelemetry.context")
+        .ok()?
+        .call_method1("set_value", (CALLBACK_SPAN_KEY, span, parent))
         .ok()
         .map(Bound::unbind)
 }

--- a/crates/monty-python/src/telemetry.rs
+++ b/crates/monty-python/src/telemetry.rs
@@ -128,6 +128,25 @@ pub(crate) fn _install_telemetry(
         .map_err(|_| PyRuntimeError::new_err("Monty telemetry is already configured"))
 }
 
+/// Resolves a native callback parent to the span created by the host tracer.
+pub(crate) fn callback_context(py: Python<'_>, context: &Context) -> Option<Py<PyAny>> {
+    let bridge = &BRIDGE.get()?.bridge;
+    let span = context.span();
+    let span = span.span_context();
+    let key = SpanKey {
+        trace_id: span.trace_id(),
+        span_id: span.span_id(),
+    };
+    let span = lock(&bridge.spans).get(&key).map(|state| state.span.clone_ref(py))?;
+    bridge
+        .helpers
+        .set_span_in_context
+        .bind(py)
+        .call1((span,))
+        .ok()
+        .map(Bound::unbind)
+}
+
 /// The pool metrics handle when a meter was installed.
 pub(crate) fn pool_metrics() -> Option<Metrics> {
     BRIDGE

--- a/crates/monty-python/tests/test_callback_context.py
+++ b/crates/monty-python/tests/test_callback_context.py
@@ -120,6 +120,7 @@ async def run(index, url=None):
             return 20
         def os_callback(function, args, kwargs):
             assert request.get() == index
+            assert baggage.get_baggage('request') == str(index)
             with tracer.start_as_current_span(f'os {index}'):
                 pass
             return True

--- a/crates/monty-python/tests/test_callback_context.py
+++ b/crates/monty-python/tests/test_callback_context.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.parametrize('mode', ['sampled-out', 'broken-attach', 'broken-tracer'])
+@pytest.mark.parametrize('mode', ['sampled-out', 'broken-attach', 'broken-tracer', 'nested'])
 def test_callback_context_telemetry_fallback(mode: str):
     subprocess.run(
         [
@@ -20,7 +20,7 @@ from contextvars import ContextVar
 from opentelemetry import context, trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
-from pydantic_monty import AsyncMonty, instrument_telemetry
+from pydantic_monty import AsyncMonty, Monty, instrument_telemetry
 
 mode = sys.argv[1]
 provider = TracerProvider(sampler=ALWAYS_OFF)
@@ -28,13 +28,15 @@ tracer = provider.get_tracer('callbacks')
 host_tracer = TracerProvider().get_tracer('host')
 spans = []
 class RecordingTracer:
+    broken = False
     def start_span(self, *args, **kwargs):
-        if mode == 'broken-tracer':
+        if mode == 'broken-tracer' or self.broken:
             raise RuntimeError('tracer failed')
-        span = tracer.start_span(*args, **kwargs)
+        span = (host_tracer if mode == 'nested' else tracer).start_span(*args, **kwargs)
         spans.append(span)
         return span
-instrument_telemetry(tracer=RecordingTracer())
+bridge_tracer = RecordingTracer()
+instrument_telemetry(tracer=bridge_tracer)
 request = ContextVar('request', default='outside')
 
 async def main():
@@ -49,10 +51,26 @@ async def main():
         def printed(stream, text):
             assert request.get() == 'caller'
             current = trace.get_current_span()
-            assert current is (spans[-1] if mode == 'sampled-out' else host)
+            assert current is (spans[-1] if mode in ('sampled-out', 'nested') else host)
             if mode == 'sampled-out':
                 assert not current.is_recording()
             seen.append(text)
+            if mode == 'nested':
+                with host_tracer.start_as_current_span('nested host') as nested_host:
+                    calls = []
+                    def inner():
+                        calls.append(1)
+                        assert request.get() == 'caller'
+                        assert trace.get_current_span() is nested_host
+                        raise ValueError('inner failed')
+                    bridge_tracer.broken = True
+                    with Monty() as pool:
+                        with pool.checkout() as session:
+                            session.feed_run('try:\\n inner()\\nexcept ValueError:\\n pass', external_lookup={'inner': inner})
+                    assert calls == [1]
+                    assert trace.get_current_span() is nested_host
+                    assert not nested_host.events and not current.events
+                assert trace.get_current_span() is current
         try:
             async with AsyncMonty() as pool:
                 async with pool.checkout() as session:
@@ -384,4 +402,5 @@ else:
             failure,
         ],
         check=True,
+        timeout=60,
     )

--- a/crates/monty-python/tests/test_callback_context.py
+++ b/crates/monty-python/tests/test_callback_context.py
@@ -298,3 +298,90 @@ for name, parent in [('async callback', 'call {function_name}'), ('sync callback
         check=True,
         timeout=60,
     )
+
+
+@pytest.mark.parametrize('kind', ['external', 'os', 'print', 'method', 'attribute'])
+@pytest.mark.parametrize('failure', ['none', 'enter', 'record', 'disabled'])
+def test_synchronous_callback_exception_recording(kind: str, failure: str):
+    subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            r"""
+import sys
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic_monty import ClassInstance, Monty, MontyRuntimeError, instrument_telemetry
+
+kind, failure = sys.argv[1:]
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+tracer = provider.get_tracer('callbacks')
+if failure != 'disabled':
+    instrument_telemetry(tracer=tracer)
+calls = []
+
+def fail(*args):
+    span = trace.get_current_span()
+    assert span.is_recording()
+    calls.append(span.get_span_context().span_id)
+    if failure == 'record':
+        def broken_record(*args, **kwargs):
+            raise RuntimeError('telemetry failed')
+        span.record_exception = broken_record
+    raise ValueError('callback failed')
+
+class HostObject:
+    method = fail
+    attribute = property(fail)
+
+with tracer.start_as_current_span('host') as host:
+    if failure == 'enter':
+        def broken_use_span(*args, **kwargs):
+            raise RuntimeError('telemetry failed')
+        trace.use_span = broken_use_span
+    with Monty() as pool:
+        with pool.checkout() as session:
+            if kind == 'print':
+                try:
+                    session.feed_run("print('hello')", print_callback=fail)
+                except MontyRuntimeError as exc:
+                    assert str(exc) == 'ValueError: callback failed'
+                else:
+                    raise AssertionError('expected print failure')
+            else:
+                expression = {
+                    'external': 'fail()',
+                    'os': "Path('/foo').exists()",
+                    'method': 'obj.method()',
+                    'attribute': 'obj.attribute',
+                }[kind]
+                code = "from pathlib import Path\ntry:\n    " + expression + "\nexcept ValueError:\n    result = 42\nresult"
+                obj = ClassInstance(HostObject(), allowed_methods='all', lazy_attrs='all')
+                assert session.feed_run(code, inputs={'obj': obj}, external_lookup={'fail': fail}, os=fail) == 42
+    assert trace.get_current_span() is host
+    assert host.is_recording()
+assert len(calls) == 1
+spans = exporter.get_finished_spans()
+span, = [s for s in spans if s.context.span_id == calls[0]]
+if failure != 'disabled':
+    assert span.context.span_id != host.get_span_context().span_id
+assert not host.events
+if failure == 'none':
+    event, = span.events
+    assert event.name == 'exception'
+    assert event.attributes['exception.type'] == 'ValueError'
+    assert event.attributes['exception.message'] == 'callback failed'
+    assert 'in fail' in event.attributes['exception.stacktrace']
+    assert span.status.status_code == trace.StatusCode.ERROR
+else:
+    assert not span.events
+""",
+            kind,
+            failure,
+        ],
+        check=True,
+    )

--- a/crates/monty-python/tests/test_callback_context.py
+++ b/crates/monty-python/tests/test_callback_context.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize('mode', ['sampled-out', 'broken-attach', 'broken-tracer'])
+def test_callback_context_telemetry_fallback(mode: str):
+    subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+import asyncio
+import sys
+from contextvars import ContextVar
+from opentelemetry import context, trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+from pydantic_monty import AsyncMonty, instrument_telemetry
+
+mode = sys.argv[1]
+provider = TracerProvider(sampler=ALWAYS_OFF)
+tracer = provider.get_tracer('callbacks')
+host_tracer = TracerProvider().get_tracer('host')
+spans = []
+class RecordingTracer:
+    def start_span(self, *args, **kwargs):
+        if mode == 'broken-tracer':
+            raise RuntimeError('tracer failed')
+        span = tracer.start_span(*args, **kwargs)
+        spans.append(span)
+        return span
+instrument_telemetry(tracer=RecordingTracer())
+request = ContextVar('request', default='outside')
+
+async def main():
+    request.set('caller')
+    with host_tracer.start_as_current_span('host') as host:
+        original_attach = context.attach
+        if mode == 'broken-attach':
+            def broken_attach(*args):
+                raise RuntimeError('attach failed')
+            context.attach = broken_attach
+        seen = []
+        def printed(stream, text):
+            assert request.get() == 'caller'
+            current = trace.get_current_span()
+            assert current is (spans[-1] if mode == 'sampled-out' else host)
+            if mode == 'sampled-out':
+                assert not current.is_recording()
+            seen.append(text)
+        try:
+            async with AsyncMonty() as pool:
+                async with pool.checkout() as session:
+                    await session.feed_run("print('hello')", print_callback=printed)
+            assert seen == ['hello\\n']
+            assert trace.get_current_span() is host
+        finally:
+            context.attach = original_attach
+asyncio.run(main())
+assert request.get() == 'outside'
+""",
+            mode,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize('transport', ['subprocess', 'websocket'])
+def test_callback_contexts(transport: str):
+    subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+import asyncio
+from contextvars import ContextVar
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic_monty import AsyncMonty, AsyncMontyWebsocket, Monty, instrument_telemetry
+from opentelemetry import baggage, context
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+tracer = provider.get_tracer('callbacks')
+instrument_telemetry(tracer=tracer)
+request = ContextVar('request', default='outside')
+
+async def run(index, url=None):
+    request.set(index)
+    token = context.attach(baggage.set_baggage('request', str(index)))
+    with tracer.start_as_current_span(f'host {index}'):
+        host = trace.get_current_span()
+        def printed(stream, text):
+            assert request.get() == index
+            assert baggage.get_baggage('request') == str(index)
+            with tracer.start_as_current_span(f'print {index}'):
+                pass
+        def sync_callback():
+            assert request.get() == index
+            assert baggage.get_baggage('request') == str(index)
+            with tracer.start_as_current_span(f'sync {index}'):
+                pass
+            return 10
+        async def async_callback():
+            assert request.get() == index
+            assert baggage.get_baggage('request') == str(index)
+            with tracer.start_as_current_span(f'async {index}'):
+                await asyncio.sleep(0.01)
+                assert request.get() == index
+            return 20
+        def os_callback(function, args, kwargs):
+            assert request.get() == index
+            with tracer.start_as_current_span(f'os {index}'):
+                pass
+            return True
+        async with (AsyncMontyWebsocket(url) if url else AsyncMonty()) as pool:
+            async with pool.checkout(script_name=str(index)) as session:
+                assert await session.feed_run(
+                    "print('hello'); sync_callback() + await async_callback()",
+                    external_lookup={'sync_callback': sync_callback, 'async_callback': async_callback},
+                    print_callback=printed,
+                ) == 30
+                assert await session.feed_run("from pathlib import Path; Path('/x').exists()", os=os_callback)
+        assert trace.get_current_span() is host
+    context.detach(token)
+
+async def main():
+    import sys
+    if sys.argv[1] == 'subprocess':
+        await asyncio.gather(run(1), run(2))
+    else:
+        import runpy
+        from websockets.asyncio.server import serve
+        from pydantic_monty._binary import find_monty_binary
+        bridge = runpy.run_path(sys.argv[2])['bridge_connection']
+        async def handler(websocket):
+            await bridge(websocket, find_monty_binary())
+        async with serve(handler, '127.0.0.1', 0, max_size=None) as server:
+            port = server.sockets[0].getsockname()[1]
+            url = f'ws://127.0.0.1:{port}'
+            await asyncio.gather(run(1, url), run(2, url))
+
+asyncio.run(main())
+assert request.get() == 'outside'
+spans = exporter.get_finished_spans()
+by_id = {s.context.span_id: s for s in spans}
+for index in (1, 2):
+    for kind, expected in [('print', 'run code'), ('sync', 'call {function_name}'), ('async', 'call {function_name}'), ('os', 'os call {function}')]:
+        span = next(s for s in spans if s.name == f'{kind} {index}')
+        parent = by_id[span.parent.span_id]
+        assert parent.name == expected, (span.name, parent.name)
+        while parent.parent is not None:
+            parent = by_id[parent.parent.span_id]
+        assert parent.name == f'host {index}'
+
+with tracer.start_as_current_span('sync host') as host:
+    request.set('sync')
+    def callback(*args):
+        assert request.get() == 'sync'
+        with tracer.start_as_current_span('sync child'):
+            pass
+        return 42
+    with Monty() as pool:
+        with pool.checkout() as session:
+            assert session.feed_run('callback()', external_lookup={'callback': callback}) == 42
+    assert trace.get_current_span() is host
+spans = exporter.get_finished_spans()
+child = next(s for s in spans if s.name == 'sync child')
+assert next(s for s in spans if s.context.span_id == child.parent.span_id).name == 'call {function_name}'
+""",
+            transport,
+            str(Path(__file__).resolve().parents[3] / 'scripts' / 'websocket_relay.py'),
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def test_uninstrumented_callback_context():
+    subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+import asyncio
+from contextvars import ContextVar
+from pydantic_monty import AsyncMonty, MontyRuntimeError
+
+request = ContextVar('request', default='outside')
+
+async def main():
+    request.set('caller')
+    seen = []
+    def printed(stream, text):
+        seen.append(request.get())
+        request.set('callback only')
+    def fail():
+        assert request.get() == 'caller'
+        request.set('callback only')
+        raise ValueError('callback failed')
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            await session.feed_run("print('first')", print_callback=printed)
+            assert request.get() == 'caller'
+            try:
+                await session.feed_run('fail()', external_lookup={'fail': fail})
+            except MontyRuntimeError:
+                pass
+            else:
+                raise AssertionError('expected callback failure')
+            assert request.get() == 'caller'
+            await session.feed_run("print('second')", print_callback=printed)
+    assert seen == ['caller', 'caller']
+
+asyncio.run(main())
+assert request.get() == 'outside'
+""",
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def test_snapshot_callback_context():
+    subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+import asyncio
+from contextvars import ContextVar
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic_monty import AsyncMonty, Monty, MontyComplete, instrument_telemetry
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+tracer = provider.get_tracer('callbacks')
+instrument_telemetry(tracer=tracer)
+request = ContextVar('request', default='outside')
+
+async def main():
+    async def callback():
+        assert request.get() == 'resume'
+        with tracer.start_as_current_span('async callback'):
+            await asyncio.sleep(0)
+            assert request.get() == 'resume'
+        return 42
+    def printed(stream, text):
+        assert request.get() == 'resume'
+        with tracer.start_as_current_span('snapshot print'):
+            pass
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            request.set('feed')
+            snapshot = await session.feed_start(
+                "value = await callback(); print(value); value",
+                external_lookup={'callback': callback}, print_callback=printed,
+            )
+            request.set('resume')
+            while not isinstance(snapshot, MontyComplete):
+                snapshot = await snapshot.resume_auto()
+            assert snapshot.output == 42
+
+asyncio.run(main())
+request.set('sync')
+def callback():
+    assert request.get() == 'sync'
+    with tracer.start_as_current_span('sync callback'):
+        pass
+    return 42
+with Monty() as pool:
+    with pool.checkout() as session:
+        snapshot = session.feed_start('callback()', external_lookup={'callback': callback})
+        assert snapshot.resume_auto().output == 42
+
+spans = exporter.get_finished_spans()
+by_id = {span.context.span_id: span for span in spans}
+for name, parent in [('async callback', 'call {function_name}'), ('sync callback', 'call {function_name}'), ('snapshot print', 'run code')]:
+    span = next(span for span in spans if span.name == name)
+    assert by_id[span.parent.span_id].name == parent
+""",
+        ],
+        check=True,
+        timeout=60,
+    )


### PR DESCRIPTION
Properly nests spans from e.g. print callback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes telemetry and context propagation across host callbacks in the JavaScript and Python SDKs. Print, external function, OS call, and name lookup callbacks now run with the caller's async context and the Monty operation's span active, so spans created inside them nest correctly and caller `contextvars`/async storage are preserved.

- Node restores the caller's AsyncLocalStorage and active span via `AsyncResource` and `context.with`, resolving the span from a native-provided trace/span identity returned with each host-bound turn.
- Python captures `contextvars` at feed start/resume and enters them inside every callback, attaching the native telemetry span; async external coroutines are spawned with copied locals so the context survives awaits.
- Snapshot resumption captures the resuming caller's context, retains the Monty parent span, and leaves the snapshot claim retryable if context capture fails.
- When telemetry is disabled, broken, sampled out, or fails to record, callbacks still run in the caller's context; telemetry never changes callback results, retries, or error raising. New Node and Python tests cover these fallbacks plus exception recording on the callback span, and run in CI via a new `pydantic-monty-client` lib test step.

<sup>Written for commit d6bf4ac681f011e1c80e867cb28f88b1e03521be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

