### PR TITLE
Handle non-builtin type objects at the Python boundary

### DIFF
--- a/crates/monty-proto/src/python/convert.rs
+++ b/crates/monty-proto/src/python/convert.rs
@@ -9,7 +9,7 @@ use monty_types::{
 };
 use num_bigint::BigInt;
 use pyo3::{
-    exceptions::{PyBaseException, PyRuntimeError, PyTypeError, PyValueError},
+    exceptions::{PyAttributeError, PyBaseException, PyRuntimeError, PyTypeError, PyValueError},
     intern,
     prelude::*,
     sync::PyOnceLock,
@@ -26,6 +26,13 @@ use super::{
     exceptions::{exc_monty_to_py, exc_py_to_monty, exc_to_monty_object},
 };
 use crate::MAX_VALUE_DEPTH;
+
+pyo3::create_exception!(
+    monty_proto,
+    UnmappedTypeError,
+    PyTypeError,
+    "A type without a host mapping; embedders choose the public exception."
+);
 
 /// Depth limit for converting host values INTO the sandbox: values must fit
 /// the wire protocol, whose decoder caps nesting (see [`MAX_VALUE_DEPTH`]) —
@@ -481,14 +488,9 @@ pub fn import_builtins(py: Python<'_>) -> PyResult<&Py<PyModule>> {
     BUILTINS.get_or_try_init(py, || py.import("builtins").map(Bound::unbind))
 }
 
-/// Reconstructs the host Python *type object* for a Monty [`MontyType`] crossing the
-/// boundary as a value (e.g. sandbox code passing `type(Path('/x'))` to a host call).
-///
-/// Genuine builtins resolve from `builtins`; modeled stdlib types resolve from their
-/// real defining module (the `Path` class maps to `PurePosixPath`, like its instances).
-/// The import path can differ from [`MontyType`]'s `Display` (io types show `_io.*` but
-/// live in `io`). Unmodeled types fall through to `builtins` and raise `AttributeError`.
-/// Each modeled type's host class is cached in its own `PyOnceLock` (imported once).
+/// Converts a Monty type to its host class, caching modeled non-builtin classes.
+/// Private iterator and view classes are derived from host objects; types without
+/// an output mapping raise [`UnmappedTypeError`] naming the type.
 fn type_object_to_py(py: Python<'_>, t: MontyType) -> PyResult<Py<PyAny>> {
     // A type this host's Python is too old to define has no object to hand back.
     // Say which type that was, rather than leaving the arm's import to raise a
@@ -508,6 +510,15 @@ fn type_object_to_py(py: Python<'_>, t: MontyType) -> PyResult<Py<PyAny>> {
             LOCK.import(py, $module, $name).map(|b| b.clone().unbind())
         }};
     }
+    // Private iterator and view classes have no module attribute; derive them
+    // from small host objects once, without advancing an iterator.
+    macro_rules! cached_type {
+        ($value:expr) => {{
+            static TYPE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+            TYPE.get_or_try_init(py, || Ok($value.get_type().into_any().unbind()))
+                .map(|ty| ty.clone_ref(py))
+        }};
+    }
     match t {
         MontyType::Date => cached!("datetime", "date"),
         MontyType::DateTime => cached!("datetime", "datetime"),
@@ -516,6 +527,34 @@ fn type_object_to_py(py: Python<'_>, t: MontyType) -> PyResult<Py<PyAny>> {
         MontyType::TimeDelta => cached!("datetime", "timedelta"),
         MontyType::TimeZone => cached!("datetime", "timezone"),
         MontyType::ListIterator => get_list_iterator_type(py).map(|b| b.clone().unbind()),
+        MontyType::TupleIterator => cached_type!(PyTuple::empty(py).try_iter()?),
+        MontyType::StrAsciiIterator => cached_type!(PyString::new(py, "").try_iter()?),
+        MontyType::StrIterator => cached_type!(PyString::new(py, "é").try_iter()?),
+        MontyType::BytesIterator => cached_type!(PyBytes::new(py, b"").try_iter()?),
+        MontyType::RangeIterator => {
+            cached_type!(
+                import_builtins(py)?
+                    .getattr(py, "range")?
+                    .call1(py, (0,))?
+                    .bind(py)
+                    .try_iter()?
+            )
+        }
+        MontyType::DictKeyIterator => cached_type!(PyDict::new(py).try_iter()?),
+        MontyType::DictItemIterator => {
+            cached_type!(PyDict::new(py).call_method0(intern!(py, "items"))?.try_iter()?)
+        }
+        MontyType::DictValueIterator => {
+            cached_type!(PyDict::new(py).call_method0(intern!(py, "values"))?.try_iter()?)
+        }
+        MontyType::SetIterator => cached_type!(PySet::empty(py)?.try_iter()?),
+        MontyType::DictKeys => cached_type!(PyDict::new(py).call_method0(intern!(py, "keys"))?),
+        MontyType::DictItems => cached_type!(PyDict::new(py).call_method0(intern!(py, "items"))?),
+        MontyType::DictValues => cached_type!(PyDict::new(py).call_method0(intern!(py, "values"))?),
+        MontyType::NotImplementedType => cached!("types", "NotImplementedType"),
+        MontyType::Function => cached!("types", "FunctionType"),
+        MontyType::BuiltinFunction => cached!("types", "BuiltinFunctionType"),
+        MontyType::Module => cached!("types", "ModuleType"),
         MontyType::CallableIterator => get_callable_iterator_type(py).map(|b| b.clone().unbind()),
         MontyType::ItertoolsCount => cached!("itertools", "count"),
         MontyType::ItertoolsRepeat => cached!("itertools", "repeat"),
@@ -553,7 +592,13 @@ fn type_object_to_py(py: Python<'_>, t: MontyType) -> PyResult<Py<PyAny>> {
             "cannot convert class '{}' to a host type object",
             class_type.name
         ))),
-        _ => import_builtins(py)?.getattr(py, t.to_string()),
+        _ => import_builtins(py)?.getattr(py, t.to_string()).map_err(|err| {
+            if err.is_instance_of::<PyAttributeError>(py) {
+                UnmappedTypeError::new_err(format!("Cannot convert {t} to a host type: no output mapping"))
+            } else {
+                err
+            }
+        }),
     }
 }
 

--- a/crates/monty-proto/src/python/mod.rs
+++ b/crates/monty-proto/src/python/mod.rs
@@ -15,5 +15,5 @@ mod convert;
 mod exceptions;
 
 pub use class_instance::{InstanceStore, PyMontyClassProxy, PyMontyClassTypeProxy, uuid_to_py};
-pub use convert::{PyMontyFileHandle, monty_to_py, py_to_monty, py_to_monty_value};
+pub use convert::{PyMontyFileHandle, UnmappedTypeError, monty_to_py, py_to_monty, py_to_monty_value};
 pub use exceptions::{exc_monty_to_py, exc_py_to_monty, exc_to_monty_object};

--- a/crates/monty-python/src/exceptions.rs
+++ b/crates/monty-python/src/exceptions.rs
@@ -14,13 +14,13 @@
 //! ├── MontyCrashedError        # Raised when the sandbox dies or times out
 //! ├── MontyDisconnectError     # A remote worker's connection closed (websocket only)
 //! ├── MontyShutdown            # The remote server is shutting down (websocket only)
-//! └── MontyConversionError     # A host value that can't be converted into the sandbox
+//! └── MontyConversionError     # A value or type that can't cross the host boundary
 //! ```
 
 use std::sync::Arc;
 
 use ahash::AHashMap;
-use monty_proto::python::exc_monty_to_py;
+use monty_proto::python::{UnmappedTypeError, exc_monty_to_py};
 use monty_types::{ExcType, MontyException};
 use pyo3::{
     PyClassInitializer,
@@ -94,15 +94,21 @@ impl MontyError {
     }
 }
 
-/// Raised when a host value cannot be converted across the Monty/host boundary
-/// — an `external_lookup` value or an `inputs` value of a type Monty cannot
-/// represent. Inherits from `MontyError` (so `except MontyError` catches it) and
-/// carries the "Cannot convert X to Monty value" message; the stored type is
-/// `TypeError`, so `exception()` reconstructs a native `TypeError`.
+/// Raised for an unsupported host input or a sandbox type with no host mapping.
+/// Inherits from `MontyError`; `exception()` reconstructs a native `TypeError`.
 #[pyclass(extends=MontyError, module="pydantic_monty")]
 pub struct MontyConversionError;
 
 impl MontyConversionError {
+    /// Wraps an unmapped output type without masking other host failures.
+    pub(crate) fn output_conversion_err(py: Python<'_>, err: PyErr) -> PyErr {
+        if err.is_instance_of::<UnmappedTypeError>(py) {
+            Self::new_err(py, err.value(py).to_string())
+        } else {
+            err
+        }
+    }
+
     /// Builds a `MontyConversionError` carrying `message`, stored as a
     /// `TypeError`. Raised via [`Self::value_conversion_err`] for a genuine
     /// unrepresentable-type failure.

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -65,7 +65,9 @@ use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
     build::{extract_connect_headers, extract_repl_inputs, extract_source_code, extract_type_check_stubs},
     callback_context::{self, CallbackContext},
-    exceptions::{MontyCrashedError, MontyDisconnectError, MontyError, MontyShutdown, MontyTypingError},
+    exceptions::{
+        MontyConversionError, MontyCrashedError, MontyDisconnectError, MontyError, MontyShutdown, MontyTypingError,
+    },
     external::{CallResult, ExternalLookup, dispatch_object_call, resolve_object_attr},
     get_not_handled,
     limits::extract_limits,
@@ -1314,7 +1316,10 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
         })?;
         let callback_guard = callback_context.enter(py, &native)?;
         let resume_with = match event {
-            TurnEvent::Complete(value) => return monty_to_py(py, &value, &instances),
+            TurnEvent::Complete(value) => {
+                return monty_to_py(py, &value, &instances)
+                    .map_err(|err| MontyConversionError::output_conversion_err(py, err));
+            }
             // This feed's mounts get first refusal on every OS call; only what
             // they don't cover reaches the `os=` callback.
             TurnEvent::OsCall {
@@ -1513,7 +1518,10 @@ async fn drive_async_inner(
             .unwrap_or_default();
         let answer: TurnAnswer = match event {
             TurnEvent::Complete(value) => {
-                return Python::attach(|py| monty_to_py(py, &value, &instances));
+                return Python::attach(|py| {
+                    monty_to_py(py, &value, &instances)
+                        .map_err(|err| MontyConversionError::output_conversion_err(py, err))
+                });
             }
             TurnEvent::ResolveFutures { .. } => {
                 let resolved = wait_for_futures(&mut join_set).await.and_then(|results| {

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -51,7 +51,7 @@ mod tests;
 use crate::{
     async_dispatch::{dispatch_function_call, spawn_coroutine_task, wait_for_futures},
     callback_context::CallbackContext,
-    exceptions::MontyError,
+    exceptions::{MontyConversionError, MontyError},
     external::{CallResult, ExternalLookup, resolve_object_attr, wire_call_arguments},
     pool::{
         FeedArgs, SharedCheckout, TurnFuture, block_on_sync, discard_checkout, discard_checkout_sync,
@@ -512,7 +512,9 @@ fn parse_external_result(
 
 /// The pending call's positional args as a Python tuple.
 fn args_to_py<'py>(py: Python<'py>, args: &[MontyObject], instances: &InstanceStore) -> PyResult<Bound<'py, PyTuple>> {
-    wire_call_arguments(py, args, &[], instances).map(|(args, _)| args)
+    wire_call_arguments(py, args, &[], instances)
+        .map(|(args, _)| args)
+        .map_err(|err| MontyConversionError::output_conversion_err(py, err))
 }
 
 /// The pending call's keyword args as a Python dict.
@@ -521,7 +523,9 @@ fn kwargs_to_py<'py>(
     kwargs: &[(MontyObject, MontyObject)],
     instances: &InstanceStore,
 ) -> PyResult<Bound<'py, PyDict>> {
-    wire_call_arguments(py, &[], kwargs, instances).map(|(_, kwargs)| kwargs)
+    wire_call_arguments(py, &[], kwargs, instances)
+        .map(|(_, kwargs)| kwargs)
+        .map_err(|err| MontyConversionError::output_conversion_err(py, err))
 }
 
 // =============================================================================
@@ -1184,6 +1188,7 @@ impl MontyComplete {
     #[getter]
     fn output(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         monty_to_py(py, &self.value, &self.instances)
+            .map_err(|err| MontyConversionError::output_conversion_err(py, err))
     }
 
     fn __repr__(&self, py: Python<'_>) -> PyResult<String> {

--- a/crates/monty-python/tests/test_types.py
+++ b/crates/monty-python/tests/test_types.py
@@ -13,7 +13,16 @@ import pytest
 from conftest import RunMonty
 from inline_snapshot import snapshot
 
-from pydantic_monty import MontyConversionError, MontyRuntimeError
+from pydantic_monty import (
+    AsyncFunctionSnapshot,
+    AsyncMonty,
+    FunctionSnapshot,
+    MontyComplete,
+    MontyConversionError,
+    MontyError,
+    MontyRuntimeError,
+    MontySession,
+)
 
 
 def test_none_input(monty_run: RunMonty):
@@ -164,6 +173,161 @@ from collections import deque
         re.Match,
         collections.deque,
     ]
+
+
+NON_BUILTIN_TYPES: list[tuple[str, type[object]]] = [
+    ('{}.keys()', type({0: 0}.keys())),
+    ('{}.values()', type({0: 0}.values())),
+    ('{}.items()', type({0: 0}.items())),
+    ('iter(())', type(iter(()))),
+    ("iter('abc')", type(iter('abc'))),
+    ("iter('é')", type(iter('é'))),
+    ("iter(b'')", type(iter(b''))),
+    ('iter(range(0))', type(iter(range(0)))),
+    ('iter({})', type(iter({}))),
+    ('iter({}.items())', type(iter({0: 0}.items()))),
+    ('iter({}.values())', type(iter({0: 0}.values()))),
+    ('iter(set())', type(iter({0}))),
+    ('NotImplemented', type(NotImplemented)),
+    ('lambda: None', type(lambda: None)),
+    ('len', type(len)),
+    ('sys', type(sys)),
+]
+
+
+@pytest.mark.parametrize(('expression', 'expected'), NON_BUILTIN_TYPES, ids=[e for e, _ in NON_BUILTIN_TYPES])
+def test_non_builtin_type_object_output(monty_run: RunMonty, expression: str, expected: type[object]):
+    assert monty_run(f'import sys\ntype({expression})') is expected
+
+
+@pytest.mark.parametrize(('expression', 'expected'), NON_BUILTIN_TYPES, ids=[e for e, _ in NON_BUILTIN_TYPES])
+def test_non_builtin_type_object_external_arguments(monty_run: RunMonty, expression: str, expected: type[object]):
+    def check(values: list[object], *, kind: object) -> bool:
+        return values[0] is expected and kind is expected
+
+    code = f'import sys\ncheck([type({expression})], kind=type({expression}))'
+    assert monty_run(code, external_lookup={'check': check}) is True
+
+
+@pytest.mark.parametrize(('expression', 'expected'), NON_BUILTIN_TYPES, ids=[e for e, _ in NON_BUILTIN_TYPES])
+async def test_non_builtin_type_object_async(expression: str, expected: type[object]):
+    async def check(value: object) -> bool:
+        return value is expected
+
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            assert await session.feed_run(f'import sys\ntype({expression})') is expected
+            assert await session.feed_run(f'await check(type({expression}))', external_lookup={'check': check}) is True
+
+
+@pytest.mark.parametrize('error_type', [TypeError, RuntimeError])
+@pytest.mark.parametrize('suspendable', [False, True])
+def test_type_object_output_preserves_host_error(
+    session: MontySession, monkeypatch: pytest.MonkeyPatch, error_type: type[Exception], suspendable: bool
+):
+    import builtins
+
+    expected = error_type('Cannot convert iterator to a host type: no output mapping')
+
+    def missing_builtin(name: str) -> object:
+        if name == 'iterator':
+            raise expected
+        raise AttributeError(name)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(builtins, '__getattr__', missing_builtin, raising=False)
+        with pytest.raises(error_type) as exc_info:
+            code = 'from collections import deque\ntype(iter(deque()))'
+            if suspendable:
+                result = session.feed_start(code)
+                assert isinstance(result, MontyComplete)
+                _ = result.output
+            else:
+                session.feed_run(code)
+    assert exc_info.value is expected
+
+
+@pytest.mark.parametrize('expression', ['type(iter(deque()))', "{'kind': [type(iter(deque()))]}"])
+@pytest.mark.parametrize('suspendable', [False, True])
+def test_unmapped_type_object_output(session: MontySession, expression: str, suspendable: bool):
+    code = f'from collections import deque\n{expression}'
+    with pytest.raises(MontyError) as exc_info:
+        if suspendable:
+            result = session.feed_start(code)
+            assert isinstance(result, MontyComplete)
+            _ = result.output
+        else:
+            session.feed_run(code)
+    assert isinstance(exc_info.value, MontyConversionError)
+    assert isinstance(exc_info.value.exception(), TypeError)
+    assert str(exc_info.value) == snapshot('Cannot convert iterator to a host type: no output mapping')
+    assert session.feed_run('42') == snapshot(42)
+
+
+@pytest.mark.parametrize('expression', ['type(iter(deque()))', "{'kind': [type(iter(deque()))]}"])
+@pytest.mark.parametrize('suspendable', [False, True])
+async def test_unmapped_type_object_async_output(expression: str, suspendable: bool):
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            code = f'from collections import deque\n{expression}'
+            with pytest.raises(MontyError) as exc_info:
+                if suspendable:
+                    result = await session.feed_start(code)
+                    assert isinstance(result, MontyComplete)
+                    _ = result.output
+                else:
+                    await session.feed_run(code)
+            assert isinstance(exc_info.value, MontyConversionError)
+            assert isinstance(exc_info.value.exception(), TypeError)
+            assert str(exc_info.value) == snapshot('Cannot convert iterator to a host type: no output mapping')
+            assert await session.feed_run('42') == snapshot(42)
+
+
+def test_unmapped_type_object_external_argument(monty_run: RunMonty):
+    def check(value: object) -> None:
+        pytest.fail('An unconvertible argument must not reach the callback')
+
+    code = """
+from collections import deque
+try:
+    check(type(iter(deque())))
+except TypeError as exc:
+    message = str(exc)
+message
+"""
+    assert monty_run(code, external_lookup={'check': check}) == snapshot(
+        'Cannot convert iterator to a host type: no output mapping'
+    )
+
+
+@pytest.mark.parametrize(('argument', 'attribute'), [('value', 'args'), ('kind=value', 'kwargs')])
+def test_unmapped_type_object_snapshot_argument(session: MontySession, argument: str, attribute: str):
+    code = f'from collections import deque\nvalue = type(iter(deque()))\ncheck({argument})'
+    pending = session.feed_start(code)
+    assert isinstance(pending, FunctionSnapshot)
+    with pytest.raises(MontyError) as exc_info:
+        getattr(pending, attribute)
+    assert isinstance(exc_info.value, MontyConversionError)
+    assert str(exc_info.value) == snapshot('Cannot convert iterator to a host type: no output mapping')
+    done = pending.resume({'return_value': 42})
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot(42)
+
+
+@pytest.mark.parametrize(('argument', 'attribute'), [('value', 'args'), ('kind=value', 'kwargs')])
+async def test_unmapped_type_object_async_snapshot_argument(argument: str, attribute: str):
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            code = f'from collections import deque\nvalue = type(iter(deque()))\ncheck({argument})'
+            pending = await session.feed_start(code)
+            assert isinstance(pending, AsyncFunctionSnapshot)
+            with pytest.raises(MontyError) as exc_info:
+                getattr(pending, attribute)
+            assert isinstance(exc_info.value, MontyConversionError)
+            assert str(exc_info.value) == snapshot('Cannot convert iterator to a host type: no output mapping')
+            done = await pending.resume({'return_value': 42})
+            assert isinstance(done, MontyComplete)
+            assert done.output == snapshot(42)
 
 
 def test_type_object_input_roundtrip(monty_run: RunMonty):

--- a/docs/limitations/builtins.md
+++ b/docs/limitations/builtins.md
@@ -116,24 +116,26 @@ These raise `NameError`:
     host callables with the same name share `is`, equality, `id()`, and `hash()`
     results. Once the last sandbox reference is dropped, a later conversion of
     that name may create a new function object.
-- **Type objects across the host boundary** — a `type` object (a class, not an
-    instance) round-trips in both directions.
-    - *Sandbox → host* (external/OS-call argument, or a `.run()` return value): the
+- **Type objects across the host boundary**: conversion of a class object depends on the direction.
+    - *Sandbox → host* (external/OS-call argument, or a `feed_run()` return value): the
         type is reconstructed as the corresponding host class. Genuine builtins
         (`int`, `str`, `type`, `bytes`, `list`, `dict`, `property`, …) resolve to the
         real builtin; Monty's modeled stdlib types map to their host stdlib class:
         `datetime`/`date`/`timedelta`/`timezone` → `datetime.*`,
         `re.Pattern`/`re.Match` → `re.*`, the binary/text file types → `io.*`. The
         `pathlib.Path` class maps to `pathlib.PurePosixPath`, consistent with how Path
-        *instances* round-trip, and instantiable on every host OS. A type with no
-        faithful host class (e.g. an internal function or cell type) cannot be
-        reconstructed and surfaces as an `AttributeError` from the host call.
+        *instances* round-trip, and instantiable on every host OS.
+        A type without an output mapping, such as the generic type used for deque iterators, raises
+        `MontyConversionError: Cannot convert iterator to a host type: no output mapping` from `feed_run()`
+        or `MontyComplete.output`. Catching `MontyError` also catches this error.
+        For callback arguments, the sandbox can catch this `TypeError`; uncaught, it raises `MontyRuntimeError`.
     - *Host → sandbox* (input, or an external-call return value): the same recognized
         builtins and modeled stdlib types are preserved as type objects, so
         `isinstance(x, the_type)` works inside the sandbox. Recognition is by
         type-object **identity**, not class name/module, so a class that forges
         `__name__`/`__module__` to impersonate a builtin is *not* treated as one. Every
         `pathlib` path class collapses to `PurePosixPath` (it re-emerges as
-        `PurePosixPath`). A host class Monty does **not** model (e.g. a user-defined
+        `PurePosixPath`). Output conversion alone does not make a host type a recognized input.
+        A host class Monty does **not** recognize (e.g. a user-defined
         class) is not preserved as a type; it degrades to a callable, appearing inside
         the sandbox as a `function` rather than a `type`.


### PR DESCRIPTION
Fixes #713.

Return the corresponding host classes for dict views, iterators, functions, modules and `NotImplementedType`. Types with no output mapping raise `MontyConversionError` from feeds and snapshot accessors. Callback argument failures remain catchable as `TypeError` inside the sandbox; unrelated host errors are preserved.

Tests cover class identity, nested callback arguments, sync/async feeds, snapshot accessors and the error boundary. Input-side type recognition, Counter/defaultdict identity and internal iterator naming are unchanged.

The targeted Python 3.14 tests pass locally. On 3.10, the existing Path snapshot test fails in `inline_snapshot`; the same error reproduces with plain `pathlib` objects, without Monty.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #713. Type objects for dict views, iterators, functions, modules, and `NotImplementedType` now convert to their host classes at the Python boundary; previously they fell through to `builtins` and raised `AttributeError`. Types with no output mapping now raise `MontyConversionError` from `feed_run()` and snapshot accessors.

**Error behavior**
- Callback argument failures remain catchable as `TypeError` inside the sandbox.
- Unrelated host errors are preserved instead of being masked.
- Input-side type recognition is unchanged.

<sup>Written for commit 59239324c78e8d2a2984801f8f79e85c9359259d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

