### PR TITLE
Implement remaining math aggregation functions and `fma`

### DIFF
--- a/crates/monty-macros/README.md
+++ b/crates/monty-macros/README.md
@@ -85,8 +85,8 @@ are all incompatible.
 
 ### Modifiers
 
-- `at_most_total` — pre-count positionals + kwargs against the positional
-  maximum before dispatch (`{name}() takes at most N arguments (M given)`).
+- `at_most_total` — pre-count positionals + kwargs against all named parameters,
+  including keyword-only parameters, before dispatch (`{name}() takes at most N arguments (M given)`).
   This is a per-function empirical fact, not derivable from the fields or
   the style. Litmus test: call the CPython function with valid positionals
   plus one bogus kwarg — if it reports `takes at most N arguments (M

--- a/crates/monty/src/args/bind_native.rs
+++ b/crates/monty/src/args/bind_native.rs
@@ -142,7 +142,7 @@ fn bind_slow<const N: usize>(
     if spec.vectorcall && n_kw == 0 && n_pos > spec.n_positional {
         return Err(ExcType::type_error_at_most(spec.func_name, spec.n_positional, n_pos));
     }
-    if spec.at_most_total && n_pos + n_kw > spec.n_positional {
+    if spec.at_most_total && n_pos + n_kw > spec.params.len() {
         return Err(total_overflow_error(spec, n_pos, n_kw));
     }
     if spec.uses_c_method_arity() && n_pos < spec.n_required_pos_only {
@@ -295,7 +295,7 @@ pub(crate) struct ParamSpec {
     pub varargs: bool,
     /// `**kwargs` — unmatched kwargs are collected instead of erroring.
     pub varkwargs: bool,
-    /// Pre-count `positional + kwarg` against `n_positional` before dispatch,
+    /// Pre-count `positional + kwarg` against all named slots before dispatch,
     /// reproducing `PyArg_ParseTupleAndKeywords`' total pre-check. Set per
     /// function from CPython's observed behaviour — not derivable from the
     /// field shapes (identical signatures differ by parser generation).
@@ -643,12 +643,9 @@ fn unpack_arity_error(spec: &ParamSpec, n_pos: usize) -> Option<RunError> {
 fn total_overflow_error(spec: &ParamSpec, n_pos: usize, n_kw: usize) -> RunError {
     let total = n_pos + n_kw;
     match spec.family {
-        ErrorFamily::C {
-            positional_pivot: false,
-        } => ExcType::type_error_c_at_most(spec.n_positional, total),
-        ErrorFamily::C { positional_pivot: true } => ExcType::type_error_c_at_most_positional(spec.n_positional, total),
+        ErrorFamily::C { .. } => ExcType::type_error_c_at_most(spec.params.len(), total),
         // Clinic / CNamed (`def`/`unpack` reject the flag at derive time).
-        _ => ExcType::type_error_method_at_most(spec.func_name, spec.n_positional, total, n_pos == 0),
+        _ => ExcType::type_error_method_at_most(spec.func_name, spec.params.len(), total, n_pos == 0),
     }
 }
 

--- a/crates/monty/src/args/mod.rs
+++ b/crates/monty/src/args/mod.rs
@@ -69,6 +69,16 @@ impl ArgValues {
         }
     }
 
+    /// Rejects keywords before a positional-only function's arity or conversion checks.
+    pub(crate) fn reject_kwargs(self, name: &str, heap: &mut Heap) -> RunResult<Self> {
+        if self.has_kwargs() {
+            self.drop_with(heap);
+            Err(ExcType::type_error_no_kwargs(name))
+        } else {
+            Ok(self)
+        }
+    }
+
     /// Checks that exactly one positional argument was passed, returning it.
     ///
     /// On error, properly drops all contained values to maintain reference counts.

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -197,7 +197,7 @@ mod tests {
         );
         assert_eq!(
             static_strings_fingerprint(),
-            0x782b_66f9_b630_180a,
+            0x8bc6_84ec_a12c_3edc,
             "static strings changed for dump version {DUMP_VERSION}"
         );
         assert_eq!(

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -504,6 +504,13 @@ pub enum StaticStrings {
     Modf,
     Frexp,
     Ldexp,
+    // Summation and products
+    Hypot,
+    Dist,
+    Fsum,
+    Prod,
+    Sumprod,
+    Fma,
     // Special functions
     Gamma,
     Lgamma,

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -504,13 +504,6 @@ pub enum StaticStrings {
     Modf,
     Frexp,
     Ldexp,
-    // Summation and products
-    Hypot,
-    Dist,
-    Fsum,
-    Prod,
-    Sumprod,
-    Fma,
     // Special functions
     Gamma,
     Lgamma,
@@ -1166,6 +1159,17 @@ pub enum StaticStrings {
     Batched,
     /// `itertools.zip_longest()` function.
     ZipLongest,
+
+    // ==========================
+    // math summation and product functions. Appended at the enum end rather
+    // than beside the other math names: discriminants are serialized
+    // `StringId`s, so mid-enum insertion would shift every later id.
+    Hypot,
+    Dist,
+    Fsum,
+    Prod,
+    Sumprod,
+    Fma,
 }
 
 /// Computes an FNV-1a hash over static-string identities and serialization.

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -17,6 +17,7 @@
 //! **Integer math**: `factorial`, `gcd`, `lcm`, `comb`, `perm`
 //! **Modular**: `fmod`, `remainder`, `modf`, `frexp`, `ldexp`
 //! **Special**: `gamma`, `lgamma`, `erf`, `erfc`
+//! **Summation & products**: `hypot`, `dist`, `fsum`, `prod`, `sumprod`, `fma`
 //!
 //! ## Constants
 //!
@@ -25,6 +26,7 @@
 use std::f64::consts;
 
 use num_bigint::BigInt;
+use num_traits::ToPrimitive;
 use smallvec::smallvec;
 
 use crate::{
@@ -38,6 +40,8 @@ use crate::{
     types::{LongInt, Module, allocate_tuple},
     value::Value,
 };
+
+mod aggregate;
 
 // ==========================
 // Shared constants and error helpers
@@ -167,6 +171,13 @@ pub(crate) enum MathFunctions {
     Lgamma,
     Erf,
     Erfc,
+    // Summation and products (append to preserve serialized variant indices).
+    Hypot,
+    Dist,
+    Fsum,
+    Prod,
+    Sumprod,
+    Fma,
 }
 
 /// Creates the `math` module and allocates it on the heap.
@@ -258,6 +269,13 @@ const MATH_FUNCTIONS: &[(StaticStrings, MathFunctions)] = &[
     (StaticStrings::Lgamma, MathFunctions::Lgamma),
     (StaticStrings::Erf, MathFunctions::Erf),
     (StaticStrings::Erfc, MathFunctions::Erfc),
+    // Summation and products
+    (StaticStrings::Hypot, MathFunctions::Hypot),
+    (StaticStrings::Dist, MathFunctions::Dist),
+    (StaticStrings::Fsum, MathFunctions::Fsum),
+    (StaticStrings::Prod, MathFunctions::Prod),
+    (StaticStrings::Sumprod, MathFunctions::Sumprod),
+    (StaticStrings::Fma, MathFunctions::Fma),
 ];
 
 /// Dispatches a call to a math module function.
@@ -326,6 +344,12 @@ pub(super) fn call(vm: &mut VM<'_>, function: MathFunctions, args: ArgValues) ->
         MathFunctions::Lgamma => math_lgamma(vm, args),
         MathFunctions::Erf => math_erf(vm, args),
         MathFunctions::Erfc => math_erfc(vm, args),
+        MathFunctions::Hypot => aggregate::hypot(vm, args),
+        MathFunctions::Dist => aggregate::dist(vm, args),
+        MathFunctions::Fsum => aggregate::fsum(vm, args),
+        MathFunctions::Prod => aggregate::prod(vm, args),
+        MathFunctions::Sumprod => aggregate::sumprod(vm, args),
+        MathFunctions::Fma => aggregate::fma(vm, args),
     }
 }
 
@@ -1307,7 +1331,7 @@ fn math_erfc(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 
 /// Converts a `Value` to `f64`, raising `TypeError` if the value is not numeric.
 ///
-/// Accepts `Float`, `Int`, and `Bool` values. For other types, raises a `TypeError`
+/// Accepts floats, integers (including big integers), and booleans. Other types raise a `TypeError`
 /// with a message matching CPython's format: "must be real number, not <type>".
 #[expect(
     clippy::cast_precision_loss,
@@ -1318,6 +1342,16 @@ fn value_to_float(value: &Value, vm: &VM<'_>) -> RunResult<f64> {
         Value::Float(f) => Ok(*f),
         Value::Int(n) => Ok(*n as f64),
         Value::Bool(b) => Ok(if *b { 1.0 } else { 0.0 }),
+        Value::InternLongInt(id) => vm
+            .interns
+            .get_long_int(*id)
+            .to_f64()
+            .filter(|f| f.is_finite())
+            .ok_or_else(ExcType::overflow_int_to_float),
+        Value::Ref(id) if let HeapData::LongInt(integer) = vm.heap.get(*id) => integer
+            .to_f64()
+            .filter(|f| f.is_finite())
+            .ok_or_else(ExcType::overflow_int_to_float),
         _ => Err(ExcType::type_error(format!(
             "must be real number, not {}",
             value.py_type_name(vm)

--- a/crates/monty/src/modules/math/aggregate.rs
+++ b/crates/monty/src/modules/math/aggregate.rs
@@ -1,0 +1,414 @@
+//! Norms, accurate sums, and products for `math`.
+//!
+//! The numerical algorithms are broadly based on CPython's `Modules/mathmodule.c`:
+//! Shewchuk's partials for `fsum`, a scaled compensated sum for `hypot`/`dist`,
+//! and Neumaier's dot product for `sumprod`.
+
+use std::mem;
+
+use smallvec::SmallVec;
+
+use super::value_to_float;
+use crate::{
+    args::{ArgValues, FromArgs},
+    bytecode::VM,
+    defer_drop,
+    exception_private::{ExcType, RunResult, SimpleException},
+    heap::DropGuard,
+    types::{PyTrait, Type, iter::collect_iterable},
+    value::Value,
+};
+
+/// Coordinates remain owned until all conversions have succeeded.
+#[derive(FromArgs)]
+#[from_args(name = "hypot")]
+struct HypotArgs {
+    #[from_args(varargs)]
+    coordinates: Vec<Value>,
+}
+
+/// Computes a norm without overflowing intermediate squares.
+pub(super) fn hypot(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let args = args.reject_kwargs("math.hypot", vm.heap)?;
+    let HypotArgs { coordinates } = HypotArgs::from_args(args, vm)?;
+    defer_drop!(coordinates, vm);
+    let mut values = coordinates
+        .iter()
+        .map(|value| value_to_float(value, vm).map(f64::abs))
+        .collect::<RunResult<SmallVec<[f64; 16]>>>()?;
+    Ok(Value::Float(vector_norm(&mut values)))
+}
+
+/// Positional-only points; CPython qualifies only the keyword error.
+#[derive(FromArgs)]
+#[from_args(name = "dist", style = unpack, kwarg_error_name = "math.dist")]
+struct DistArgs {
+    #[from_args(pos_only)]
+    p: Value,
+    #[from_args(pos_only)]
+    q: Value,
+}
+
+/// Collects both points before checking dimensions and converting coordinates.
+pub(super) fn dist(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let DistArgs { p, q } = DistArgs::from_args(args, vm)?;
+    defer_drop!(p, vm);
+    defer_drop!(q, vm);
+    let p = collect_iterable(p, vm)?;
+    defer_drop!(p, vm);
+    let q = collect_iterable(q, vm)?;
+    defer_drop!(q, vm);
+    if p.len() != q.len() {
+        return Err(SimpleException::new_msg(
+            ExcType::ValueError,
+            "both points must have the same number of dimensions",
+        )
+        .into());
+    }
+    let mut differences = p
+        .iter()
+        .zip(q.iter())
+        .map(|(p, q)| Ok((value_to_float(p, vm)? - value_to_float(q, vm)?).abs()))
+        .collect::<RunResult<SmallVec<[f64; 16]>>>()?;
+    Ok(Value::Float(vector_norm(&mut differences)))
+}
+
+/// Scales by powers of two, compensates squares and sums, then corrects the square root.
+/// Inputs are magnitudes; the subnormal branch rescales them in place once.
+fn vector_norm(values: &mut [f64]) -> f64 {
+    let max = values.iter().copied().fold(0.0, f64::max);
+    if max.is_infinite() {
+        max
+    } else if values.iter().any(|x| x.is_nan()) {
+        f64::NAN
+    } else if max == 0.0 || values.len() <= 1 {
+        max
+    } else {
+        let (_, exponent) = libm::frexp(max);
+        if exponent < -1023 {
+            for value in values.iter_mut() {
+                *value /= f64::MIN_POSITIVE;
+            }
+            f64::MIN_POSITIVE * vector_norm(values)
+        } else {
+            let scale = libm::ldexp(1.0, -exponent);
+            // Starting at one makes the first operand dominate every square.
+            let mut sum = 1.0;
+            let mut square_errors = 0.0;
+            let mut sum_errors = 0.0;
+            for value in values {
+                let x = *value * scale;
+                let (square, error) = two_product(x, x);
+                let (next, residual) = fast_two_sum(sum, square);
+                sum = next;
+                square_errors += error;
+                sum_errors += residual;
+            }
+            let mut root = (sum - 1.0 + (square_errors + sum_errors)).sqrt();
+            let (square, error) = two_product(-root, root);
+            let (sum, residual) = fast_two_sum(sum, square);
+            square_errors += error;
+            sum_errors += residual;
+            let correction = sum - 1.0 + (square_errors + sum_errors);
+            root += correction / (2.0 * root);
+            root / scale
+        }
+    }
+}
+
+/// Returns the rounded sum and its residual when `|a| >= |b|`.
+fn fast_two_sum(a: f64, b: f64) -> (f64, f64) {
+    let sum = a + b;
+    (sum, (a - sum) + b)
+}
+
+/// Returns a sum and its residual without requiring ordered magnitudes.
+fn two_sum(a: f64, b: f64) -> (f64, f64) {
+    let sum = a + b;
+    let recovered_b = sum - a;
+    (sum, (a - (sum - recovered_b)) + (b - recovered_b))
+}
+
+/// Retains the product's rounding error with fused multiply-add.
+fn two_product(a: f64, b: f64) -> (f64, f64) {
+    let product = a * b;
+    (product, a.mul_add(b, -product))
+}
+
+/// Sums non-overlapping partials, preserving cancellation and half-even rounding.
+pub(super) fn fsum(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let args = args.reject_kwargs("math.fsum", vm.heap)?;
+    let iterable = args.get_one_arg("math.fsum", vm.heap)?;
+    let iterator = iterable.into_py_iter(vm)?;
+    defer_drop!(iterator, vm);
+    let mut iterator = iterator.read(vm);
+    let mut partials = SmallVec::<[f64; 32]>::new();
+    let mut special_sum = 0.0;
+    let mut inf_sum = 0.0;
+    while let Some(item) = iterator.py_next(vm)? {
+        defer_drop!(item, vm);
+        let original = value_to_float(item, vm)?;
+        let mut x = original;
+        let mut retained = 0;
+        for index in 0..partials.len() {
+            let mut y = partials[index];
+            if x.abs() < y.abs() {
+                mem::swap(&mut x, &mut y);
+            }
+            let hi = x + y;
+            let lo = y - (hi - x);
+            if lo != 0.0 {
+                partials[retained] = lo;
+                retained += 1;
+            }
+            x = hi;
+        }
+        partials.truncate(retained);
+        if x != 0.0 {
+            if x.is_finite() {
+                partials.push(x);
+            } else {
+                if original.is_finite() {
+                    return Err(
+                        SimpleException::new_msg(ExcType::OverflowError, "intermediate overflow in fsum").into(),
+                    );
+                }
+                if original.is_infinite() {
+                    inf_sum += original;
+                }
+                special_sum += original;
+                partials.clear();
+            }
+        }
+    }
+    if special_sum == 0.0 {
+        Ok(Value::Float(round_partials(&mut partials)))
+    } else if inf_sum.is_nan() {
+        Err(SimpleException::new_msg(ExcType::ValueError, "-inf + inf in fsum").into())
+    } else {
+        Ok(Value::Float(special_sum))
+    }
+}
+
+/// Combines partials largest-first, using the remaining tail to resolve rounding ties.
+#[expect(
+    clippy::float_cmp,
+    reason = "exact comparison detects a representable rounding correction"
+)]
+fn round_partials(partials: &mut SmallVec<[f64; 32]>) -> f64 {
+    let mut hi = partials.pop().unwrap_or(0.0);
+    let mut lo = 0.0;
+    while let Some(y) = partials.pop() {
+        let x = hi;
+        hi = x + y;
+        lo = y - (hi - x);
+        if lo != 0.0 {
+            break;
+        }
+    }
+    if let Some(tail) = partials.last()
+        && ((lo < 0.0 && *tail < 0.0) || (lo > 0.0 && *tail > 0.0))
+    {
+        let correction = lo * 2.0;
+        let rounded = hi + correction;
+        if correction == rounded - hi {
+            hi = rounded;
+        }
+    }
+    hi
+}
+
+/// `start` is keyword-only and is returned unchanged for an empty iterable.
+#[derive(FromArgs)]
+#[from_args(name = "prod", style = c_named, at_most_total)]
+struct ProdArgs {
+    #[from_args(pos_only)]
+    iterable: Value,
+    #[from_args(kw_only, default = Value::Int(1))]
+    start: Value,
+}
+
+/// Multiplies through Python's numeric protocol, retaining arbitrary-size integer results.
+pub(super) fn prod(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let ProdArgs { iterable, start } = ProdArgs::from_args(args, vm)?;
+    let mut result = DropGuard::new(start, vm);
+    {
+        let (total, vm) = result.as_parts_mut();
+        let iterator = iterable.into_py_iter(vm)?;
+        defer_drop!(iterator, vm);
+        let mut iterator = iterator.read(vm);
+        while let Some(item) = iterator.py_next(vm)? {
+            defer_drop!(item, vm);
+            let next = multiply(total, item, vm)?;
+            mem::replace(total, next).drop_with(vm);
+        }
+    }
+    Ok(result.into_inner())
+}
+
+/// Dot-product compensation keeps three floating-point components.
+#[derive(Clone, Copy, Default)]
+struct Triple {
+    /// Leading rounded sum.
+    hi: f64,
+    /// Residual from the leading sum and product.
+    lo: f64,
+    /// Accumulated residuals from combining the low components.
+    tiny: f64,
+}
+
+impl Triple {
+    /// Adds a product with the three-component algorithm used by CPython's `sumprod`.
+    fn add_product(self, a: f64, b: f64) -> Self {
+        let (product, product_lo) = two_product(a, b);
+        let (hi, sum_lo) = two_sum(self.hi, product);
+        let (low_sum, low_error) = two_sum(self.lo, product_lo);
+        let (lo, tiny) = two_sum(low_sum, sum_lo);
+        Self {
+            hi,
+            lo,
+            tiny: self.tiny + low_error + tiny,
+        }
+    }
+
+    /// Rounds the low components into the leading sum.
+    fn to_float(self) -> f64 {
+        let (hi, lo) = two_sum(self.lo, self.hi);
+        self.tiny + lo + hi
+    }
+}
+
+/// Dot-product inputs are advanced in pairs, with strict length checking.
+#[derive(FromArgs)]
+#[from_args(name = "sumprod", style = unpack, kwarg_error_name = "math.sumprod")]
+struct SumprodArgs {
+    #[from_args(pos_only)]
+    p: Value,
+    #[from_args(pos_only)]
+    q: Value,
+}
+
+/// Uses exact integer arithmetic and compensated float products before generic arithmetic.
+pub(super) fn sumprod(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let SumprodArgs { p, q } = SumprodArgs::from_args(args, vm)?;
+    defer_drop!(p, vm);
+    defer_drop!(q, vm);
+    let p = p.py_iter(vm)?;
+    defer_drop!(p, vm);
+    let q = q.py_iter(vm)?;
+    defer_drop!(q, vm);
+    let mut p = p.read(vm);
+    let mut q = q.read(vm);
+    let mut result = DropGuard::new(Value::Int(0), vm);
+    let (total, vm) = result.as_parts_mut();
+    let mut integer_total = Some(0_i64);
+    let mut float_total = Some(Triple::default());
+    let mut float_used = false;
+    loop {
+        let a = p.py_next(vm)?;
+        defer_drop!(a, vm);
+        let b = q.py_next(vm)?;
+        defer_drop!(b, vm);
+        if a.is_some() != b.is_some() {
+            return Err(SimpleException::new_msg(ExcType::ValueError, "Inputs are not the same length").into());
+        }
+        let pair = a.as_ref().zip(b.as_ref());
+        if let Some(accumulator) = integer_total {
+            if let Some((Value::Int(a), Value::Int(b))) = pair
+                && let Some(next) = a.checked_mul(*b).and_then(|product| accumulator.checked_add(product))
+            {
+                integer_total = Some(next);
+                continue;
+            }
+            integer_total = None;
+            let next = add(total, &Value::Int(accumulator), vm)?;
+            mem::replace(total, next).drop_with(vm);
+        }
+        if let Some(accumulator) = float_total {
+            if let Some((a, b)) = pair
+                && let Ok(Some((a, b))) = float_pair(a, b, vm)
+            {
+                let next = accumulator.add_product(a, b);
+                if next.hi.is_finite() {
+                    float_total = Some(next);
+                    float_used = true;
+                    continue;
+                }
+            }
+            float_total = None;
+            if float_used {
+                let next = add(total, &Value::Float(accumulator.to_float()), vm)?;
+                mem::replace(total, next).drop_with(vm);
+            }
+        }
+        if let Some((a, b)) = pair {
+            let product = multiply(a, b, vm)?;
+            defer_drop!(product, vm);
+            let next = add(total, product, vm)?;
+            mem::replace(total, next).drop_with(vm);
+        } else {
+            break;
+        }
+    }
+    Ok(result.into_inner())
+}
+
+/// The compensated path accepts float/float and float/int pairs, including booleans.
+fn float_pair(a: &Value, b: &Value, vm: &VM<'_>) -> RunResult<Option<(f64, f64)>> {
+    if (matches!(a, Value::Float(_)) && matches!(b.py_type(vm), Type::Float | Type::Int | Type::Bool))
+        || (matches!(b, Value::Float(_)) && matches!(a.py_type(vm), Type::Float | Type::Int | Type::Bool))
+    {
+        Ok(Some((value_to_float(a, vm)?, value_to_float(b, vm)?)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Checks mixed float/integer conversion before multiplication; generic arithmetic permits infinity.
+fn multiply(a: &Value, b: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
+    if let Some((a, b)) = float_pair(a, b, vm)? {
+        Ok(Value::Float(a * b))
+    } else {
+        a.py_mul(b, vm)
+    }
+}
+
+/// Checks mixed float/integer conversion when flushing a dot-product accumulator.
+fn add(a: &Value, b: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
+    if let Some((a, b)) = float_pair(a, b, vm)? {
+        Ok(Value::Float(a + b))
+    } else {
+        a.py_add(b, vm)
+    }
+}
+
+/// Three positional real numbers, converted in declaration order.
+#[derive(FromArgs)]
+#[from_args(name = "fma", style = unpack, kwarg_error_name = "math.fma")]
+struct FmaArgs {
+    #[from_args(pos_only)]
+    x: Value,
+    #[from_args(pos_only)]
+    y: Value,
+    #[from_args(pos_only)]
+    z: Value,
+}
+
+/// Performs one rounding and raises CPython's errors for invalid operations and overflow.
+pub(super) fn fma(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let FmaArgs { x, y, z } = FmaArgs::from_args(args, vm)?;
+    defer_drop!(x, vm);
+    defer_drop!(y, vm);
+    defer_drop!(z, vm);
+    let x = value_to_float(x, vm)?;
+    let y = value_to_float(y, vm)?;
+    let z = value_to_float(z, vm)?;
+    let result = x.mul_add(y, z);
+    if result.is_nan() && !x.is_nan() && !y.is_nan() && !z.is_nan() {
+        Err(SimpleException::new_msg(ExcType::ValueError, "invalid operation in fma").into())
+    } else if result.is_infinite() && x.is_finite() && y.is_finite() && z.is_finite() {
+        Err(SimpleException::new_msg(ExcType::OverflowError, "overflow in fma").into())
+    } else {
+        Ok(Value::Float(result))
+    }
+}

--- a/crates/monty/test_cases/args__macro_errors.py
+++ b/crates/monty/test_cases/args__macro_errors.py
@@ -14,11 +14,43 @@ import base64
 import binascii
 import datetime
 import json
+import math
 import re
 import sys
 import unicodedata
 
 is_monty = sys.platform == 'monty'
+
+# === Math aggregations: positional-only calls and keyword-only start ===
+for function, args, kwargs, message in [
+    (math.hypot, (), {'x': 1}, 'math.hypot() takes no keyword arguments'),
+    (math.hypot, ('bad',), {'x': 1}, 'math.hypot() takes no keyword arguments'),
+    (math.fsum, (), {}, 'math.fsum() takes exactly one argument (0 given)'),
+    (math.fsum, ([], []), {}, 'math.fsum() takes exactly one argument (2 given)'),
+    (math.fsum, (), {'seq': []}, 'math.fsum() takes no keyword arguments'),
+    (math.dist, (), {}, 'dist expected 2 arguments, got 0'),
+    (math.dist, ([], [], []), {}, 'dist expected 2 arguments, got 3'),
+    (math.dist, (), {'p': [], 'q': []}, 'math.dist() takes no keyword arguments'),
+    (math.sumprod, ([],), {}, 'sumprod expected 2 arguments, got 1'),
+    (math.sumprod, ([], [], []), {}, 'sumprod expected 2 arguments, got 3'),
+    (math.sumprod, (), {'p': [], 'q': []}, 'math.sumprod() takes no keyword arguments'),
+    (math.prod, (), {}, 'prod() takes exactly 1 positional argument (0 given)'),
+    (math.prod, ([], 2), {}, 'prod() takes exactly 1 positional argument (2 given)'),
+    (math.prod, (), {'iterable': []}, 'prod() takes exactly 1 positional argument (0 given)'),
+    (math.prod, ([],), {'bogus': 1}, "prod() got an unexpected keyword argument 'bogus'"),
+    (math.prod, (1,), {'bogus': 1}, "prod() got an unexpected keyword argument 'bogus'"),
+    (math.prod, ([], 2), {'bogus': 1}, 'prod() takes at most 2 arguments (3 given)'),
+    (math.prod, ([],), {'start': 1, 'bogus': 1}, 'prod() takes at most 2 arguments (3 given)'),
+    (math.fma, (), {}, 'fma expected 3 arguments, got 0'),
+    (math.fma, (1, 2, 3, 4), {}, 'fma expected 3 arguments, got 4'),
+    (math.fma, (), {'x': 1, 'y': 2, 'z': 3}, 'math.fma() takes no keyword arguments'),
+    (math.fma, ('bad', 2, 3), {'x': 1}, 'math.fma() takes no keyword arguments'),
+]:
+    try:
+        function(*args, **kwargs)
+        assert False, 'invalid math arguments must fail'
+    except TypeError as e:
+        assert str(e) == message, (str(e), message)
 
 # =====================================================================
 # === Clinic style (the default — plus `def` for pure-Python targets) ===

--- a/crates/monty/test_cases/math__aggregates.py
+++ b/crates/monty/test_cases/math__aggregates.py
@@ -1,0 +1,229 @@
+import math
+
+# === Norms: dimensions, scaling, signs, and special values ===
+assert math.hypot() == 0.0
+assert type(math.hypot()) is float
+assert math.hypot(-7) == 7.0
+assert math.hypot(3, -4) == 5.0
+assert math.hypot(2, 3, 6) == 7.0
+assert math.hypot(*([1.0] * 100)) == 10.0
+assert math.hypot(True, False) == 1.0
+assert math.copysign(1, math.hypot(-0.0)) == 1
+assert math.isclose(math.hypot(3e200, 4e200), 5e200, rel_tol=1e-15)
+assert math.isclose(math.hypot(3e-200, 4e-200), 5e-200, rel_tol=1e-15)
+assert math.hypot(3e-323, 4e-323) == 5e-323
+assert math.hypot(5e-324, 5e-324) == 5e-324
+assert math.hypot(1e308, 1e308) == 1.4142135623730951e308
+assert math.hypot(1.7e308, 1.7e308) == math.inf
+assert math.hypot(math.nan, -math.inf) == math.inf
+assert math.hypot(math.inf, math.nan) == math.inf
+assert math.isnan(math.hypot(math.nan))
+assert math.isnan(math.hypot(0, math.nan))
+assert math.hypot(2**100) == 2.0**100
+assert math.hypot(1267650600228229401496703205376) == 2.0**100
+
+# These inputs exposed rounding errors in earlier CPython norm algorithms.
+for x, y, expected in [
+    (572330659.1077356, 1180450261.5893514, 1311878501.7832494),
+    (712049370.5674208, 791476409.2831447, 1064635718.251647),
+    (1037023154.6745788, 794204895.5538545, 1306207655.5635877),
+]:
+    assert math.hypot(x, y) == expected
+    assert math.dist([x, y], [0, 0]) == expected
+
+assert math.dist([], []) == 0.0
+assert type(math.dist([], [])) is float
+assert math.dist((1, 2), (4, 6)) == 5.0
+assert math.dist(iter([2, 3, 6]), (0 for _ in range(3))) == 7.0
+assert math.dist([3e-323, 4e-323], [0, 0]) == 5e-323
+assert math.dist([1e308], [-1e308]) == math.inf
+assert math.isnan(math.dist([math.inf], [math.inf]))
+assert math.dist([math.inf, math.nan], [0, 0]) == math.inf
+assert math.dist([2**100], [0]) == 2.0**100
+
+for p, q in [([1], []), ([], [1]), (['bad'], []), (['bad'], [1, 2])]:
+    try:
+        math.dist(p, q)
+        assert False, 'unequal dimensions must fail before coordinate conversion'
+    except ValueError as e:
+        assert str(e) == 'both points must have the same number of dimensions'
+
+# === Accurate sums: cancellation, rounding ties, and partials spanning exponents ===
+assert math.fsum([]) == 0.0
+assert type(math.fsum([])) is float
+assert math.copysign(1, math.fsum([-0.0])) == 1
+assert math.fsum([True, False, 2]) == 3.0
+assert math.fsum(x for x in [1e100, 1, -1e100]) == 1.0
+assert math.fsum([1e100, 1, -1e100, 1e-100, 1e50, -1, -1e50]) == 1e-100
+assert math.fsum([2.0**53, -0.5, -(2.0**-54)]) == 2.0**53 - 1.0
+assert math.fsum([2.0**53, 1.0, 2.0**-100]) == 2.0**53 + 2.0
+assert math.fsum([1e16, 1.0, 1e-16]) == 10000000000000002.0
+assert math.fsum([-1e16, -1.0, -1e-16]) == -10000000000000002.0
+assert math.fsum([5e-324] * 10) == 5e-323
+assert math.fsum([2**100, 1, -(2**100)]) == 1.0
+assert math.fsum([math.inf, 1]) == math.inf
+assert math.fsum([-math.inf, 1]) == -math.inf
+assert math.isnan(math.fsum([math.nan, 1]))
+assert math.isnan(math.fsum([math.nan, math.inf]))
+partials = [2.0**n - 2.0 ** (n + 50) + 2.0 ** (n + 52) for n in range(-1074, 972, 2)]
+assert math.fsum(partials + [-(2.0**1022)]) == 1.3305602063564798e292
+
+for values in [[math.inf, -math.inf], [math.nan, math.inf, -math.inf]]:
+    try:
+        math.fsum(values)
+        assert False, 'opposite infinities must fail'
+    except ValueError as e:
+        assert str(e) == '-inf + inf in fsum'
+
+for values in [[1e308, 1e308], [math.nan, 1e308, 1e308]]:
+    try:
+        math.fsum(values)
+        assert False, 'intermediate overflow must fail'
+    except OverflowError as e:
+        assert str(e) == 'intermediate overflow in fsum'
+
+# === Products: integer preservation, generators, and the start value ===
+assert math.prod([]) == 1
+assert type(math.prod([])) is int
+assert math.prod(range(1, 6)) == 120
+assert math.prod(x for x in [2, 3, 4]) == 24
+assert math.prod([2, 3], start=5) == 30
+assert math.prod([2, 3], start=0.5) == 3.0
+assert type(math.prod([2, 3], start=0.5)) is float
+assert math.prod([2**50, 2**60, -3]) == -3 * 2**110
+assert math.prod([True, True]) == 1
+assert math.prod([True, False]) == 0
+assert math.prod([1e308, 2.0]) == math.inf
+assert math.isnan(math.prod([0.0, math.inf]))
+assert math.copysign(1, math.prod([-0.0, 2])) == -1
+start = ['retained']
+assert math.prod([], start=start) is start
+assert math.prod([2, 3], start='x') == 'xxxxxx'
+assert math.prod([2], start=start) == ['retained', 'retained']
+
+# === Dot products: exact integers and compensated float multiplication ===
+assert math.sumprod([], []) == 0
+assert type(math.sumprod([], [])) is int
+assert math.sumprod(iter([10, 20, 30]), (1, 2, 3)) == 140
+assert math.sumprod((x for x in [1.5, 2.5]), [3.5, 4.5]) == 16.5
+assert math.sumprod([True, False], [True, True]) == 1
+assert math.sumprod([1.5, 2.5], [True, False]) == 1.5
+assert math.sumprod([True, False], [1.5, 2.5]) == 1.5
+assert math.sumprod([2**100, 1], [2**100, 2]) == 2**200 + 2
+assert math.sumprod([2**62, 2**62], [1, 1]) == 2**63
+assert math.sumprod([2**40], [2**40]) == 2**80
+assert math.sumprod([1e100, 1.0, -1e100], [1.0, 1.0, 1.0]) == 1.0
+assert math.sumprod([1e100, 1.0, -1e100], [1, 1, 1]) == 1.0
+assert math.sumprod([1.0], [2**100]) == 2.0**100
+assert math.sumprod([2**100], [1.0]) == 2.0**100
+a = 2.0**-50
+assert math.sumprod([a - 1.0, 1.0], [a + 1.0, 1.0]) == a * a
+assert math.sumprod([-5, -5, 10], [1.5, 4611686018427387904, 2305843009213693952]) == 0.0
+assert math.sumprod([1.0, math.inf], [2.0, 3.0]) == math.inf
+assert math.isnan(math.sumprod([1e308, -1e308], [2.0, 2.0]))
+assert math.isnan(math.sumprod([0.0], [math.inf]))
+assert math.isnan(math.sumprod([math.nan], [1]))
+
+for p, q in [([1], []), ([], [1]), ([1, 2], [3]), ([1], [2, 3])]:
+    try:
+        math.sumprod(p, q)
+        assert False, 'unequal lengths must fail'
+    except ValueError as e:
+        assert str(e) == 'Inputs are not the same length'
+
+# === Fused multiply-add: a single rounding, overflow, and invalid operations ===
+assert math.fma(2, 3, 4) == 10.0
+assert type(math.fma(2, 3, 4)) is float
+assert math.fma(True, 2, False) == 2.0
+assert math.fma(a - 1.0, a + 1.0, 1.0) == a * a
+assert math.fma(1e308, 2.0, -1e308) == 1e308
+assert math.fma(5e-324, 1, 5e-324) == 1e-323
+assert math.fma(2**100, 1, 0) == 2.0**100
+assert math.copysign(1, math.fma(-0.0, 1.0, -0.0)) == -1
+assert math.fma(math.inf, 1, 0) == math.inf
+assert math.isnan(math.fma(0, math.inf, math.nan))
+assert math.isnan(math.fma(math.nan, 1, 2))
+for x, y, z in [(0, math.inf, 1), (math.inf, 0, 1), (math.inf, 1, -math.inf)]:
+    try:
+        math.fma(x, y, z)
+        assert False, 'invalid fused operation must fail'
+    except ValueError as e:
+        assert str(e) == 'invalid operation in fma'
+try:
+    math.fma(1e308, 2, 0)
+    assert False, 'fused overflow must fail'
+except OverflowError as e:
+    assert str(e) == 'overflow in fma'
+
+# === Conversion and iteration errors release retained values ===
+for function, args in [
+    (math.hypot, (math.inf, 'bad')),
+    (math.dist, (['bad'], [0])),
+    (math.fsum, ([1, 'bad'],)),
+    (math.fma, (1, 'bad', 3)),
+]:
+    try:
+        function(*args)
+        assert False, 'non-numeric arguments must fail'
+    except TypeError as e:
+        assert str(e) == 'must be real number, not str'
+
+for function, args in [
+    (math.hypot, (2**2000,)),
+    (math.dist, ([2**2000], [0])),
+    (math.fsum, ([2**2000],)),
+    (math.fma, (1, 2**2000, 0)),
+    (math.sumprod, ([1.0], [2**2000])),
+    (math.sumprod, ([2**2000], [1.0])),
+    (math.sumprod, ([2**2000, 1.0], [1, 1.0])),
+    (math.prod, ([2**2000, 1.0],)),
+    (math.prod, ([1.0, 2**2000],)),
+]:
+    try:
+        function(*args)
+        assert False, 'float conversion must reject overflowing integers'
+    except OverflowError as e:
+        assert str(e) == 'int too large to convert to float'
+
+
+def broken(values):
+    """Yield retained values before failing inside a native aggregation loop."""
+    values = iter(values)
+
+    def step():
+        """Raise after the last successful item."""
+        value = next(values, None)
+        if value is None:
+            raise RuntimeError('iterator failed')
+        return value
+
+    return iter(step, None)
+
+
+for function, args in [
+    (math.prod, (broken([2**100]),)),
+    (math.fsum, (broken([1.0]),)),
+    (math.dist, (broken([1.0]), [0])),
+    (math.dist, ([0], broken([1.0]))),
+    (math.sumprod, (broken([1.0]), [2])),
+    (math.sumprod, ([1], broken([2**100]))),
+]:
+    try:
+        function(*args)
+        assert False, 'iterator errors must propagate'
+    except RuntimeError as e:
+        assert str(e) == 'iterator failed'
+
+for function, args, message in [
+    (math.prod, ([2**100, {}],), "unsupported operand type(s) for *: 'int' and 'dict'"),
+    (math.sumprod, ([2**100, {}], [1, 2]), "unsupported operand type(s) for *: 'dict' and 'int'"),
+    (math.sumprod, (['abc'], [2]), "unsupported operand type(s) for +: 'int' and 'str'"),
+    (math.prod, (None,), "'NoneType' object is not iterable"),
+    (math.dist, ([2**100], None), "'NoneType' object is not iterable"),
+    (math.sumprod, ([2**100], None), "'NoneType' object is not iterable"),
+]:
+    try:
+        function(*args)
+        assert False, 'invalid operands must fail'
+    except TypeError as e:
+        assert str(e) == message

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -505,6 +505,21 @@ fn timeout_in_sum_builtin() {
     assert_timeout_in_builtin("sum(range(10**18))", "sum(range(10**18))");
 }
 
+/// Math aggregations must interrupt infinite iterators while inside one native call.
+#[test]
+fn timeout_in_math_aggregations() {
+    for expression in [
+        "math.prod(itertools.repeat(1))",
+        "math.fsum(itertools.repeat(1.0))",
+        "math.dist(itertools.repeat(0), [])",
+        "math.dist([], itertools.repeat(0))",
+        "math.sumprod(itertools.repeat(1), itertools.repeat(1))",
+        "math.sumprod(itertools.repeat(1.0), itertools.repeat(1.0))",
+    ] {
+        assert_timeout_in_builtin(&format!("import math\nimport itertools\n{expression}"), expression);
+    }
+}
+
 /// Test that `list(range(huge))` respects the time limit.
 ///
 /// The `list()` constructor drains its concrete Python iterator.

--- a/docs/limitations/math.md
+++ b/docs/limitations/math.md
@@ -16,20 +16,13 @@ below.
 **Integer math**: `factorial`, `gcd`, `lcm`, `comb`, `perm`.
 **Modular**: `fmod`, `remainder`, `modf`, `frexp`, `ldexp`.
 **Special**: `gamma`, `lgamma`, `erf`, `erfc`.
+**Summation / products**: `hypot`, `dist`, `fsum`, `prod`, `sumprod`, `fma`.
 
 **Constants**: `pi`, `e`, `tau`, `inf`, `nan`.
 
-## Not implemented
-
-`fsum`, `prod`, `hypot`, `dist`, `sumprod`, `nan` from arbitrary
-payloads.
-
 ## Behavioural notes
 
-- `math.asin` / `math.acos` reject inputs outside `[-1, 1]` with
-    `ValueError: "expected a number in range from -1 up to 1, got <x>"`, where
-    CPython says `"math domain error"`.
-- Domain errors (e.g. `log(-1)`) raise `ValueError: "math domain error"`,
-    matching CPython.
-- Overflow (finite input, infinite result) raises `OverflowError: "math range error"`, matching CPython.
-- `math.gamma` rejects non-positive integers (poles) with `ValueError`.
+- Real-number arguments accept floats, integers of any size, and booleans, but do not call user-defined `__float__` or
+    `__index__` methods.
+- `factorial`, `comb`, and `perm` raise `OverflowError` for results exceeding the signed 64-bit integer range.
+    `prod` and integer-only `sumprod` support arbitrary-size integer results.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the missing `math` aggregation functions (`hypot`, `dist`, `fsum`, `prod`, `sumprod`) and `fma`, with CPython-compatible numerics, error messages, and argument handling. Also fixes `at_most_total` arity checks to include keyword-only parameters and supports arbitrary-size integers in real-number conversions.

- `math.prod` and `math.sumprod` preserve arbitrary-size integer results; other real-number functions raise `OverflowError` for integers too large to convert to float.
- `math.prod` takes a keyword-only `start` argument; the other new functions reject keyword arguments.
- New names are appended to the `StaticStrings` and `MathFunctions` enums to preserve serialized IDs, updating the dump fingerprint.

<sup>Written for commit 788d8235a712aa01d8442d79ad9d66c256d307b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

