### PR TITLE
Normalize type-check paths before cleanup

### DIFF
--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -1315,6 +1315,8 @@ fn reset_scrubs_type_check_state_from_the_next_session() {
         ("a.py", "a"),
         ("sub/nested.py", "sub.nested"),
         ("../escape.py", "escape"),
+        ("../../file.py", "file"),
+        ("foo/../bar.py", "bar"),
         ("/abs.py", "abs"),
     ];
     let mut child = ChildProc::spawn();
@@ -1368,6 +1370,29 @@ fn reset_scrubs_type_check_state_from_the_next_session() {
         let pb::child_event::Kind::Ok(_) = child.recv() else {
             panic!("expected Ok for the trailing Reset");
         };
+    }
+    child.shutdown();
+}
+
+/// Parent components in a script path must not discard a worker during reset.
+#[test]
+fn reset_after_unnormalized_script_name_without_stubs() {
+    let mut child = ChildProc::spawn();
+    for script_name in ["../../file.py", "foo/../bar.py", "main.py"] {
+        child.create_repl_with(pb::Configure {
+            script_name: script_name.to_owned(),
+            type_check: true,
+            monty_version: env!("CARGO_PKG_VERSION").to_owned(),
+            protocol_version: PROTOCOL_VERSION,
+            ..Default::default()
+        });
+        assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2));
+        child.send(pb::parent_request::Kind::Reset(pb::Reset {}));
+        let event = child.recv();
+        assert!(
+            matches!(event, pb::child_event::Kind::Ok(_)),
+            "{script_name}: {event:?}"
+        );
     }
     child.shutdown();
 }

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -59,11 +59,12 @@ impl TypeChecker {
         config: TypeCheckingConfig,
     ) -> Result<Option<TypeCheckingDiagnostics<'a>>, String> {
         let src_root = SystemPathBuf::from(SRC_ROOT);
-        let main_path = src_root.join(python_source.path);
+        // Track the same normalized paths as the in-memory filesystem for reset.
+        let main_path = SystemPath::absolute(python_source.path, &src_root);
         let main_source = python_source.source_code;
 
         let (main_file, code_offset): (File, u32) = if let Some(stubs_file) = stubs_file {
-            let stubs_path = src_root.join(stubs_file.path);
+            let stubs_path = SystemPath::absolute(stubs_file.path, &src_root);
             self.write_root_file(&stubs_path, stubs_file.source_code)?;
 
             // prepend the stub import to the main source code

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -307,6 +307,40 @@ fn reset_removes_nested_paths() {
     assert_snapshot!(second, @"other.py:1:6: error[unresolved-import] Cannot resolve imported module `sub_dir.leaky`");
 }
 
+/// Path aliases must share one tracked file, including diagnostic rewrites.
+#[test]
+fn reset_removes_aliased_paths() {
+    let mut checker = TypeChecker::default();
+    assert!(
+        checker
+            .run(&SourceFile::new("GOOD: int = 1\n", "main.py"), None, concise())
+            .unwrap()
+            .is_none()
+    );
+    let mut diagnostics = Vec::new();
+    for path in ["../../main.py", "foo/../main.py", "/./main.py", "main.py"] {
+        let diagnostic = checker
+            .run(&SourceFile::new("x: int = GOOD\n", path), None, concise())
+            .unwrap()
+            .expect("the rewritten source no longer defines GOOD")
+            .to_string();
+        diagnostics.push(diagnostic);
+    }
+    assert_snapshot!(diagnostics.join(""), @"
+    main.py:1:10: error[unresolved-reference] Name `GOOD` used when not defined
+    main.py:1:10: error[unresolved-reference] Name `GOOD` used when not defined
+    main.py:1:10: error[unresolved-reference] Name `GOOD` used when not defined
+    main.py:1:10: error[unresolved-reference] Name `GOOD` used when not defined
+    ");
+    checker.reset().unwrap();
+    let diagnostics = checker
+        .run(&SourceFile::new("import main\n", "other.py"), None, concise())
+        .unwrap()
+        .expect("the aliased file was removed")
+        .to_string();
+    assert_snapshot!(diagnostics, @"other.py:1:8: error[unresolved-import] Cannot resolve imported module `main`");
+}
+
 /// Security-critical: checkers hold no shared state, so concurrent sessions
 /// (workers in one process, or just several threads) must never observe each
 /// other's files. Guards against a process-wide cache creeping back in.


### PR DESCRIPTION
Fixes #798.

Normalize source and stub paths with Ruff's existing `SystemPath::absolute` before tracking them for reset. Cleanup then uses the same paths as the in-memory filesystem, so parent components do not cause a reusable worker to be discarded.

Adds a no-stubs subprocess regression for both reported paths and extends same-process isolation coverage. A type-checker regression covers aliased paths, unchanged diagnostic filenames, source rewrites and cleanup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #798 by normalizing type-check source and stub paths with `SystemPath::absolute` before tracking them for reset. Cleanup now uses the same paths as the in-memory filesystem, so parent components (like `../` and `foo/../`) no longer cause a reusable worker to be discarded.

- Source and stub paths are normalized before being written to the in-memory filesystem.
- Diagnostics still report the original filename as given.
- Adds subprocess regression for unnormalized script names without stubs.
- Extends same-process isolation coverage for aliased paths.

<sup>Written for commit 5b4f9146645d5be6b133e9ec4fc85ca30fdfe68a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

