### PR TITLE
Match CPython for int/float arithmetic on long ints and float pow overflow

### DIFF
--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -890,6 +890,10 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
         ("[None] * 1_000_000", 16_031_391),
         ("2 ** 10_000_000", 10_031_230),
         ("1 << 10_000_000", 1_281_231),
+        // `int / int` scales one operand before dividing; both shift directions are
+        // preflighted.
+        ("x = 1 << 3_000_000\nx / (x - 1)", 1_531_926),
+        ("x = 1 << 3_000_000\nx / (x >> 100)", 1_531_908),
         ("('a' * 1000).replace('a', 'b' * 2000)", 2_034_769),
         // Bulk container clones: `+=` preflights the temp clone plus the target
         // growth, `+` preflights each side's clone.

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -12,7 +12,7 @@ use crate::{
     heap::HeapData,
     resource_checks::check_div_size,
     types::{LongInt, allocate_tuple},
-    value::{Value, floor_divmod},
+    value::{Value, floor_divmod, py_float_divmod},
 };
 
 /// Implementation of the divmod() builtin function.
@@ -76,43 +76,16 @@ pub fn builtin_divmod(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
                 Ok(allocate_tuple(smallvec![quot_val, rem_val], vm.heap))
             }
         }
-        (Value::Float(x), Value::Float(y)) => {
-            if *y == 0.0 {
-                Err(ExcType::divmod_by_zero())
-            } else {
-                let quot = (x / y).floor();
-                let rem = x - quot * y;
-                Ok(allocate_tuple(
-                    smallvec![Value::Float(quot), Value::Float(rem)],
-                    vm.heap,
-                ))
-            }
+        (Value::Float(x), Value::Float(y)) => float_divmod_tuple(*x, *y, vm),
+        (Value::Int(x), Value::Float(y)) => float_divmod_tuple(*x as f64, *y, vm),
+        (Value::Float(x), Value::Int(y)) => float_divmod_tuple(*x, *y as f64, vm),
+        (Value::Float(x), Value::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+            let y = li.to_f64_checked()?;
+            float_divmod_tuple(*x, y, vm)
         }
-        (Value::Int(x), Value::Float(y)) => {
-            if *y == 0.0 {
-                Err(ExcType::divmod_by_zero())
-            } else {
-                let xf = *x as f64;
-                let quot = (xf / y).floor();
-                let rem = xf - quot * y;
-                Ok(allocate_tuple(
-                    smallvec![Value::Float(quot), Value::Float(rem)],
-                    vm.heap,
-                ))
-            }
-        }
-        (Value::Float(x), Value::Int(y)) => {
-            if *y == 0 {
-                Err(ExcType::divmod_by_zero())
-            } else {
-                let yf = *y as f64;
-                let quot = (x / yf).floor();
-                let rem = x - quot * yf;
-                Ok(allocate_tuple(
-                    smallvec![Value::Float(quot), Value::Float(rem)],
-                    vm.heap,
-                ))
-            }
+        (Value::Ref(id), Value::Float(y)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+            let x = li.to_f64_checked()?;
+            float_divmod_tuple(x, *y, vm)
         }
         _ => {
             let a_type = a.py_type_name(vm);
@@ -123,6 +96,19 @@ pub fn builtin_divmod(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
             )
             .into())
         }
+    }
+}
+
+/// Builds the `(quotient, remainder)` tuple for float operands, rejecting a zero divisor.
+fn float_divmod_tuple(x: f64, y: f64, vm: &mut VM<'_>) -> RunResult<Value> {
+    if y == 0.0 {
+        Err(ExcType::divmod_by_zero())
+    } else {
+        let (quot, rem) = py_float_divmod(x, y);
+        Ok(allocate_tuple(
+            smallvec![Value::Float(quot), Value::Float(rem)],
+            vm.heap,
+        ))
     }
 }
 

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -10,8 +10,11 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     heap::{Heap, HeapData},
     resource_checks::check_pow_size,
-    types::{LongInt, PyTrait, long_int::modular_pow},
-    value::Value,
+    types::{
+        LongInt, PyTrait,
+        long_int::{bigint_to_f64_checked, modular_pow},
+    },
+    value::{Value, float_pow},
 };
 
 /// Implementation of the pow() builtin function.
@@ -117,29 +120,15 @@ fn two_arg_pow(base: &Value, exp: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
         {
             longint_pow_longint(b_li.inner(), e_li.inner(), vm.heap)
         }
-        (Value::Float(b), Value::Float(e)) => {
-            if *b == 0.0 && *e < 0.0 {
-                Err(ExcType::zero_negative_power())
-            } else {
-                Ok(Value::Float(b.powf(*e)))
-            }
+        (Value::Ref(id), Value::Float(e)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+            Ok(Value::Float(float_pow(li.to_f64_checked()?, *e)?))
         }
-        (Value::Int(b), Value::Float(e)) => {
-            if *b == 0 && *e < 0.0 {
-                Err(ExcType::zero_negative_power())
-            } else {
-                Ok(Value::Float((*b as f64).powf(*e)))
-            }
+        (Value::Float(b), Value::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+            Ok(Value::Float(float_pow(*b, li.to_f64_checked()?)?))
         }
-        (Value::Float(b), Value::Int(e)) => {
-            if *b == 0.0 && *e < 0 {
-                Err(ExcType::zero_negative_power())
-            } else if let Ok(exp_i32) = i32::try_from(*e) {
-                Ok(Value::Float(b.powi(exp_i32)))
-            } else {
-                Ok(Value::Float(b.powf(*e as f64)))
-            }
-        }
+        (Value::Float(b), Value::Float(e)) => Ok(Value::Float(float_pow(*b, *e)?)),
+        (Value::Int(b), Value::Float(e)) => Ok(Value::Float(float_pow(*b as f64, *e)?)),
+        (Value::Float(b), Value::Int(e)) => Ok(Value::Float(float_pow(*b, *e as f64)?)),
         _ => Err(ExcType::binary_type_error(
             "** or pow()",
             base.py_type(vm),
@@ -187,11 +176,7 @@ fn int_pow_longint(b: i64, e: &BigInt, heap: &Heap) -> RunResult<Value> {
     }
     if e.is_negative() {
         // Negative LongInt exponent: return float
-        if let Some(e_f64) = e.to_f64() {
-            Ok(Value::Float((b as f64).powf(e_f64)))
-        } else {
-            Ok(Value::Float(0.0))
-        }
+        Ok(Value::Float((b as f64).powf(bigint_to_f64_checked(e)?)))
     } else if e.is_zero() {
         // x ** 0 = 1 for all x (including 0 ** 0 = 1)
         Ok(Value::Int(1))
@@ -221,11 +206,7 @@ fn longint_pow_int(b: &BigInt, e: i64, heap: &Heap) -> RunResult<Value> {
     }
     if e < 0 {
         // Negative exponent: return float
-        if let (Some(b_f64), Some(e_f64)) = (b.to_f64(), Some(e as f64)) {
-            Ok(Value::Float(b_f64.powf(e_f64)))
-        } else {
-            Ok(Value::Float(0.0))
-        }
+        Ok(Value::Float(bigint_to_f64_checked(b)?.powf(e as f64)))
     } else if let Ok(exp_u32) = u32::try_from(e) {
         // Check size before computing to prevent DoS
         check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;
@@ -250,11 +231,7 @@ fn longint_pow_longint(b: &BigInt, e: &BigInt, heap: &Heap) -> RunResult<Value> 
     }
     if e.is_negative() {
         // Negative exponent: return float
-        if let (Some(b_f64), Some(e_f64)) = (b.to_f64(), e.to_f64()) {
-            Ok(Value::Float(b_f64.powf(e_f64)))
-        } else {
-            Ok(Value::Float(0.0))
-        }
+        Ok(Value::Float(bigint_to_f64_checked(b)?.powf(bigint_to_f64_checked(e)?)))
     } else if let Some(exp_u32) = e.to_u32() {
         // Check size before computing to prevent DoS
         check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -141,11 +141,8 @@ fn two_arg_pow(base: &Value, exp: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
 /// int ** int with LongInt promotion on overflow.
 fn int_pow_int(b: i64, e: i64, heap: &mut Heap) -> RunResult<Value> {
     if e < 0 {
-        // Negative exponent returns float
-        if b == 0 {
-            return Err(ExcType::zero_negative_power());
-        }
-        Ok(Value::Float((b as f64).powf(e as f64)))
+        // Negative exponent: CPython hands off to `float_pow`
+        Ok(Value::Float(float_pow(b as f64, e as f64)?))
     } else if let Ok(exp_u32) = u32::try_from(e) {
         if let Some(v) = checked_pow_i64(b, exp_u32) {
             Ok(Value::Int(v))
@@ -171,12 +168,9 @@ fn int_pow_int(b: i64, e: i64, heap: &mut Heap) -> RunResult<Value> {
 
 /// int ** LongInt with LongInt result.
 fn int_pow_longint(b: i64, e: &BigInt, heap: &Heap) -> RunResult<Value> {
-    if b == 0 && e.is_negative() {
-        return Err(ExcType::zero_negative_power());
-    }
     if e.is_negative() {
-        // Negative LongInt exponent: return float
-        Ok(Value::Float((b as f64).powf(bigint_to_f64_checked(e)?)))
+        // CPython hands off to `float_pow`, converting the exponent before its zero-base check.
+        Ok(Value::Float(float_pow(b as f64, bigint_to_f64_checked(e)?)?))
     } else if e.is_zero() {
         // x ** 0 = 1 for all x (including 0 ** 0 = 1)
         Ok(Value::Int(1))
@@ -201,12 +195,9 @@ fn int_pow_longint(b: i64, e: &BigInt, heap: &Heap) -> RunResult<Value> {
 
 /// LongInt ** int with LongInt result.
 fn longint_pow_int(b: &BigInt, e: i64, heap: &Heap) -> RunResult<Value> {
-    if b.is_zero() && e < 0 {
-        return Err(ExcType::zero_negative_power());
-    }
     if e < 0 {
-        // Negative exponent: return float
-        Ok(Value::Float(bigint_to_f64_checked(b)?.powf(e as f64)))
+        // Negative exponent: CPython hands off to `float_pow`
+        Ok(Value::Float(float_pow(bigint_to_f64_checked(b)?, e as f64)?))
     } else if let Ok(exp_u32) = u32::try_from(e) {
         // Check size before computing to prevent DoS
         check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;
@@ -226,12 +217,12 @@ fn longint_pow_int(b: &BigInt, e: i64, heap: &Heap) -> RunResult<Value> {
 
 /// LongInt ** LongInt with LongInt result.
 fn longint_pow_longint(b: &BigInt, e: &BigInt, heap: &Heap) -> RunResult<Value> {
-    if b.is_zero() && e.is_negative() {
-        return Err(ExcType::zero_negative_power());
-    }
     if e.is_negative() {
-        // Negative exponent: return float
-        Ok(Value::Float(bigint_to_f64_checked(b)?.powf(bigint_to_f64_checked(e)?)))
+        // Negative exponent: CPython hands off to `float_pow`
+        Ok(Value::Float(float_pow(
+            bigint_to_f64_checked(b)?,
+            bigint_to_f64_checked(e)?,
+        )?))
     } else if let Some(exp_u32) = e.to_u32() {
         // Check size before computing to prevent DoS
         check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1538,6 +1538,18 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::OverflowError, "int too large to convert to float").into()
     }
 
+    /// Creates the OverflowError raised when a float power overflows; CPython reports C's `ERANGE`.
+    #[must_use]
+    fn overflow_float_pow() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "(34, 'Result too large')").into()
+    }
+
+    /// Creates the OverflowError raised when `int / int` has a quotient beyond the float range.
+    #[must_use]
+    fn overflow_int_division_to_float() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "integer division result too large for a float").into()
+    }
+
     /// Creates the OverflowError raised when converting an infinite float to an integer.
     #[must_use]
     fn overflow_float_infinity_to_integer() -> RunError {

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1538,10 +1538,13 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::OverflowError, "int too large to convert to float").into()
     }
 
-    /// Creates the OverflowError raised when a float power overflows; CPython reports C's `ERANGE`.
+    /// Creates the OverflowError raised when a float power overflows.
+    ///
+    /// CPython reports C's `ERANGE` through `strerror`, whose wording depends on the host libc;
+    /// Monty always uses glibc's so sandboxed code sees the same message on every platform.
     #[must_use]
     fn overflow_float_pow() -> RunError {
-        SimpleException::new_msg(ExcType::OverflowError, "(34, 'Result too large')").into()
+        SimpleException::new_msg(ExcType::OverflowError, "(34, 'Numerical result out of range')").into()
     }
 
     /// Creates the OverflowError raised when `int / int` has a quotient beyond the float range.

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -16,6 +16,7 @@ use std::{
     sync::OnceLock,
 };
 
+use monty_types::ResourceTracker;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
@@ -558,12 +559,12 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
     fn py_truediv_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let lhs = self.get(vm.heap);
         let result = match other {
-            Value::Int(rhs) => bigint_true_divide(lhs.inner(), &BigInt::from(*rhs))?,
-            Value::Bool(rhs) => bigint_true_divide(lhs.inner(), &BigInt::from(*rhs))?,
+            Value::Int(rhs) => bigint_true_divide(lhs.inner(), &BigInt::from(*rhs), &vm.heap.tracker)?,
+            Value::Bool(rhs) => bigint_true_divide(lhs.inner(), &BigInt::from(*rhs), &vm.heap.tracker)?,
             Value::Float(0.0) => return Err(ExcType::zero_division().into()),
             Value::Float(rhs) => lhs.to_f64_checked()? / rhs,
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
-                bigint_true_divide(lhs.inner(), rhs.inner())?
+                bigint_true_divide(lhs.inner(), rhs.inner(), &vm.heap.tracker)?
             }
             _ => return Ok(None),
         };
@@ -574,8 +575,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         // A long divisor is never zero: zero always fits in `i64`.
         let rhs = self.get(vm.heap);
         let result = match other {
-            Value::Int(lhs) => bigint_true_divide(&BigInt::from(*lhs), rhs.inner())?,
-            Value::Bool(lhs) => bigint_true_divide(&BigInt::from(*lhs), rhs.inner())?,
+            Value::Int(lhs) => bigint_true_divide(&BigInt::from(*lhs), rhs.inner(), &vm.heap.tracker)?,
+            Value::Bool(lhs) => bigint_true_divide(&BigInt::from(*lhs), rhs.inner(), &vm.heap.tracker)?,
             Value::Float(lhs) => lhs / rhs.to_f64_checked()?,
             _ => return Ok(None),
         };
@@ -823,7 +824,10 @@ pub(crate) fn bigint_to_f64_checked(value: &BigInt) -> RunResult<f64> {
 /// Converting each operand to `f64` first rounds twice, and overflows whenever an operand
 /// exceeds the float range even though the quotient fits. Instead the integer quotient is
 /// computed with two extra bits plus a sticky bit and rounded half-to-even exactly once.
-pub(crate) fn bigint_true_divide(a: &BigInt, b: &BigInt) -> RunResult<f64> {
+///
+/// The scaled operand and the remainder are temporaries of about the operands' size, so
+/// they are preflighted against `tracker` like any other division before being allocated.
+pub(crate) fn bigint_true_divide(a: &BigInt, b: &BigInt, tracker: &ResourceTracker) -> RunResult<f64> {
     const MANT_DIG: i64 = f64::MANTISSA_DIGITS as i64;
     const MIN_EXP: i64 = f64::MIN_EXP as i64;
     const MAX_EXP: i64 = f64::MAX_EXP as i64;
@@ -849,6 +853,9 @@ pub(crate) fn bigint_true_divide(a: &BigInt, b: &BigInt) -> RunResult<f64> {
         // Scale so the integer quotient has 55 bits, fewer only when the result is subnormal
         // and the rounding position moves up accordingly.
         let shift = diff.max(MIN_EXP) - MANT_DIG - 2;
+        // Peak temporaries: the shifted operand plus a remainder smaller than the divisor.
+        let shifted_bits = if shift <= 0 { bits(a) + shift.abs() } else { bits(a) };
+        check_div_size((shifted_bits + bits(b)).unsigned_abs(), tracker)?;
         let (quotient, remainder) = if shift <= 0 {
             (a << shift.unsigned_abs()).div_rem(b)
         } else {

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -16,7 +16,7 @@ use std::{
     sync::OnceLock,
 };
 
-use num_bigint::BigInt;
+use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
 
@@ -27,7 +27,7 @@ use crate::{
     heap::{Heap, HeapData, HeapObjectRead, HeapRead},
     resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size},
     types::{LazyHeapSet, PyTrait, Type, str::allocate_string},
-    value::{Value, eq_bigint},
+    value::{Value, eq_bigint, float_pow, py_float_divmod, py_float_mod},
 };
 
 /// Maximum number of decimal digits allowed for integer-string conversion.
@@ -159,6 +159,13 @@ impl LongInt {
     /// is too large to represent as f64.
     pub fn to_f64(&self) -> Option<f64> {
         self.0.to_f64()
+    }
+
+    /// Converts to `f64`, raising `OverflowError` when the magnitude exceeds the float range.
+    ///
+    /// Mirrors CPython's `PyLong_AsDouble`, which every mixed int/float operation goes through.
+    pub fn to_f64_checked(&self) -> RunResult<f64> {
+        bigint_to_f64_checked(&self.0)
     }
 
     /// Compares this integer against an `f64` *exactly* (no precision loss).
@@ -439,7 +446,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         let result = match other {
             Value::Int(rhs) => lhs.inner() + rhs,
             Value::Bool(rhs) => lhs.inner() + i64::from(*rhs),
-            Value::Float(rhs) => return Ok(Some(Value::Float(long_int_to_f64(lhs) + rhs))),
+            Value::Float(rhs) => return Ok(Some(Value::Float(lhs.to_f64_checked()? + rhs))),
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => lhs.inner() + rhs.inner(),
             _ => return Ok(None),
         };
@@ -469,7 +476,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         let result = match other {
             Value::Int(rhs) => lhs.inner() - rhs,
             Value::Bool(rhs) => lhs.inner() - i64::from(*rhs),
-            Value::Float(rhs) => return Ok(Some(Value::Float(long_int_to_f64(lhs) - rhs))),
+            Value::Float(rhs) => return Ok(Some(Value::Float(lhs.to_f64_checked()? - rhs))),
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => lhs.inner() - rhs.inner(),
             _ => return Ok(None),
         };
@@ -481,7 +488,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         let result = match other {
             Value::Int(lhs) => BigInt::from(*lhs) - rhs.inner(),
             Value::Bool(lhs) => BigInt::from(*lhs) - rhs.inner(),
-            Value::Float(lhs) => return Ok(Some(Value::Float(lhs - long_int_to_f64(rhs)))),
+            Value::Float(lhs) => return Ok(Some(Value::Float(lhs - rhs.to_f64_checked()?))),
             Value::Ref(id) if let HeapData::LongInt(lhs) = vm.heap.get(*id) => lhs.inner() - rhs.inner(),
             _ => return Ok(None),
         };
@@ -494,6 +501,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
             Value::Int(0) | Value::Bool(false) => return Err(ExcType::zero_division().into()),
             Value::Int(rhs) => lhs.mod_floor(&BigInt::from(*rhs)),
             Value::Bool(true) => BigInt::ZERO,
+            Value::Float(0.0) => return Err(ExcType::zero_division().into()),
+            Value::Float(rhs) => return Ok(Some(Value::Float(py_float_mod(bigint_to_f64_checked(lhs)?, *rhs)))),
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
                 if rhs.is_zero() {
                     return Err(ExcType::zero_division().into());
@@ -513,6 +522,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         let result = match other {
             Value::Int(lhs) => BigInt::from(*lhs).mod_floor(rhs.inner()),
             Value::Bool(lhs) => BigInt::from(*lhs).mod_floor(rhs.inner()),
+            Value::Float(lhs) => return Ok(Some(Value::Float(py_float_mod(*lhs, rhs.to_f64_checked()?)))),
             Value::Ref(id) if let HeapData::LongInt(lhs) = vm.heap.get(*id) => lhs.inner().mod_floor(rhs.inner()),
             _ => return Ok(None),
         };
@@ -531,7 +541,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
             } else {
                 Value::Int(0)
             }),
-            Value::Float(rhs) => Some(Value::Float(long_int_to_f64(lhs) * rhs)),
+            Value::Float(rhs) => Some(Value::Float(lhs.to_f64_checked()? * rhs)),
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
                 check_mult_size(lhs.bits(), rhs.bits(), &vm.heap.tracker)?;
                 Some(LongInt::new(lhs.inner() * rhs.inner()).into_value(vm.heap))
@@ -547,35 +557,29 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
 
     fn py_truediv_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let lhs = self.get(vm.heap);
-        let rhs = match other {
-            Value::Int(0) | Value::Bool(false) => return Err(ExcType::zero_division().into()),
-            Value::Int(rhs) => *rhs as f64,
-            Value::Bool(true) => 1.0,
+        let result = match other {
+            Value::Int(rhs) => bigint_true_divide(lhs.inner(), &BigInt::from(*rhs))?,
+            Value::Bool(rhs) => bigint_true_divide(lhs.inner(), &BigInt::from(*rhs))?,
             Value::Float(0.0) => return Err(ExcType::zero_division().into()),
-            Value::Float(rhs) => *rhs,
+            Value::Float(rhs) => lhs.to_f64_checked()? / rhs,
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
-                if rhs.is_zero() {
-                    return Err(ExcType::zero_division().into());
-                }
-                long_int_to_f64(rhs)
+                bigint_true_divide(lhs.inner(), rhs.inner())?
             }
             _ => return Ok(None),
         };
-        Ok(Some(Value::Float(long_int_to_f64(lhs) / rhs)))
+        Ok(Some(Value::Float(result)))
     }
 
     fn py_rtruediv_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        // A long divisor is never zero: zero always fits in `i64`.
         let rhs = self.get(vm.heap);
-        if rhs.is_zero() {
-            return Err(ExcType::zero_division().into());
-        }
-        let lhs = match other {
-            Value::Int(lhs) => *lhs as f64,
-            Value::Bool(lhs) => f64::from(*lhs),
-            Value::Float(lhs) => *lhs,
+        let result = match other {
+            Value::Int(lhs) => bigint_true_divide(&BigInt::from(*lhs), rhs.inner())?,
+            Value::Bool(lhs) => bigint_true_divide(&BigInt::from(*lhs), rhs.inner())?,
+            Value::Float(lhs) => lhs / rhs.to_f64_checked()?,
             _ => return Ok(None),
         };
-        Ok(Some(Value::Float(lhs / long_int_to_f64(rhs))))
+        Ok(Some(Value::Float(result)))
     }
 
     fn py_floordiv_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
@@ -587,6 +591,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
                 lhs.inner().div_floor(&BigInt::from(*rhs))
             }
             Value::Bool(true) => lhs.inner().clone(),
+            Value::Float(0.0) => return Err(ExcType::zero_division().into()),
+            Value::Float(rhs) => return Ok(Some(Value::Float(py_float_divmod(lhs.to_f64_checked()?, *rhs).0))),
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
                 if rhs.is_zero() {
                     return Err(ExcType::zero_division().into());
@@ -607,6 +613,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         let lhs = match other {
             Value::Int(lhs) => *lhs,
             Value::Bool(lhs) => i64::from(*lhs),
+            Value::Float(lhs) => return Ok(Some(Value::Float(py_float_divmod(*lhs, rhs.to_f64_checked()?).0))),
             _ => return Ok(None),
         };
         check_div_size(i64_bits(lhs), &vm.heap.tracker)?;
@@ -624,13 +631,16 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
     }
 
     fn py_rpow_impl(&self, other: &Value, modulus: Option<&Value>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        let exponent = self.get(vm.heap);
         if modulus.is_some() {
             Ok(None)
+        } else if let Value::Float(base) = other {
+            Ok(Some(Value::Float(float_pow(*base, exponent.to_f64_checked()?)?)))
         } else {
             let Some(base) = integer_value(other, vm.heap) else {
                 return Ok(None);
             };
-            long_int_pow_value(base.as_ref(), self.get(vm.heap).inner(), vm.heap)
+            long_int_pow_value(base.as_ref(), exponent.inner(), vm.heap)
         }
     }
 
@@ -757,10 +767,7 @@ pub(crate) fn modular_pow(base: &BigInt, exponent: &Value, modulus: &Value, heap
 /// Raises a long integer to another integer value.
 fn long_int_pow(base: &LongInt, exponent: &Value, heap: &Heap) -> RunResult<Option<Value>> {
     if let Value::Float(exponent) = exponent {
-        if base.is_zero() && *exponent < 0.0 {
-            return Err(ExcType::zero_negative_power());
-        }
-        return Ok(Some(Value::Float(long_int_to_f64(base).powf(*exponent))));
+        return Ok(Some(Value::Float(float_pow(base.to_f64_checked()?, *exponent)?)));
     }
     let Some(exponent) = integer_value(exponent, heap) else {
         return Ok(None);
@@ -777,7 +784,7 @@ fn long_int_pow_value(base: &BigInt, exponent: &BigInt, heap: &Heap) -> RunResul
             .to_f64()
             .filter(|exponent| exponent.is_finite())
             .ok_or_else(ExcType::overflow_int_to_float)?;
-        Ok(Some(Value::Float(bigint_to_f64(base).powf(exponent))))
+        Ok(Some(Value::Float(float_pow(bigint_to_f64_checked(base)?, exponent)?)))
     } else if exponent.is_zero() || base.is_one() {
         Ok(Some(Value::Int(1)))
     } else if base.is_zero() {
@@ -802,20 +809,69 @@ fn integer_value<'a>(value: &'a Value, heap: &'a Heap) -> Option<Cow<'a, BigInt>
     }
 }
 
-/// Converts a long integer to float, preserving its sign on overflow.
-fn long_int_to_f64(value: &LongInt) -> f64 {
-    bigint_to_f64(value.inner())
+/// Converts an arbitrary-precision integer to float, raising `OverflowError` when out of range.
+///
+/// `to_f64` yields infinity for magnitudes past `f64::MAX`; Python raises instead of
+/// letting that infinity leak into arithmetic.
+pub(crate) fn bigint_to_f64_checked(value: &BigInt) -> RunResult<f64> {
+    value
+        .to_f64()
+        .filter(|f| f.is_finite())
+        .ok_or_else(ExcType::overflow_int_to_float)
 }
 
-/// Converts an arbitrary-precision integer to float, preserving its sign on overflow.
-fn bigint_to_f64(value: &BigInt) -> f64 {
-    value.to_f64().unwrap_or_else(|| {
-        if value.is_negative() {
-            f64::NEG_INFINITY
+/// Divides two integers to a single correctly rounded `f64`, after CPython's `long_true_divide`.
+///
+/// Converting each operand to `f64` first rounds twice, and overflows whenever an operand
+/// exceeds the float range even though the quotient fits. Instead the integer quotient is
+/// computed with two extra bits plus a sticky bit and rounded half-to-even exactly once.
+pub(crate) fn bigint_true_divide(a: &BigInt, b: &BigInt) -> RunResult<f64> {
+    const MANT_DIG: i64 = f64::MANTISSA_DIGITS as i64;
+    const MIN_EXP: i64 = f64::MIN_EXP as i64;
+    const MAX_EXP: i64 = f64::MAX_EXP as i64;
+    if b.is_zero() {
+        return Err(ExcType::zero_division().into());
+    }
+    let negative = a.is_negative() != b.is_negative();
+    let (a, b) = (a.magnitude(), b.magnitude());
+    let bits = |value: &BigUint| i64::try_from(value.bits()).unwrap_or(i64::MAX);
+    // The quotient lies in `[2^(diff-1), 2^(diff+1))`.
+    let diff = bits(a) - bits(b);
+    let magnitude = if bits(a) <= MANT_DIG && bits(b) <= MANT_DIG {
+        // Both operands are exact floats, so hardware division rounds once.
+        Ok(a.to_f64().unwrap_or(f64::NAN) / b.to_f64().unwrap_or(f64::NAN))
+    } else if diff > MAX_EXP {
+        Err(ExcType::overflow_int_division_to_float())
+    } else if diff < MIN_EXP - MANT_DIG - 1 {
+        Ok(0.0)
+    } else {
+        // Scale so the integer quotient has 55 bits, fewer only when the result is subnormal
+        // and the rounding position moves up accordingly.
+        let shift = diff.max(MIN_EXP) - MANT_DIG - 2;
+        let (quotient, remainder) = if shift <= 0 {
+            (a << shift.unsigned_abs()).div_rem(b)
         } else {
-            f64::INFINITY
+            a.div_rem(&(b << shift.unsigned_abs()))
+        };
+        let quotient = quotient.to_u64().unwrap_or(u64::MAX);
+        let quotient_bits = 64 - quotient.leading_zeros();
+        // Round half-to-even at `extra_bits` (at least 2), with the remainder as a sticky bit.
+        let extra_bits = i64::from(quotient_bits).max(MIN_EXP - shift) - MANT_DIG;
+        let half = 1u64 << u32::try_from(extra_bits - 1).unwrap_or(0);
+        let mut low = quotient | u64::from(!remainder.is_zero());
+        if low & half != 0 && low & (3 * half - 1) != 0 {
+            low += half;
         }
-    })
+        let rounded = low & !(2 * half - 1);
+        let exponent = shift + i64::from(quotient_bits);
+        // A rounding carry to `2^quotient_bits` can push the result past the float range.
+        if exponent > MAX_EXP || (exponent == MAX_EXP && rounded == 1u64 << quotient_bits) {
+            Err(ExcType::overflow_int_division_to_float())
+        } else {
+            Ok(libm::ldexp(rounded as f64, i32::try_from(shift).unwrap_or(i32::MIN)))
+        }
+    }?;
+    Ok(if negative { -magnitude } else { magnitude })
 }
 
 /// Raises a `BigInt` to a `u64` exponent without truncating the exponent.

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -777,14 +777,12 @@ fn long_int_pow(base: &LongInt, exponent: &Value, heap: &Heap) -> RunResult<Opti
 
 /// Raises one arbitrary-precision integer to another.
 fn long_int_pow_value(base: &BigInt, exponent: &BigInt, heap: &Heap) -> RunResult<Option<Value>> {
-    if base.is_zero() && exponent.is_negative() {
-        Err(ExcType::zero_negative_power())
-    } else if exponent.is_negative() {
-        let exponent = exponent
-            .to_f64()
-            .filter(|exponent| exponent.is_finite())
-            .ok_or_else(ExcType::overflow_int_to_float)?;
-        Ok(Some(Value::Float(float_pow(bigint_to_f64_checked(base)?, exponent)?)))
+    if exponent.is_negative() {
+        // CPython hands off to `float_pow`, converting both operands before its zero-base check.
+        Ok(Some(Value::Float(float_pow(
+            bigint_to_f64_checked(base)?,
+            bigint_to_f64_checked(exponent)?,
+        )?)))
     } else if exponent.is_zero() || base.is_one() {
         Ok(Some(Value::Int(1)))
     } else if base.is_zero() {
@@ -833,6 +831,9 @@ pub(crate) fn bigint_true_divide(a: &BigInt, b: &BigInt) -> RunResult<f64> {
         return Err(ExcType::zero_division().into());
     }
     let negative = a.is_negative() != b.is_negative();
+    if a.is_zero() {
+        return Ok(if negative { -0.0 } else { 0.0 });
+    }
     let (a, b) = (a.magnitude(), b.magnitude());
     let bits = |value: &BigUint| i64::try_from(value.bits()).unwrap_or(i64::MAX);
     // The quotient lies in `[2^(diff-1), 2^(diff+1))`.

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -854,8 +854,12 @@ pub(crate) fn bigint_true_divide(a: &BigInt, b: &BigInt, tracker: &ResourceTrack
         // and the rounding position moves up accordingly.
         let shift = diff.max(MIN_EXP) - MANT_DIG - 2;
         // Peak temporaries: the shifted operand plus a remainder smaller than the divisor.
-        let shifted_bits = if shift <= 0 { bits(a) + shift.abs() } else { bits(a) };
-        check_div_size((shifted_bits + bits(b)).unsigned_abs(), tracker)?;
+        let temporary_bits = if shift <= 0 {
+            bits(a) + shift.abs() + bits(b)
+        } else {
+            2 * (bits(b) + shift)
+        };
+        check_div_size(temporary_bits.unsigned_abs(), tracker)?;
         let (quotient, remainder) = if shift <= 0 {
             (a << shift.unsigned_abs()).div_rem(b)
         } else {

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -18,7 +18,7 @@ use crate::{
         date, datetime,
         dict::{DictKind, dict_fromkeys},
         instance::class_name,
-        long_int::INT_MAX_STR_DIGITS,
+        long_int::{INT_MAX_STR_DIGITS, bigint_to_f64_checked},
         str::StringRepr,
         time, timedelta,
     },
@@ -576,8 +576,10 @@ impl Type {
                     Value::InternString(string_id) => {
                         Ok(Value::Float(parse_f64_from_str(interns.get_str(*string_id))?))
                     }
+                    Value::InternLongInt(id) => Ok(Value::Float(bigint_to_f64_checked(interns.get_long_int(*id))?)),
                     Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
                         HeapData::Str(s) => Ok(Value::Float(parse_f64_from_str(s.as_str())?)),
+                        HeapData::LongInt(value) => Ok(Value::Float(value.to_f64_checked()?)),
                         _ => Err(ExcType::type_error_float_conversion(&v.py_type_name(vm))),
                     },
                     _ => Err(ExcType::type_error_float_conversion(&v.py_type_name(vm))),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -2547,11 +2547,12 @@ pub(crate) fn py_float_divmod(a: f64, b: f64) -> (f64, f64) {
 
 /// Raises `base` to `exp` with CPython's `float_pow` error rules.
 ///
-/// Zero to a negative power is `ZeroDivisionError`, and finite operands whose result
-/// overflows raise `OverflowError` where C's `pow` would set `ERANGE`. Infinite or NaN
-/// operands pass straight through `powf`, whose special cases match C99 `pow`.
+/// Zero to a finite negative power is `ZeroDivisionError`, and finite operands whose
+/// result overflows raise `OverflowError` where C's `pow` would set `ERANGE`. Infinite or
+/// NaN operands pass straight through `powf`, whose special cases match C99 `pow`
+/// (so `0.0 ** -inf` is `inf`, not an error).
 pub(crate) fn float_pow(base: f64, exp: f64) -> RunResult<f64> {
-    if base == 0.0 && exp < 0.0 {
+    if base == 0.0 && exp.is_finite() && exp < 0.0 {
         Err(ExcType::zero_negative_power())
     } else {
         let result = base.powf(exp);

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -30,8 +30,8 @@ use crate::{
         host_class_type,
         instance::{instance_dataclass_eq, instance_getattr, instance_str, instance_user_eq},
         long_int::{
-            bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
-            repeat_count, wide_i128_into_value,
+            bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, bigint_true_divide,
+            check_bits_str_digits_limit, i64_cmp_f64, repeat_count, wide_i128_into_value,
         },
         namedtuple::cmp_item_seqs,
         slice::slice_collect_iterator,
@@ -774,8 +774,15 @@ impl<'h> PyTrait<'h> for Value {
             (Self::Int(a), Self::Int(b)) => {
                 if *b == 0 {
                     Err(ExcType::zero_division().into())
-                } else {
+                } else if a.unsigned_abs() <= 1 << f64::MANTISSA_DIGITS && b.unsigned_abs() <= 1 << f64::MANTISSA_DIGITS
+                {
                     Ok(Some(Self::Float(*a as f64 / *b as f64)))
+                } else {
+                    // Rounding each operand to `f64` first would round the quotient twice.
+                    Ok(Some(Self::Float(bigint_true_divide(
+                        &BigInt::from(*a),
+                        &BigInt::from(*b),
+                    )?)))
                 }
             }
             (Self::Float(a), Self::Float(b)) => {
@@ -870,21 +877,21 @@ impl<'h> PyTrait<'h> for Value {
                 if *b == 0.0 {
                     Err(ExcType::zero_division().into())
                 } else {
-                    Ok(Some(Self::Float((a / b).floor())))
+                    Ok(Some(Self::Float(py_float_divmod(*a, *b).0)))
                 }
             }
             (Self::Int(a), Self::Float(b)) => {
                 if *b == 0.0 {
                     Err(ExcType::zero_division().into())
                 } else {
-                    Ok(Some(Self::Float((*a as f64 / b).floor())))
+                    Ok(Some(Self::Float(py_float_divmod(*a as f64, *b).0)))
                 }
             }
             (Self::Float(a), Self::Int(b)) => {
                 if *b == 0 {
                     Err(ExcType::zero_division().into())
                 } else {
-                    Ok(Some(Self::Float((a / *b as f64).floor())))
+                    Ok(Some(Self::Float(py_float_divmod(*a, *b as f64).0)))
                 }
             }
             // Bool floor division (True=1, False=0)
@@ -1047,31 +1054,9 @@ impl<'h> PyTrait<'h> for Value {
                         }
                     }
                 }
-                (Self::Float(base), Self::Float(exp)) => {
-                    if *base == 0.0 && *exp < 0.0 {
-                        Err(ExcType::zero_negative_power())
-                    } else {
-                        Ok(Some(Self::Float(base.powf(*exp))))
-                    }
-                }
-                (Self::Int(base), Self::Float(exp)) => {
-                    if *base == 0 && *exp < 0.0 {
-                        Err(ExcType::zero_negative_power())
-                    } else {
-                        Ok(Some(Self::Float((*base as f64).powf(*exp))))
-                    }
-                }
-                (Self::Float(base), Self::Int(exp)) => {
-                    if *base == 0.0 && *exp < 0 {
-                        Err(ExcType::zero_negative_power())
-                    } else if let Ok(exp_i32) = i32::try_from(*exp) {
-                        // Use powi if exp fits in i32
-                        Ok(Some(Self::Float(base.powi(exp_i32))))
-                    } else {
-                        // Fall back to powf for exponents outside i32 range
-                        Ok(Some(Self::Float(base.powf(*exp as f64))))
-                    }
-                }
+                (Self::Float(base), Self::Float(exp)) => Ok(Some(Self::Float(float_pow(*base, *exp)?))),
+                (Self::Int(base), Self::Float(exp)) => Ok(Some(Self::Float(float_pow(*base as f64, *exp)?))),
+                (Self::Float(base), Self::Int(exp)) => Ok(Some(Self::Float(float_pow(*base, *exp as f64)?))),
                 // Bool power operations (True=1, False=0)
                 (Self::Bool(base), Self::Int(exp)) => {
                     let base_int = i64::from(*base);
@@ -1104,14 +1089,7 @@ impl<'h> PyTrait<'h> for Value {
                         Ok(Some(Self::Int(1)))
                     }
                 }
-                (Self::Bool(base), Self::Float(exp)) => {
-                    let base_float = f64::from(*base);
-                    if base_float == 0.0 && *exp < 0.0 {
-                        Err(ExcType::zero_negative_power())
-                    } else {
-                        Ok(Some(Self::Float(base_float.powf(*exp))))
-                    }
-                }
+                (Self::Bool(base), Self::Float(exp)) => Ok(Some(Self::Float(float_pow(f64::from(*base), *exp)?))),
                 (Self::Float(base), Self::Bool(exp)) => {
                     // base ** True = base, base ** False = 1.0
                     if *exp {
@@ -2542,13 +2520,56 @@ pub(crate) fn floor_divmod(a: i64, b: i64) -> Option<(i64, i64)> {
     }
 }
 
+/// Computes Python-style float floor division and modulo together (CPython's `float_divmod`).
+///
+/// The remainder comes from `fmod` adjusted to the divisor's sign, and the quotient is
+/// floored from the exactly adjusted dividend rather than from `a / b`, which keeps
+/// `quotient * b + remainder == a` as close as floats allow. Callers must reject a zero
+/// divisor first; this helper assumes `b != 0`.
+pub(crate) fn py_float_divmod(a: f64, b: f64) -> (f64, f64) {
+    let mut modulus = a % b;
+    let mut div = (a - modulus) / b;
+    if modulus == 0.0 {
+        modulus = 0.0f64.copysign(b);
+    } else if (b < 0.0) != (modulus < 0.0) {
+        modulus += b;
+        div -= 1.0;
+    }
+    let floordiv = if div == 0.0 {
+        0.0f64.copysign(a / b)
+    } else {
+        // `div` is within an ulp of an integer; an excess above one half means it rounded down.
+        let floordiv = div.floor();
+        if div - floordiv > 0.5 { floordiv + 1.0 } else { floordiv }
+    };
+    (floordiv, modulus)
+}
+
+/// Raises `base` to `exp` with CPython's `float_pow` error rules.
+///
+/// Zero to a negative power is `ZeroDivisionError`, and finite operands whose result
+/// overflows raise `OverflowError` where C's `pow` would set `ERANGE`. Infinite or NaN
+/// operands pass straight through `powf`, whose special cases match C99 `pow`.
+pub(crate) fn float_pow(base: f64, exp: f64) -> RunResult<f64> {
+    if base == 0.0 && exp < 0.0 {
+        Err(ExcType::zero_negative_power())
+    } else {
+        let result = base.powf(exp);
+        if result.is_infinite() && base.is_finite() && exp.is_finite() {
+            Err(ExcType::overflow_float_pow())
+        } else {
+            Ok(result)
+        }
+    }
+}
+
 /// Computes Python-style float modulo (CPython's `float_rem`).
 ///
 /// Unlike Rust's `%` (which follows the dividend's sign), the result takes the
 /// divisor's sign — `-7.0 % 3.0 == 2.0` — and a zero result gets the divisor's
 /// sign too (`6.0 % -3.0 == -0.0`). Callers must reject a zero divisor first
 /// (`ZeroDivisionError`); this helper assumes `b != 0`.
-fn py_float_mod(a: f64, b: f64) -> f64 {
+pub(crate) fn py_float_mod(a: f64, b: f64) -> f64 {
     let r = a % b;
     if r == 0.0 {
         0.0f64.copysign(b)

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1019,9 +1019,7 @@ impl<'h> PyTrait<'h> for Value {
         } else {
             match (self, other) {
                 (Self::Int(base), Self::Int(exp)) => {
-                    if *base == 0 && *exp < 0 {
-                        Err(ExcType::zero_negative_power())
-                    } else if *exp >= 0 {
+                    if *exp >= 0 {
                         // Positive exponent: try to return int, promote to LongInt on overflow
                         if let Ok(exp_u32) = u32::try_from(*exp) {
                             if let Some(result) = base.checked_pow(exp_u32) {
@@ -1045,13 +1043,8 @@ impl<'h> PyTrait<'h> for Value {
                             Ok(Some(LongInt::new(bi).into_value(vm.heap)))
                         }
                     } else {
-                        // Negative exponent: return float
-                        // Use powi if exp fits in i32, otherwise use powf
-                        if let Ok(exp_i32) = i32::try_from(*exp) {
-                            Ok(Some(Self::Float((*base as f64).powi(exp_i32))))
-                        } else {
-                            Ok(Some(Self::Float((*base as f64).powf(*exp as f64))))
-                        }
+                        // Negative exponent: CPython hands off to `float_pow`
+                        Ok(Some(Self::Float(float_pow(*base as f64, *exp as f64)?)))
                     }
                 }
                 (Self::Float(base), Self::Float(exp)) => Ok(Some(Self::Float(float_pow(*base, *exp)?))),
@@ -1060,9 +1053,7 @@ impl<'h> PyTrait<'h> for Value {
                 // Bool power operations (True=1, False=0)
                 (Self::Bool(base), Self::Int(exp)) => {
                     let base_int = i64::from(*base);
-                    if base_int == 0 && *exp < 0 {
-                        Err(ExcType::zero_negative_power())
-                    } else if *exp >= 0 {
+                    if *exp >= 0 {
                         // Positive exponent: 1**n=1, 0**n=0 (for n>0), 0**0=1
                         if let Ok(exp_u32) = u32::try_from(*exp) {
                             match base_int.checked_pow(exp_u32) {
@@ -1073,12 +1064,8 @@ impl<'h> PyTrait<'h> for Value {
                             Ok(Some(Self::Float((base_int as f64).powf(*exp as f64))))
                         }
                     } else {
-                        // Negative exponent: return float (1**-n=1.0)
-                        if let Ok(exp_i32) = i32::try_from(*exp) {
-                            Ok(Some(Self::Float((base_int as f64).powi(exp_i32))))
-                        } else {
-                            Ok(Some(Self::Float((base_int as f64).powf(*exp as f64))))
-                        }
+                        // Negative exponent: CPython hands off to `float_pow`
+                        Ok(Some(Self::Float(float_pow(base_int as f64, *exp as f64)?)))
                     }
                 }
                 (Self::Int(base), Self::Bool(exp)) => {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -782,6 +782,7 @@ impl<'h> PyTrait<'h> for Value {
                     Ok(Some(Self::Float(bigint_true_divide(
                         &BigInt::from(*a),
                         &BigInt::from(*b),
+                        &vm.heap.tracker,
                     )?)))
                 }
             }

--- a/crates/monty/test_cases/float__pow.py
+++ b/crates/monty/test_cases/float__pow.py
@@ -1,0 +1,76 @@
+# === Overflow raises like CPython's float_pow ===
+for compute in [
+    lambda: 1.5**10000,
+    lambda: 10.0**400,
+    lambda: 10**400.0,
+    lambda: (-10.0) ** 401,
+    lambda: (-1.5) ** 10000,
+    lambda: (2**70) ** 15.0,
+    lambda: 1.5 ** (2**70),
+    lambda: 2.0**1024,
+    lambda: pow(1.5, 10000),
+    lambda: pow(10, 400.0),
+    lambda: pow(2**70, 15.0),
+    lambda: pow(1.5, 2**70),
+]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) == "(34, 'Result too large')"
+
+x = 10.0
+try:
+    x **= 400
+    assert False, 'expected OverflowError'
+except OverflowError as e:
+    assert str(e) == "(34, 'Result too large')"
+
+# === Infinite and NaN operands never raise ===
+inf = float('inf')
+nan = float('nan')
+assert inf**2 == inf
+assert 2.0**inf == inf
+assert 0.5**inf == 0.0
+assert (-1.5) ** inf == inf
+assert (-1.0) ** inf == 1.0
+assert 2.0**-inf == 0.0
+assert inf**-1 == 0.0
+assert (-inf) ** 3 == -inf
+assert (-inf) ** 2 == inf
+assert 1.0**nan == 1.0
+assert nan**0 == 1.0
+assert str(nan**2) == 'nan'
+assert str(2.0**nan) == 'nan'
+assert pow(inf, 2) == inf
+assert pow(2**70, inf) == inf
+
+# === Underflow is silent ===
+assert 2.0**-10000 == 0.0
+assert 0.5**10000 == 0.0
+assert 10**-400.0 == 0.0
+assert pow(1.5, -10000) == 0.0
+assert 2 ** -(2**70) == 0.0
+
+# === Zero to a negative power ===
+for compute in [
+    lambda: 0.0**-1,
+    lambda: 0**-1.0,
+    lambda: 0.0**-1.5,
+    lambda: pow(0.0, -2),
+    lambda: False**-1.0,
+    lambda: 0.0 ** -(2**70),
+]:
+    try:
+        compute()
+        assert False, 'expected ZeroDivisionError'
+    except ZeroDivisionError as e:
+        assert str(e) == 'zero to a negative power'
+
+# === Ordinary results ===
+assert 2.0**10 == 1024.0
+assert 2**0.5 == 1.4142135623730951
+assert 1.1**10 == 2.5937424601000023
+assert (-2.0) ** 3 == -8.0
+assert 9.0**0.5 == 3.0
+assert pow(2.0, -2) == 0.25

--- a/crates/monty/test_cases/float__pow.py
+++ b/crates/monty/test_cases/float__pow.py
@@ -84,3 +84,14 @@ assert 1.1**10 == 2.5937424601000023
 assert (-2.0) ** 3 == -8.0
 assert 9.0**0.5 == 3.0
 assert pow(2.0, -2) == 0.25
+
+# === int ** negative int goes through float pow ===
+# Every spelling calls the same C `pow`, so they agree to the last bit.
+assert 5**-23 == pow(5, -23) == 5.0**-23 == 8.388608e-17
+assert 7**-13 == pow(7, -13) == 7.0**-13
+assert 3**-33 == 1.79886509245143e-16
+assert True**-3 == 1.0
+assert (-3) ** -3 == -0.037037037037037035
+assert (-10) ** -401 == 0.0
+assert str((-10) ** -401) == '-0.0'
+assert (-(2**63)) ** -1 == -1.0842021724855044e-19

--- a/crates/monty/test_cases/float__pow.py
+++ b/crates/monty/test_cases/float__pow.py
@@ -46,6 +46,14 @@ assert str(nan**2) == 'nan'
 assert str(2.0**nan) == 'nan'
 assert pow(inf, 2) == inf
 assert pow(2**70, inf) == inf
+# A zero base with an infinite exponent is not "zero to a negative power".
+assert 0.0**-inf == inf
+assert (-0.0) ** -inf == inf
+assert 0**-inf == inf
+assert False**-inf == inf
+assert pow(0.0, -inf) == inf
+assert 0.0**inf == 0.0
+assert str(0.0**nan) == 'nan'
 
 # === Underflow is silent ===
 assert 2.0**-10000 == 0.0

--- a/crates/monty/test_cases/float__pow.py
+++ b/crates/monty/test_cases/float__pow.py
@@ -1,4 +1,6 @@
 # === Overflow raises like CPython's float_pow ===
+# CPython's message is strerror(ERANGE), which differs by libc; Monty always uses glibc's.
+ERANGE_MESSAGES = {"(34, 'Numerical result out of range')", "(34, 'Result too large')"}
 for compute in [
     lambda: 1.5**10000,
     lambda: 10.0**400,
@@ -17,14 +19,14 @@ for compute in [
         compute()
         assert False, 'expected OverflowError'
     except OverflowError as e:
-        assert str(e) == "(34, 'Result too large')"
+        assert str(e) in ERANGE_MESSAGES
 
 x = 10.0
 try:
     x **= 400
     assert False, 'expected OverflowError'
 except OverflowError as e:
-    assert str(e) == "(34, 'Result too large')"
+    assert str(e) in ERANGE_MESSAGES
 
 # === Infinite and NaN operands never raise ===
 inf = float('inf')

--- a/crates/monty/test_cases/int__bigint.py
+++ b/crates/monty/test_cases/int__bigint.py
@@ -608,3 +608,21 @@ for compute in [lambda: huge / 1, lambda: -huge / 3, lambda: (2**1024 - 2**970) 
         assert False, 'expected OverflowError'
     except OverflowError as e:
         assert str(e) == 'integer division result too large for a float'
+
+# A zero base still converts the exponent first, so an out-of-range exponent overflows
+# before the zero-to-a-negative-power check.
+for compute in [lambda: 0**-huge, lambda: pow(0, -huge), lambda: False**-huge, lambda: pow(False, -huge)]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) == 'int too large to convert to float'
+for compute in [lambda: 0**-big, lambda: pow(0, -big), lambda: False**-big, lambda: (big - big) ** -big]:
+    try:
+        compute()
+        assert False, 'expected ZeroDivisionError'
+    except ZeroDivisionError as e:
+        assert str(e) == 'zero to a negative power'
+assert 0 / big == 0.0
+assert str(0 / -big) == '-0.0'
+assert str(-0.0 // big) == '-0.0'

--- a/crates/monty/test_cases/int__bigint.py
+++ b/crates/monty/test_cases/int__bigint.py
@@ -484,3 +484,127 @@ assert b'ab' * neg == b''
 zero = big - big
 assert 'ab' * zero == ''
 assert b'ab' * zero == b''
+
+# === Mixed int/float arithmetic with long ints ===
+big = 2**70
+assert big // 3.0 == 3.935305402391371e20
+assert -big // 3.0 == -3.935305402391371e20
+assert 3.0 // big == 0.0
+assert big % 3.0 == 1.0
+assert -big % 3.0 == 2.0
+assert big % -3.0 == -2.0
+assert 3.0 % -big == -1.1805916207174113e21
+assert divmod(-big, 3.0) == (-3.935305402391371e20, 2.0)
+assert divmod(3.0, -big) == (-1.0, -1.1805916207174113e21)
+assert 1.0**big == 1.0
+assert 0.5**big == 0.0
+assert big**1.5 == 4.056481920730334e31
+assert big**-1 == 8.470329472543003e-22
+assert pow(0.5, big) == 0.0
+assert pow(big, 1.5) == 4.056481920730334e31
+assert pow(big, -1) == 8.470329472543003e-22
+assert 2**-big == 0.0
+assert float(big) == 1.1805916207174113e21
+assert float(-big) == -1.1805916207174113e21
+assert float(100000000000000000000000000000) == 1e29
+assert 100000000000000000000000000000 * 1.0 == 1e29
+
+for compute in [lambda: big / 0.0, lambda: big // 0.0, lambda: big % 0.0, lambda: divmod(big, 0.0)]:
+    try:
+        compute()
+        assert False, 'expected ZeroDivisionError'
+    except ZeroDivisionError as e:
+        assert str(e) == 'division by zero'
+
+for compute in [lambda: 0.0**-big, lambda: pow(0.0, -big)]:
+    try:
+        compute()
+        assert False, 'expected ZeroDivisionError'
+    except ZeroDivisionError as e:
+        assert str(e) == 'zero to a negative power'
+
+# === Float conversion overflow ===
+# Every mixed int/float operation converts the int the way float() does, so an int
+# beyond the float range raises instead of turning into inf.
+huge = 10**400
+for compute in [
+    lambda: float(huge),
+    lambda: huge + 1.0,
+    lambda: 1.0 + huge,
+    lambda: huge - 1.0,
+    lambda: 1.0 - huge,
+    lambda: huge * 1.0,
+    lambda: 1.0 * huge,
+    lambda: -huge * 1.0,
+    lambda: huge / 1.0,
+    lambda: 1.0 / huge,
+    lambda: huge // 1.0,
+    lambda: 1.0 // huge,
+    lambda: huge % 1.0,
+    lambda: 1.0 % huge,
+    lambda: divmod(huge, 1.0),
+    lambda: divmod(1.0, huge),
+    lambda: huge**1.5,
+    lambda: 1.5**huge,
+    lambda: huge**-1,
+    lambda: 2**-huge,
+    lambda: pow(huge, 1.5),
+    lambda: pow(1.5, huge),
+    lambda: pow(huge, -1),
+    lambda: pow(2, -huge),
+    lambda: huge * float('inf'),
+    lambda: huge * float('nan'),
+]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) == 'int too large to convert to float'
+
+x = 1.0
+try:
+    x *= huge
+    assert False, 'expected OverflowError'
+except OverflowError as e:
+    assert str(e) == 'int too large to convert to float'
+
+# Comparisons are exact and never convert.
+assert 1.0 < huge
+assert huge != 1.0
+
+# float() rounds half to even at the float boundary and its range edge.
+assert float(2**64 + 2**11) == 1.8446744073709552e19
+assert float(2**64 + 2**11 + 1) == 1.8446744073709556e19
+assert float(2**64 + 3 * 2**11) == 1.844674407370956e19
+assert float(2**1024 - 2**971) == 1.7976931348623157e308
+assert float(2**1024 - 2**970 - 1) == 1.7976931348623157e308
+try:
+    float(2**1024 - 2**970)
+    assert False, 'expected OverflowError'
+except OverflowError as e:
+    assert str(e) == 'int too large to convert to float'
+
+# === True division rounds once ===
+# int / int divides the integers and rounds to the nearest float, so operands beyond
+# the float range still divide, and i64 operands above 2**53 do not round twice.
+assert huge / huge == 1.0
+assert (huge + 1) / huge == 1.0
+assert huge / (huge // 2) == 2.0
+assert 1 / huge == 0.0
+assert str(-1 / huge) == '-0.0'
+assert (2**1024 - 2**971) / 1 == 1.7976931348623157e308
+assert (2**1024 - 2**970 - 1) / 1 == 1.7976931348623157e308
+assert (2**63 - 1) / (2**62 + 1) == 2.0
+assert -(2**63) / 3 == -3.0744573456182584e18
+assert 1 / 2**1074 == 5e-324
+assert 1 / 2**1075 == 0.0
+assert 3 / 2**1076 == 5e-324
+assert 3 / 2**1075 == 1e-323
+assert 5 / 2**1075 == 1e-323
+
+for compute in [lambda: huge / 1, lambda: -huge / 3, lambda: (2**1024 - 2**970) / 1, lambda: huge / -(2**70)]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) == 'integer division result too large for a float'

--- a/docs/limitations/builtins.md
+++ b/docs/limitations/builtins.md
@@ -101,6 +101,10 @@ These raise `NameError`:
     rejects negative exponents with `ValueError` instead of computing a modular
     inverse. Non-modular exponents whose result cannot be materialized raise
     `OverflowError` (see [resource_limits.md](resource_limits.md)).
+- **`pow(base, exp)` and `**` with a negative float base and a fractional
+    exponent** — gives `nan` where CPython returns a `complex` (Monty has no
+    complex type). Overflow does match CPython: `OverflowError: (34, 'Result too large')`, though `exc.args` is that
+    text as one string rather than the `(34, 'Result too large')` tuple.
 - **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
     must be passed by keyword; positional forms raise `TypeError`.
 - **`round(n, ndigits)`** — `ndigits` values outside the i64 range are

--- a/docs/limitations/builtins.md
+++ b/docs/limitations/builtins.md
@@ -103,8 +103,10 @@ These raise `NameError`:
     `OverflowError` (see [resource_limits.md](resource_limits.md)).
 - **`pow(base, exp)` and `**` with a negative float base and a fractional
     exponent** — gives `nan` where CPython returns a `complex` (Monty has no
-    complex type). Overflow does match CPython: `OverflowError: (34, 'Result too large')`, though `exc.args` is that
-    text as one string rather than the `(34, 'Result too large')` tuple.
+    complex type). Overflow raises `OverflowError` like CPython, always worded
+    `(34, 'Numerical result out of range')` (glibc's `strerror(ERANGE)`; CPython
+    on macOS and Windows says `(34, 'Result too large')`), and `exc.args` is that
+    text as one string rather than CPython's `(34, '...')` tuple.
 - **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
     must be passed by keyword; positional forms raise `TypeError`.
 - **`round(n, ndigits)`** — `ndigits` values outside the i64 range are


### PR DESCRIPTION
Mixed int/float operations converted a long int to `f64` with an infinity fallback, so anything past the float range produced `inf`; they now raise `OverflowError: int too large to convert to float`, as does `float(big)`, which previously rejected long ints outright. `//`, `%`, `divmod()` and float `**` had no long-int arms at all and raised `TypeError`.

`int / int` went through `f64` on both operands, giving `nan` for `10**400 / 10**400` and double rounding for i64 values above 2**53. `bigint_true_divide` ports CPython's `long_true_divide`, rounding once.

`float_pow` centralises float power: finite operands whose result overflows raise `OverflowError: (34, 'Result too large')` instead of returning `inf`. Float floor division and `divmod()` share `py_float_divmod`, CPython's `float_divmod` algorithm.


Claude-Session: https://claude.ai/code/session_01UtioDiZUh2jpWsc5r55FbS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches CPython for mixed int/float arithmetic on long ints and float power overflow. Long ints past the float range now raise `OverflowError: int too large to convert to float` instead of leaking `inf` into arithmetic, and `float(big)` accepts in-range long ints it previously rejected.

- Long-int operands now work in `//`, `%`, `divmod()`, and float `**` instead of raising `TypeError`; float `//` and `divmod()` use CPython's `float_divmod` algorithm.
- `int / int` no longer converts both operands to `f64`; it divides the integers and rounds once, so `10**400 / 10**400` returns `1.0`, and it preflights its temporaries against the memory limit.
- Negative integer exponents now go through the float-power path, keeping `int`, `bool`, `float`, and `pow()` results consistent and converting operands before zero-power checks.
- Float power overflow raises `OverflowError` instead of returning `inf`; `0.0 ** -inf` returns `inf` as in CPython.

**Known divergences**

- Negative float bases with fractional exponents return `nan` instead of `complex`.
- Float-power overflow always uses glibc's `(34, 'Numerical result out of range')` wording, and `OverflowError.args` contains one string instead of CPython's tuple.

<sup>Written for commit 027fe92001067835b04a60fb83f87b0b468b9f8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

