### PR TITLE
Binascii and base64 resource limits checks

### DIFF
--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -1199,6 +1199,106 @@ fn loading_a_dump_applies_its_own_memory_limit() {
     );
 }
 
+/// Every `binascii`/`base64` conversion whose output is larger than its input
+/// can be handed a buffer that fits under the soft limit and encodes to one
+/// that clears the allocator's hard ceiling, which kills the worker rather
+/// than raising. Each preflights its output, so the session survives.
+///
+/// The sizes matter: the input must fit under the soft limit while the
+/// expansion clears soft + `BASE_HEADROOM`, which needs a limit above 2 MiB.
+/// `a85decode` is here rather than among the decoders because Ascii85's `z`
+/// stands for a whole zero word, so a buffer of them quadruples.
+#[test]
+fn expanding_codecs_fail_softly() {
+    const LIMIT: u64 = 8 * 1024 * 1024;
+    // smallest expansion here is base64's 4/3, so 5 MB covers every case
+    const SETUP: &str = "import binascii, base64\nsrc = {FILL} * 5_000_000\n";
+    let cases = [
+        ("b'\\xff'", "binascii.hexlify(src)"),
+        ("b'\\xff'", "binascii.b2a_base64(src)"),
+        ("b'\\xff'", "binascii.b2a_qp(src)"),
+        ("b'\\xff'", "base64.b64encode(src)"),
+        ("b'\\xff'", "base64.b32encode(src)"),
+        ("b'\\xff'", "base64.b16encode(src)"),
+        ("b'\\xff'", "base64.b85encode(src)"),
+        ("b'\\xff'", "base64.a85encode(src)"),
+        ("b'\\xff'", "base64.encodebytes(src)"),
+        ("b'z'", "base64.a85decode(src)"),
+    ];
+
+    for (fill, call) in cases {
+        let mut child = ChildProc::spawn();
+        child.create_repl_with(configure_with_max_memory(LIMIT));
+        let (_, event) = child.feed(&format!("{}{call}", SETUP.replace("{FILL}", fill)));
+        assert_eq!(expect_error(event).exc_type, "MemoryError", "{call}");
+        // the worker raised rather than exiting, so it is still serving
+        assert_eq!(child.feed_complete("1 + 1"), MontyObject::Int(2), "{call}");
+        child.shutdown();
+    }
+}
+
+/// A conversion that appends to, or frames, a buffer it filled exactly must
+/// reserve that room before filling it. `Vec` doubles when it grows, so one
+/// appended byte charges the session a second copy of the encoded output —
+/// a burst the preflight never accounted for, and past the allocator's hard
+/// ceiling with it.
+///
+/// Each size sits in the window where the preflight passes but the doubling
+/// would not, so before the reservations every case exited the worker and the
+/// parent saw EOF instead of a turn-ending event.
+#[test]
+fn expanding_codecs_reserve_what_they_preflight() {
+    // (max_memory, code, the length CPython gives for the same call)
+    let cases = [
+        // the Ascii85 `z` word, which is sized from the input's content
+        (
+            30 * 1024 * 1024,
+            "import base64\nsrc = b'z' * 5_000_000\nlen(base64.a85decode(src))",
+            20_000_000,
+        ),
+        // the trailing newline appended to an exactly filled base64 buffer
+        (
+            32 * 1024 * 1024,
+            "import binascii\nsrc = b'\\xff' * 12_000_000\nlen(binascii.b2a_base64(src))",
+            16_000_001,
+        ),
+        // quoted-printable, whose bound is not a fixed ratio of its input
+        (
+            48 * 1024 * 1024,
+            "import binascii\nsrc = b'\\xff' * 11_000_000\nlen(binascii.b2a_qp(src))",
+            33_879_998,
+        ),
+        // the `<~` / `~>` framing spliced onto both ends of the encoded output
+        (
+            32 * 1024 * 1024,
+            "import base64\nsrc = b'\\xff' * 9_000_000\nlen(base64.a85encode(src, adobe=True))",
+            11_250_004,
+        ),
+    ];
+
+    for (limit, code, encoded_len) in cases {
+        let mut child = ChildProc::spawn();
+        child.create_repl_with(configure_with_max_memory(limit));
+        assert_eq!(child.feed_complete(code), MontyObject::Int(encoded_len), "{code}");
+        child.shutdown();
+    }
+}
+
+/// `b2a_qp`'s buffer is sized from what the input actually quotes, not from
+/// the worst case every byte escaping.
+///
+/// Plain text encodes to a little over its own length, so bounding it at the
+/// 3.125 bytes per byte that `b'\xff'` reaches would reject, at a third of the
+/// budget it needs, an input the session has ample room for.
+#[test]
+fn quoted_printable_is_sized_from_what_it_quotes() {
+    let mut child = ChildProc::spawn();
+    child.create_repl_with(configure_with_max_memory(32 * 1024 * 1024));
+    let code = "import binascii\nsrc = b'a' * 10_000_000\nlen(binascii.b2a_qp(src))";
+    assert_eq!(child.feed_complete(code), MontyObject::Int(10_266_666));
+    child.shutdown();
+}
+
 /// A `Configure` carrying `max_memory`, which is what limits the worker.
 fn configure_with_max_memory(bytes: u64) -> pb::Configure {
     pb::Configure {

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -49,3 +49,6 @@ pub use crate::{
     type_checking::{TypeCheckState, TypeCheckingConfig, TypeCheckingFormat},
     uuid::MontyUuid,
 };
+
+#[cfg(feature = "test-hooks")]
+pub use resource::{clock_polls, reset_clock_polls};

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -329,6 +329,9 @@ impl ResourceTracker {
     /// monotonic, so once the budget is exceeded every later call fails too.
     #[inline]
     pub fn check_time(&self) -> Result<(), ResourceError> {
+        #[cfg(feature = "test-hooks")]
+        CLOCK_POLLS.with(|polls| polls.set(polls.get().saturating_add(1)));
+
         if let Some(max) = self.limits.max_duration {
             let elapsed = self.elapsed();
             if elapsed > max {
@@ -354,6 +357,37 @@ impl ResourceTracker {
     #[inline]
     pub fn check_time_every(&self, i: usize) -> Result<(), ResourceError> {
         if i % Self::LOOP_CHECK_INTERVAL == Self::LOOP_CHECK_INTERVAL - 1 {
+            self.check_time()
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Bytes processed between clock reads in loops whose item is one byte.
+    ///
+    /// [`LOOP_CHECK_INTERVAL`](Self::LOOP_CHECK_INTERVAL) counts items and is
+    /// sized for loops whose item is a Python value; at one byte per item it
+    /// reads the clock 64x more often per unit of work than that, which a
+    /// codec loop feels. The overshoot this allows is still microseconds.
+    pub const BYTE_LOOP_CHECK_INTERVAL: usize = 4096;
+
+    /// The largest multiple of `group` that fits one poll window.
+    ///
+    /// Lets a loop over `data.chunks(group)` poll on an outer window instead:
+    /// every window but the last splits evenly into groups, so the inner loop
+    /// carries no check at all. `group` must be non-zero.
+    #[must_use]
+    pub const fn poll_window(group: usize) -> usize {
+        Self::BYTE_LOOP_CHECK_INTERVAL / group * group
+    }
+
+    /// Byte-scale sibling of [`check_time_every`](Self::check_time_every), for
+    /// byte loops that cannot be windowed — a state machine whose stride
+    /// varies with the input, say. Prefer windowing where the loop allows it:
+    /// this still costs a test per byte, which denies the body its unrolling.
+    #[inline]
+    pub fn check_time_every_bytes(&self, i: usize) -> Result<(), ResourceError> {
+        if i % Self::BYTE_LOOP_CHECK_INTERVAL == Self::BYTE_LOOP_CHECK_INTERVAL - 1 {
             self.check_time()
         } else {
             Ok(())
@@ -460,6 +494,35 @@ impl ResourceTracker {
         self.recursion_limit_override.set(Some(new_limit));
         Ok(())
     }
+}
+
+#[cfg(feature = "test-hooks")]
+thread_local! {
+    /// Clock polls this thread has made since [`reset_clock_polls`].
+    ///
+    /// Thread-local so tests running in parallel cannot see each other's
+    /// counts. A count is the only way to tell a loop that polls from one that
+    /// simply finished before its budget mattered: a wall-clock assertion sees
+    /// the same result either way, and so depends on how fast the machine is.
+    static CLOCK_POLLS: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Zeroes this thread's clock-poll count, so a measurement can start from a
+/// known point.
+#[cfg(feature = "test-hooks")]
+pub fn reset_clock_polls() {
+    CLOCK_POLLS.with(|polls| polls.set(0));
+}
+
+/// How many times this thread has read the clock since [`reset_clock_polls`].
+///
+/// Counts every [`ResourceTracker::check_time`], whether or not a
+/// `max_duration` is configured, so a test can assert how densely a native
+/// loop polls without also having to make it time out.
+#[cfg(feature = "test-hooks")]
+#[must_use]
+pub fn clock_polls() -> usize {
+    CLOCK_POLLS.with(Cell::get)
 }
 
 /// Returns memory used in bytes

--- a/crates/monty/src/modules/base64.rs
+++ b/crates/monty/src/modules/base64.rs
@@ -13,7 +13,9 @@
 //! Encoders take bytes only; decoders also take ASCII `str` (CPython's
 //! `_bytes_from_decode_data`).
 
-use std::{borrow::Cow, cmp::Ordering};
+use std::{borrow::Cow, cmp::Ordering, iter::once};
+
+use monty_types::ResourceTracker;
 
 use crate::{
     args::{ArgValues, FromArgs},
@@ -23,6 +25,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
+    resource_checks::check_estimated_size,
     types::{CmpOrder, Module, PyTrait, bytes::bytes_repr},
     value::Value,
 };
@@ -183,13 +186,13 @@ fn call_b64encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(s, vm);
     defer_drop!(altchars, vm);
 
-    let mut encoded = b64_encode(encode_input(s, vm)?.as_ref());
+    let mut encoded = b64_encode(encode_input(s, vm)?.as_ref(), &vm.heap.tracker)?;
     if !matches!(altchars, Value::None) {
         // CPython asserts on the raw object's length before `bytes.maketrans`
         // type-checks it, so a 1-byte `str` is an AssertionError, not a TypeError.
         assert_len(altchars, 2, vm)?;
         let alt = encode_input(altchars, vm)?.into_owned();
-        translate(&mut encoded, b"+/", &alt);
+        translate(&mut encoded, b"+/", &alt, &vm.heap.tracker)?;
     }
     Ok(allocate_bytes(encoded, vm.heap))
 }
@@ -209,10 +212,10 @@ fn call_b64decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         // Unlike the encode path, CPython coerces before asserting the length.
         let alt = decode_input(altchars, vm)?.into_owned();
         assert_len_bytes(&alt, 2)?;
-        translate(&mut data, &alt, b"+/");
+        translate(&mut data, &alt, b"+/", &vm.heap.tracker)?;
     }
     let strict = validate.py_bool(vm)?;
-    let decoded = b64_decode(&data, strict)?;
+    let decoded = b64_decode(&data, strict, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -220,7 +223,7 @@ fn call_b64decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 fn call_standard_b64encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let StandardB64EncodeArgs { s } = StandardB64EncodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let encoded = b64_encode(encode_input(s, vm)?.as_ref());
+    let encoded = b64_encode(encode_input(s, vm)?.as_ref(), &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -228,7 +231,7 @@ fn call_standard_b64encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value>
 fn call_standard_b64decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let StandardB64DecodeArgs { s } = StandardB64DecodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let decoded = b64_decode(decode_input(s, vm)?.as_ref(), false)?;
+    let decoded = b64_decode(decode_input(s, vm)?.as_ref(), false, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -237,8 +240,8 @@ fn call_standard_b64decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value>
 fn call_urlsafe_b64encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let UrlsafeB64EncodeArgs { s } = UrlsafeB64EncodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let mut encoded = b64_encode(encode_input(s, vm)?.as_ref());
-    translate(&mut encoded, b"+/", b"-_");
+    let mut encoded = b64_encode(encode_input(s, vm)?.as_ref(), &vm.heap.tracker)?;
+    translate(&mut encoded, b"+/", b"-_", &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -247,8 +250,8 @@ fn call_urlsafe_b64decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> 
     let UrlsafeB64DecodeArgs { s } = UrlsafeB64DecodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
     let mut data = decode_input(s, vm)?.into_owned();
-    translate(&mut data, b"-_", b"+/");
-    let decoded = b64_decode(&data, false)?;
+    translate(&mut data, b"-_", b"+/", &vm.heap.tracker)?;
+    let decoded = b64_decode(&data, false, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -256,7 +259,7 @@ fn call_urlsafe_b64decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> 
 fn call_b32encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let B32EncodeArgs { s } = B32EncodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let encoded = b32_encode(memoryview_input(s, vm)?.as_ref(), B32_ALPHABET);
+    let encoded = b32_encode(memoryview_input(s, vm)?.as_ref(), B32_ALPHABET, &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -277,9 +280,9 @@ fn call_b32decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     if !matches!(map01, Value::None) {
         let map = decode_input(map01, vm)?.into_owned();
         assert_len_bytes(&map, 1)?;
-        translate(&mut data, b"01", &[b'O', map[0]]);
+        translate(&mut data, b"01", &[b'O', map[0]], &vm.heap.tracker)?;
     }
-    let decoded = b32_decode(&data, B32_ALPHABET, casefold.py_bool(vm)?)?;
+    let decoded = b32_decode(&data, B32_ALPHABET, casefold.py_bool(vm)?, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -287,7 +290,7 @@ fn call_b32decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 fn call_b32hexencode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let B32HexEncodeArgs { s } = B32HexEncodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let encoded = b32_encode(memoryview_input(s, vm)?.as_ref(), B32HEX_ALPHABET);
+    let encoded = b32_encode(memoryview_input(s, vm)?.as_ref(), B32HEX_ALPHABET, &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -302,7 +305,7 @@ fn call_b32hexdecode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     if !data.len().is_multiple_of(8) {
         return Err(incorrect_padding());
     }
-    let decoded = b32_decode(&data, B32HEX_ALPHABET, casefold.py_bool(vm)?)?;
+    let decoded = b32_decode(&data, B32HEX_ALPHABET, casefold.py_bool(vm)?, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -310,7 +313,7 @@ fn call_b32hexdecode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 fn call_b16encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let B16EncodeArgs { s } = B16EncodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let encoded = b16_encode(encode_input(s, vm)?.as_ref());
+    let encoded = b16_encode(encode_input(s, vm)?.as_ref(), &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -322,7 +325,7 @@ fn call_b16decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(casefold, vm);
 
     let data = decode_input(s, vm)?.into_owned();
-    let decoded = b16_decode(&data, casefold.py_bool(vm)?)?;
+    let decoded = b16_decode(&data, casefold.py_bool(vm)?, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -333,9 +336,20 @@ fn call_encodebytes(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(s, vm);
 
     let data = input_type_check(s, vm)?;
-    let mut encoded = Vec::new();
-    for chunk in data.chunks(usize::from(MAX_BIN_SIZE)) {
-        encoded.extend_from_slice(&b64_encode(chunk));
+    // Each `MAX_BIN_SIZE` chunk becomes `MAX_LINE_SIZE` characters plus a
+    // newline. The per-chunk encode only ever sees 57 bytes, so the whole
+    // output has to be preflighted here.
+    let capacity = data
+        .len()
+        .div_ceil(usize::from(MAX_BIN_SIZE))
+        .saturating_mul(usize::from(MAX_LINE_SIZE) + 1);
+    check_estimated_size(capacity, &vm.heap.tracker)?;
+    let mut encoded = Vec::with_capacity(capacity);
+    for (index, chunk) in data.chunks(usize::from(MAX_BIN_SIZE)).enumerate() {
+        // Each chunk is 57 bytes, so the encode's own poll never reaches its
+        // stride; this loop is the one that runs long.
+        vm.heap.tracker.check_time_every(index)?;
+        encoded.extend_from_slice(&b64_encode(chunk, &vm.heap.tracker)?);
         encoded.push(b'\n');
     }
     Ok(allocate_bytes(encoded, vm.heap))
@@ -346,7 +360,7 @@ fn call_encodebytes(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 fn call_decodebytes(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let DecodebytesArgs { s } = DecodebytesArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
-    let decoded = b64_decode(input_type_check(s, vm)?.as_ref(), false)?;
+    let decoded = b64_decode(input_type_check(s, vm)?.as_ref(), false, &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -360,7 +374,7 @@ fn call_b85encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(pad, vm);
 
     let pad = pad.py_bool(vm)?;
-    let encoded = b85_encode(memoryview_input(b, vm)?.as_ref(), B85_ALPHABET, pad);
+    let encoded = b85_encode(memoryview_input(b, vm)?.as_ref(), B85_ALPHABET, pad, &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -369,7 +383,7 @@ fn call_b85decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let B85DecodeArgs { b } = B85DecodeArgs::from_args(args, vm)?;
     defer_drop!(b, vm);
 
-    let decoded = b85_decode(decode_input(b, vm)?.as_ref(), B85_ALPHABET, "base85")?;
+    let decoded = b85_decode(decode_input(b, vm)?.as_ref(), B85_ALPHABET, "base85", &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -378,7 +392,7 @@ fn call_z85encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let Z85EncodeArgs { s } = Z85EncodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
 
-    let encoded = b85_encode(memoryview_input(s, vm)?.as_ref(), Z85_ALPHABET, false);
+    let encoded = b85_encode(memoryview_input(s, vm)?.as_ref(), Z85_ALPHABET, false, &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -387,7 +401,7 @@ fn call_z85decode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let Z85DecodeArgs { s } = Z85DecodeArgs::from_args(args, vm)?;
     defer_drop!(s, vm);
 
-    let decoded = b85_decode(decode_input(s, vm)?.as_ref(), Z85_ALPHABET, "z85")?;
+    let decoded = b85_decode(decode_input(s, vm)?.as_ref(), Z85_ALPHABET, "z85", &vm.heap.tracker)?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -419,7 +433,12 @@ fn call_a85encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let fold = foldspaces.py_bool(vm)?;
     let keep_padding = data.len() % 4 != 0 && pad.py_bool(vm)?;
     let adobe = adobe.py_bool(vm)?;
-    let mut encoded = a85_encode(&data, keep_padding, fold);
+    let framing = if adobe {
+        A85_ADOBE_START.len() + A85_ADOBE_END.len()
+    } else {
+        0
+    };
+    let mut encoded = a85_encode(&data, keep_padding, fold, framing, &vm.heap.tracker)?;
 
     if adobe {
         encoded.splice(0..0, *A85_ADOBE_START);
@@ -428,7 +447,7 @@ fn call_a85encode(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     // result — so the opening marker counts towards the first line.
     if wrapcol.py_bool(vm)? {
         let width = a85_wrapcol(wrapcol, if adobe { 2 } else { 1 }, vm)?;
-        encoded = a85_wrap(&encoded, width, adobe);
+        encoded = a85_wrap(&encoded, width, adobe, &vm.heap.tracker)?;
     }
     if adobe {
         encoded.extend_from_slice(A85_ADOBE_END);
@@ -603,22 +622,36 @@ single_arg_struct!(Z85EncodeArgs, "z85encode");
 single_arg_struct!(Z85DecodeArgs, "z85decode");
 
 /// Encodes bytes as standard base64 with `=` padding.
-pub(super) fn b64_encode(data: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(data.len().div_ceil(3) * 4);
-    for chunk in data.chunks(3) {
-        let b0 = usize::from(chunk[0]);
-        let b1 = chunk.get(1).map_or(0, |b| usize::from(*b));
-        let b2 = chunk.get(2).map_or(0, |b| usize::from(*b));
-        out.push(B64_ALPHABET[b0 >> 2]);
-        out.push(B64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)]);
-        out.push(if chunk.len() > 1 {
-            B64_ALPHABET[((b1 & 0x0f) << 2) | (b2 >> 6)]
-        } else {
-            b'='
-        });
-        out.push(if chunk.len() > 2 { B64_ALPHABET[b2 & 0x3f] } else { b'=' });
+pub(super) fn b64_encode(data: &[u8], tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    b64_encode_reserving(data, 0, tracker)
+}
+
+/// [`b64_encode`], leaving room for `extra` bytes the caller will append.
+///
+/// The encoder fills its buffer exactly, so appending even one byte —
+/// `b2a_base64`'s trailing newline — grows it, and a `Vec` grows by doubling:
+/// a second copy of the output, charged as a burst the preflight never saw.
+pub(super) fn b64_encode_reserving(data: &[u8], extra: usize, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    let capacity = data.len().div_ceil(3) * 4 + extra;
+    check_estimated_size(capacity, tracker)?;
+    let mut out = Vec::with_capacity(capacity);
+    for window in data.chunks(ResourceTracker::poll_window(3)) {
+        tracker.check_time()?;
+        for chunk in window.chunks(3) {
+            let b0 = usize::from(chunk[0]);
+            let b1 = chunk.get(1).map_or(0, |b| usize::from(*b));
+            let b2 = chunk.get(2).map_or(0, |b| usize::from(*b));
+            out.push(B64_ALPHABET[b0 >> 2]);
+            out.push(B64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)]);
+            out.push(if chunk.len() > 1 {
+                B64_ALPHABET[((b1 & 0x0f) << 2) | (b2 >> 6)]
+            } else {
+                b'='
+            });
+            out.push(if chunk.len() > 2 { B64_ALPHABET[b2 & 0x3f] } else { b'=' });
+        }
     }
-    out
+    Ok(out)
 }
 
 /// Decodes base64, mirroring `binascii.a2b_base64`'s two modes.
@@ -628,7 +661,7 @@ pub(super) fn b64_encode(data: &[u8]) -> Vec<u8> {
 /// `b64decode(b'YQ==YQ==')` is three bytes, not two `a`s. The state machine
 /// transcribes CPython's, since which error an input produces depends on
 /// exactly where CPython gives up.
-pub(super) fn b64_decode(data: &[u8], strict: bool) -> RunResult<Vec<u8>> {
+pub(super) fn b64_decode(data: &[u8], strict: bool, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     if strict && data.first() == Some(&b'=') {
         return Err(binascii_error("Leading padding not allowed"));
     }
@@ -642,65 +675,68 @@ pub(super) fn b64_decode(data: &[u8], strict: bool) -> RunResult<Vec<u8>> {
     // non-zero `quad_pos` legal at end of input.
     let mut quad_closed = false;
 
-    for byte in data {
-        if *byte == b'=' {
+    for window in data.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        for byte in window {
+            if *byte == b'=' {
+                if strict {
+                    // A pad is only ever legal two or three characters into an
+                    // open quad. One character in, CPython reports the same
+                    // "1 more than a multiple of 4" error it would at end of input.
+                    if quad_closed || quad_pos == 0 {
+                        return Err(binascii_error("Excess padding not allowed"));
+                    } else if quad_pos == 1 {
+                        return Err(invalid_data_characters(out.len()));
+                    }
+                }
+                padding_started = true;
+                // Only count pads while the quad is open: once closed, further `=`
+                // bytes are inert, and counting them would overflow these `u8`s.
+                if quad_pos >= 2 && !quad_closed {
+                    pads += 1;
+                    if quad_pos + pads >= 4 {
+                        quad_closed = true;
+                    }
+                }
+                continue;
+            }
+
+            let Some(sextet) = b64_value(*byte) else {
+                if strict {
+                    return Err(binascii_error("Only base64 data is allowed"));
+                }
+                continue;
+            };
             if strict {
-                // A pad is only ever legal two or three characters into an
-                // open quad. One character in, CPython reports the same
-                // "1 more than a multiple of 4" error it would at end of input.
-                if quad_closed || quad_pos == 0 {
-                    return Err(binascii_error("Excess padding not allowed"));
-                } else if quad_pos == 1 {
-                    return Err(invalid_data_characters(out.len()));
+                if quad_closed {
+                    return Err(binascii_error("Excess data after padding"));
+                } else if padding_started {
+                    return Err(binascii_error("Discontinuous padding not allowed"));
                 }
             }
-            padding_started = true;
-            // Only count pads while the quad is open: once closed, further `=`
-            // bytes are inert, and counting them would overflow these `u8`s.
-            if quad_pos >= 2 && !quad_closed {
-                pads += 1;
-                if quad_pos + pads >= 4 {
-                    quad_closed = true;
+            pads = 0;
+            quad_closed = false;
+
+            match quad_pos {
+                0 => {
+                    quad_pos = 1;
+                    leftchar = sextet;
                 }
-            }
-            continue;
-        }
-
-        let Some(sextet) = b64_value(*byte) else {
-            if strict {
-                return Err(binascii_error("Only base64 data is allowed"));
-            }
-            continue;
-        };
-        if strict {
-            if quad_closed {
-                return Err(binascii_error("Excess data after padding"));
-            } else if padding_started {
-                return Err(binascii_error("Discontinuous padding not allowed"));
-            }
-        }
-        pads = 0;
-        quad_closed = false;
-
-        match quad_pos {
-            0 => {
-                quad_pos = 1;
-                leftchar = sextet;
-            }
-            1 => {
-                quad_pos = 2;
-                out.push((leftchar << 2) | (sextet >> 4));
-                leftchar = sextet & 0x0f;
-            }
-            2 => {
-                quad_pos = 3;
-                out.push((leftchar << 4) | (sextet >> 2));
-                leftchar = sextet & 0x03;
-            }
-            _ => {
-                quad_pos = 0;
-                out.push((leftchar << 6) | sextet);
-                leftchar = 0;
+                1 => {
+                    quad_pos = 2;
+                    out.push((leftchar << 2) | (sextet >> 4));
+                    leftchar = sextet & 0x0f;
+                }
+                2 => {
+                    quad_pos = 3;
+                    out.push((leftchar << 4) | (sextet >> 2));
+                    leftchar = sextet & 0x03;
+                }
+                _ => {
+                    quad_pos = 0;
+                    out.push((leftchar << 6) | sextet);
+                    leftchar = 0;
+                }
             }
         }
     }
@@ -738,31 +774,36 @@ fn b64_value(byte: u8) -> Option<u8> {
 
 /// Encodes bytes as base32 over `alphabet`, padding the final group to eight
 /// characters with `=`.
-fn b32_encode(data: &[u8], alphabet: &[u8; 32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(data.len().div_ceil(5) * 8);
-    for chunk in data.chunks(5) {
-        let mut acc: u64 = 0;
-        for i in 0..5 {
-            acc = (acc << 8) | u64::from(chunk.get(i).copied().unwrap_or(0));
-        }
-        // Characters carrying data; the remaining 8 - encoded_len are pads.
-        let encoded_len = match chunk.len() {
-            1 => 2,
-            2 => 4,
-            3 => 5,
-            4 => 7,
-            _ => 8,
-        };
-        for i in 0..8 {
-            out.push(if i < encoded_len {
-                let shift = 35 - i * 5;
-                alphabet[usize::try_from((acc >> shift) & 0x1f).expect("5 bits fit usize")]
-            } else {
-                b'='
-            });
+fn b32_encode(data: &[u8], alphabet: &[u8; 32], tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    let capacity = data.len().div_ceil(5) * 8;
+    check_estimated_size(capacity, tracker)?;
+    let mut out = Vec::with_capacity(capacity);
+    for window in data.chunks(ResourceTracker::poll_window(5)) {
+        tracker.check_time()?;
+        for chunk in window.chunks(5) {
+            let mut acc: u64 = 0;
+            for i in 0..5 {
+                acc = (acc << 8) | u64::from(chunk.get(i).copied().unwrap_or(0));
+            }
+            // Characters carrying data; the remaining 8 - encoded_len are pads.
+            let encoded_len = match chunk.len() {
+                1 => 2,
+                2 => 4,
+                3 => 5,
+                4 => 7,
+                _ => 8,
+            };
+            for i in 0..8 {
+                out.push(if i < encoded_len {
+                    let shift = 35 - i * 5;
+                    alphabet[usize::try_from((acc >> shift) & 0x1f).expect("5 bits fit usize")]
+                } else {
+                    b'='
+                });
+            }
         }
     }
-    out
+    Ok(out)
 }
 
 /// Decodes base32 over `alphabet`.
@@ -770,7 +811,7 @@ fn b32_encode(data: &[u8], alphabet: &[u8; 32]) -> Vec<u8> {
 /// Assumes the caller has already checked that the length is a multiple of
 /// eight and applied any `map01` translation — CPython performs both before
 /// this point and the resulting error ordering is observable.
-fn b32_decode(data: &[u8], alphabet: &[u8; 32], casefold: bool) -> RunResult<Vec<u8>> {
+fn b32_decode(data: &[u8], alphabet: &[u8; 32], casefold: bool, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     let folded: Cow<'_, [u8]> = if casefold {
         Cow::Owned(data.to_ascii_uppercase())
     } else {
@@ -779,6 +820,8 @@ fn b32_decode(data: &[u8], alphabet: &[u8; 32], casefold: bool) -> RunResult<Vec
     let stripped = {
         let mut end = folded.len();
         while end > 0 && folded[end - 1] == b'=' {
+            // An input that is nothing but padding walks the whole buffer here.
+            tracker.check_time_every_bytes(folded.len() - end)?;
             end -= 1;
         }
         &folded[..end]
@@ -787,18 +830,23 @@ fn b32_decode(data: &[u8], alphabet: &[u8; 32], casefold: bool) -> RunResult<Vec
 
     let mut out = Vec::with_capacity(stripped.len() / 8 * 5 + 5);
     let mut last_acc: u64 = 0;
-    for group in stripped.chunks(8) {
-        let mut acc: u64 = 0;
-        for byte in group {
-            let Some(value) = alphabet.iter().position(|c| c == byte) else {
-                return Err(binascii_error("Non-base32 digit found"));
-            };
-            acc = (acc << 5) | u64::try_from(value).expect("alphabet index fits u64");
+    // Each byte costs a linear scan of the 32-character alphabet, so this is
+    // the slowest decoder in the module.
+    for window in stripped.chunks(ResourceTracker::poll_window(8)) {
+        tracker.check_time()?;
+        for group in window.chunks(8) {
+            let mut acc: u64 = 0;
+            for byte in group {
+                let Some(value) = alphabet.iter().position(|c| c == byte) else {
+                    return Err(binascii_error("Non-base32 digit found"));
+                };
+                acc = (acc << 5) | u64::try_from(value).expect("alphabet index fits u64");
+            }
+            last_acc = acc;
+            // A short final group is still written as five bytes here and
+            // trimmed below, as CPython's `decoded[-5:] = last[:leftover]` does.
+            out.extend_from_slice(&acc.to_be_bytes()[3..]);
         }
-        last_acc = acc;
-        // A short final group is still written as five bytes here and trimmed
-        // below, exactly as CPython's `decoded[-5:] = last[:leftover]` does.
-        out.extend_from_slice(&acc.to_be_bytes()[3..]);
     }
 
     // 0, 1, 3, 4 and 6 are the pad counts a base32 encoder can emit.
@@ -816,36 +864,61 @@ fn b32_decode(data: &[u8], alphabet: &[u8; 32], casefold: bool) -> RunResult<Vec
 }
 
 /// Encodes bytes as uppercase hex (`b16encode`).
-fn b16_encode(data: &[u8]) -> Vec<u8> {
+fn b16_encode(data: &[u8], tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     const HEX: &[u8; 16] = b"0123456789ABCDEF";
-    let mut out = Vec::with_capacity(data.len() * 2);
-    for byte in data {
-        out.push(HEX[usize::from(byte >> 4)]);
-        out.push(HEX[usize::from(byte & 0x0f)]);
+    let capacity = data.len() * 2;
+    check_estimated_size(capacity, tracker)?;
+    let mut out = Vec::with_capacity(capacity);
+    for window in data.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        for byte in window {
+            out.push(HEX[usize::from(byte >> 4)]);
+            out.push(HEX[usize::from(byte & 0x0f)]);
+        }
     }
-    out
+    Ok(out)
 }
 
 /// Decodes uppercase hex, folding case first when asked.
 ///
 /// CPython screens the whole input for non-`[0-9A-F]` bytes before
 /// `binascii.unhexlify` sees it, so a bad digit outranks an odd length.
-fn b16_decode(data: &[u8], casefold: bool) -> RunResult<Vec<u8>> {
+fn b16_decode(data: &[u8], casefold: bool, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     let folded: Cow<'_, [u8]> = if casefold {
         Cow::Owned(data.to_ascii_uppercase())
     } else {
         Cow::Borrowed(data)
     };
-    if folded.iter().any(|b| !matches!(b, b'0'..=b'9' | b'A'..=b'F')) {
-        return Err(binascii_error("Non-base16 digit found"));
+    // Screens the whole buffer before a single byte is decoded, so on a large
+    // input it is the longer of the two passes; polling per window leaves the
+    // scan itself a tight loop.
+    for window in folded.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        if window.iter().any(|b| !matches!(b, b'0'..=b'9' | b'A'..=b'F')) {
+            return Err(binascii_error("Non-base16 digit found"));
+        }
     }
     if !folded.len().is_multiple_of(2) {
         return Err(binascii_error("Odd-length string"));
     }
-    Ok(folded
-        .chunks(2)
-        .map(|pair| (hex_value(pair[0]) << 4) | hex_value(pair[1]))
-        .collect())
+    // Reserved rather than collected: collecting into a `Result` erases the
+    // lower size hint, leaving the output to grow by doubling.
+    let mut out = Vec::with_capacity(folded.len() / 2);
+    // `chunks_exact` rather than `chunks`: the length is known even above and
+    // the window is a multiple of two, so no window ever has a remainder for
+    // it to drop — and the known stride is what lets this vectorise. A plain
+    // `chunks` costs the loop that, at several times what the poll does.
+    for window in folded.chunks(ResourceTracker::poll_window(2)) {
+        tracker.check_time()?;
+        out.extend(
+            window
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|pair| (hex_value(pair[0]) << 4) | hex_value(pair[1])),
+        );
+    }
+    Ok(out)
 }
 
 /// Maps a validated uppercase hex digit to its value.
@@ -862,28 +935,33 @@ fn hex_value(byte: u8) -> u8 {
 /// A short final group is zero-padded to four bytes; unless `pad` is set, the
 /// characters those padding bytes produced are dropped again, so the output
 /// length tracks the input's.
-fn b85_encode(data: &[u8], alphabet: &[u8; 85], pad: bool) -> Vec<u8> {
+fn b85_encode(data: &[u8], alphabet: &[u8; 85], pad: bool, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     let padding = (4 - data.len() % 4) % 4;
-    let mut out = Vec::with_capacity(data.len().div_ceil(4) * 5);
+    let capacity = data.len().div_ceil(4) * 5;
+    check_estimated_size(capacity, tracker)?;
+    let mut out = Vec::with_capacity(capacity);
 
-    for chunk in data.chunks(4) {
-        let mut word: u32 = 0;
-        for i in 0..4 {
-            word = (word << 8) | u32::from(chunk.get(i).copied().unwrap_or(0));
+    for window in data.chunks(ResourceTracker::poll_window(4)) {
+        tracker.check_time()?;
+        for chunk in window.chunks(4) {
+            let mut word: u32 = 0;
+            for i in 0..4 {
+                word = (word << 8) | u32::from(chunk.get(i).copied().unwrap_or(0));
+            }
+            // Five base-85 digits, most significant first.
+            let mut digits = [0u8; 5];
+            for slot in digits.iter_mut().rev() {
+                *slot = alphabet[usize::try_from(word % 85).expect("remainder below 85")];
+                word /= 85;
+            }
+            out.extend_from_slice(&digits);
         }
-        // Five base-85 digits, most significant first.
-        let mut digits = [0u8; 5];
-        for slot in digits.iter_mut().rev() {
-            *slot = alphabet[usize::try_from(word % 85).expect("remainder below 85")];
-            word /= 85;
-        }
-        out.extend_from_slice(&digits);
     }
 
     if !pad {
         out.truncate(out.len() - padding);
     }
-    out
+    Ok(out)
 }
 
 /// Decodes base85 over `alphabet`, with `codec` naming the scheme in errors.
@@ -891,27 +969,32 @@ fn b85_encode(data: &[u8], alphabet: &[u8; 85], pad: bool) -> Vec<u8> {
 /// A trailing partial group is completed with the alphabet's highest character
 /// and the extra bytes trimmed off, so any input length decodes. Unlike the
 /// other decoders here, failures are plain `ValueError`s, as CPython's are.
-fn b85_decode(data: &[u8], alphabet: &[u8; 85], codec: &str) -> RunResult<Vec<u8>> {
+fn b85_decode(data: &[u8], alphabet: &[u8; 85], codec: &str, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     let table = base85_table(alphabet);
     let padding = (5 - data.len() % 5) % 5;
     let mut out = Vec::with_capacity(data.len().div_ceil(5) * 4);
 
-    for (chunk_index, chunk) in data.chunks(5).enumerate() {
-        let start = chunk_index * 5;
-        let mut acc: u64 = 0;
-        for offset in 0..5 {
-            // Positions past the end are the virtual padding: the top digit.
-            let value = match chunk.get(offset) {
-                Some(byte) => table[usize::from(*byte)].ok_or_else(|| {
-                    codec_value_error(format!("bad {codec} character at position {}", start + offset))
-                })?,
-                None => 84,
-            };
-            acc = acc * 85 + u64::from(value);
+    // The byte offset of the current group, which the errors below report.
+    let mut start = 0;
+    for window in data.chunks(ResourceTracker::poll_window(5)) {
+        tracker.check_time()?;
+        for chunk in window.chunks(5) {
+            let mut acc: u64 = 0;
+            for offset in 0..5 {
+                // Positions past the end are the virtual padding: the top digit.
+                let value = match chunk.get(offset) {
+                    Some(byte) => table[usize::from(*byte)].ok_or_else(|| {
+                        codec_value_error(format!("bad {codec} character at position {}", start + offset))
+                    })?,
+                    None => 84,
+                };
+                acc = acc * 85 + u64::from(value);
+            }
+            let word = u32::try_from(acc)
+                .map_err(|_| codec_value_error(format!("{codec} overflow in hunk starting at byte {start}")))?;
+            out.extend_from_slice(&word.to_be_bytes());
+            start += 5;
         }
-        let word = u32::try_from(acc)
-            .map_err(|_| codec_value_error(format!("{codec} overflow in hunk starting at byte {start}")))?;
-        out.extend_from_slice(&word.to_be_bytes());
     }
 
     out.truncate(out.len() - padding);
@@ -932,31 +1015,39 @@ fn base85_table(alphabet: &[u8; 85]) -> [Option<u8>; 256] {
 /// An all-zero word folds to `z` and, with `foldspaces`, four spaces fold to
 /// `y`. A short final group is zero-padded to a full word and the digits that
 /// padding produced are dropped again unless `pad` is set.
-fn a85_encode(data: &[u8], pad: bool, foldspaces: bool) -> Vec<u8> {
+///
+/// `extra` reserves the Adobe framing the caller splices onto both ends, which
+/// would otherwise double a buffer this fills to the byte.
+fn a85_encode(data: &[u8], pad: bool, foldspaces: bool, extra: usize, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     let padding = (4 - data.len() % 4) % 4;
-    let mut out: Vec<u8> = Vec::with_capacity(data.len().div_ceil(4) * 5);
+    let capacity = data.len().div_ceil(4) * 5 + extra;
+    check_estimated_size(capacity, tracker)?;
+    let mut out: Vec<u8> = Vec::with_capacity(capacity);
     // Where the final word's digits start, so the padding trim below can
     // rewrite them the way CPython rewrites `chunks[-1]`.
     let mut last_start = 0;
 
-    for chunk in data.chunks(4) {
-        last_start = out.len();
-        let mut word: u32 = 0;
-        for i in 0..4 {
-            word = (word << 8) | u32::from(chunk.get(i).copied().unwrap_or(0));
-        }
-        if word == 0 {
-            out.push(b'z');
-        } else if foldspaces && word == 0x2020_2020 {
-            out.push(b'y');
-        } else {
-            // Five base-85 digits, most significant first.
-            let mut digits = [0u8; 5];
-            for slot in digits.iter_mut().rev() {
-                *slot = A85_FIRST_DIGIT + u8::try_from(word % 85).expect("remainder below 85");
-                word /= 85;
+    for window in data.chunks(ResourceTracker::poll_window(4)) {
+        tracker.check_time()?;
+        for chunk in window.chunks(4) {
+            last_start = out.len();
+            let mut word: u32 = 0;
+            for i in 0..4 {
+                word = (word << 8) | u32::from(chunk.get(i).copied().unwrap_or(0));
             }
-            out.extend_from_slice(&digits);
+            if word == 0 {
+                out.push(b'z');
+            } else if foldspaces && word == 0x2020_2020 {
+                out.push(b'y');
+            } else {
+                // Five base-85 digits, most significant first.
+                let mut digits = [0u8; 5];
+                for slot in digits.iter_mut().rev() {
+                    *slot = A85_FIRST_DIGIT + u8::try_from(word % 85).expect("remainder below 85");
+                    word /= 85;
+                }
+                out.extend_from_slice(&digits);
+            }
         }
     }
 
@@ -969,17 +1060,23 @@ fn a85_encode(data: &[u8], pad: bool, foldspaces: bool) -> Vec<u8> {
         }
         out.truncate(out.len() - padding);
     }
-    out
+    Ok(out)
 }
 
 /// Breaks encoded output into lines of at most `width` characters.
 ///
 /// With the Adobe framing an extra newline is added when `~>` would not fit on
 /// the last line, so no line ever exceeds `width`.
-fn a85_wrap(result: &[u8], width: usize, adobe: bool) -> Vec<u8> {
-    let mut out = Vec::with_capacity(result.len() + result.len() / width + 1);
+fn a85_wrap(result: &[u8], width: usize, adobe: bool, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    // The closing marker is appended to what this returns, so it is reserved
+    // here alongside the newlines rather than growing the buffer afterwards.
+    let closing = if adobe { A85_ADOBE_END.len() } else { 0 };
+    let capacity = result.len() + result.len() / width + 1 + closing;
+    check_estimated_size(capacity, tracker)?;
+    let mut out = Vec::with_capacity(capacity);
     let mut last_len = 0;
     for (index, line) in result.chunks(width).enumerate() {
+        tracker.check_time_every(index)?;
         if index > 0 {
             out.push(b'\n');
         }
@@ -989,7 +1086,7 @@ fn a85_wrap(result: &[u8], width: usize, adobe: bool) -> Vec<u8> {
     if adobe && last_len + A85_ADOBE_END.len() > width {
         out.push(b'\n');
     }
-    out
+    Ok(out)
 }
 
 /// Resolves `max(2 if adobe else 1, wrapcol)` and the index `range` then needs.
@@ -1057,45 +1154,55 @@ fn a85_strip_adobe(data: &[u8], adobe: bool) -> RunResult<&[u8]> {
 /// The four `u`s appended to the input flush a trailing partial group, exactly
 /// as CPython's `b + b'u' * 4` does; the bytes they contributed are trimmed
 /// off again at the end, so a group left one digit short decodes to nothing.
+///
+/// Alone among the decoders this can outgrow its input, so its buffer is sized
+/// by [`a85_decoded_size`] rather than from the input's length.
 fn a85_decode(data: &[u8], foldspaces: bool, ignore: &IgnoreChars<'_>, vm: &mut VM<'_>) -> RunResult<Vec<u8>> {
-    let mut out: Vec<u8> = Vec::with_capacity(data.len().div_ceil(5) * 4);
+    // The four digits CPython appends to flush a partial group, ridden along
+    // as a final window so the loop body is written once.
+    const FLUSH: [u8; 4] = [A85_LAST_DIGIT; 4];
+
+    let capacity = a85_decoded_size(data, foldspaces, &vm.heap.tracker)?;
+    check_estimated_size(capacity, &vm.heap.tracker)?;
+    let mut out: Vec<u8> = Vec::with_capacity(capacity);
     let mut acc: u64 = 0;
     let mut digits = 0u8;
-    // Counts only the bytes reaching `skips`, the one arm whose cost grows with
-    // a caller's `ignorechars`. Indexing by position instead would let input
-    // that lands those bytes off the poll's stride skip the clock entirely.
-    let mut ignored = 0usize;
 
-    for byte in data.iter().copied().chain([A85_LAST_DIGIT; 4]) {
-        if (A85_FIRST_DIGIT..=A85_LAST_DIGIT).contains(&byte) {
-            acc = acc * 85 + u64::from(byte - A85_FIRST_DIGIT);
-            digits += 1;
-            if digits == 5 {
-                // Five digits reach 85**5 - 1, half again as much as a word holds.
-                let word = u32::try_from(acc).map_err(|_| codec_value_error("Ascii85 overflow"))?;
-                out.extend_from_slice(&word.to_be_bytes());
-                acc = 0;
-                digits = 0;
-            }
-        } else if byte == b'z' {
-            // The short forms stand for a whole word, so they cannot appear
-            // part-way through one.
-            if digits != 0 {
-                return Err(codec_value_error("z inside Ascii85 5-tuple"));
-            }
-            out.extend_from_slice(&[0; 4]);
-        } else if foldspaces && byte == b'y' {
-            if digits != 0 {
-                return Err(codec_value_error("y inside Ascii85 5-tuple"));
-            }
-            out.extend_from_slice(b"    ");
-        } else {
-            // `ignorechars` is a Python container, so this is a `py_contains`
-            // per byte — linear for `bytes`. Nothing here returns to the VM's
-            // dispatch checkpoint, so the loop polls the clock itself.
-            vm.heap.tracker.check_time_every(ignored)?;
-            ignored += 1;
-            if !ignore.skips(byte, vm)? {
+    // Polled per window rather than per byte, which covers every arm — the
+    // digit arms are cheap but unbounded in number, and `skips` below is a
+    // `py_contains` per byte, so a window caps the expensive work between two
+    // checks either way.
+    for window in data
+        .chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL)
+        .chain(once(&FLUSH[..]))
+    {
+        vm.heap.tracker.check_time()?;
+        for byte in window.iter().copied() {
+            if (A85_FIRST_DIGIT..=A85_LAST_DIGIT).contains(&byte) {
+                acc = acc * 85 + u64::from(byte - A85_FIRST_DIGIT);
+                digits += 1;
+                if digits == 5 {
+                    // Five digits reach 85**5 - 1, half again as much as a word holds.
+                    let word = u32::try_from(acc).map_err(|_| codec_value_error("Ascii85 overflow"))?;
+                    out.extend_from_slice(&word.to_be_bytes());
+                    acc = 0;
+                    digits = 0;
+                }
+            } else if byte == b'z' {
+                // The short forms stand for a whole word, so they cannot appear
+                // part-way through one.
+                if digits != 0 {
+                    return Err(codec_value_error("z inside Ascii85 5-tuple"));
+                }
+                out.extend_from_slice(&[0; 4]);
+            } else if foldspaces && byte == b'y' {
+                if digits != 0 {
+                    return Err(codec_value_error("y inside Ascii85 5-tuple"));
+                }
+                out.extend_from_slice(b"    ");
+            } else if !ignore.skips(byte, vm)? {
+                // `ignorechars` is a Python container, so `skips` is a
+                // `py_contains` per byte — linear for `bytes`.
                 return Err(codec_value_error(format!(
                     "Non-Ascii85 digit found: {}",
                     char::from(byte)
@@ -1108,6 +1215,39 @@ fn a85_decode(data: &[u8], foldspaces: bool, ignore: &IgnoreChars<'_>, vm: &mut 
     // guarantees a whole word was written, so there is always that much to trim.
     out.truncate(out.len() - usize::from(4 - digits));
     Ok(out)
+}
+
+/// How many bytes [`a85_decode`] writes before its trailing trim.
+///
+/// The input's length is no guide: five ordinary digits decode to four bytes,
+/// but `z` — and `y` when folding — each stand for a whole four-byte word, so
+/// a buffer of them quadruples. Counting both is exact for an input that
+/// decodes and an upper bound for one that fails part-way.
+fn a85_decoded_size(data: &[u8], foldspaces: bool, tracker: &ResourceTracker) -> RunResult<usize> {
+    let mut digits = 0usize;
+    let mut words = 0usize;
+    // This runs ahead of the decode's own pass, so it is half of what a large
+    // input costs. Counted as two passes over each window rather than one:
+    // each is a plain predicate the compiler vectorises, where the single
+    // if/else chain they replace ran a byte at a time.
+    for chunk in data.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        digits += count_matching(chunk, |byte| (A85_FIRST_DIGIT..=A85_LAST_DIGIT).contains(&byte));
+        words += count_matching(chunk, |byte| byte == b'z' || (foldspaces && byte == b'y'));
+    }
+    // The decode appends four `u`s of its own, so any partial group is flushed
+    // as a whole one — which makes the group count the digits rounded up.
+    // Saturating so a 32-bit target reports a rejectable size rather than wrapping.
+    Ok(digits.div_ceil(5).saturating_add(words).saturating_mul(4))
+}
+
+/// Counts the bytes of `data` satisfying `predicate`.
+///
+/// Out of line for the same reason as [`decode_hex_window`]: on its own the
+/// compiler vectorises it, inlined into a polled loop it does not.
+#[inline(never)]
+fn count_matching(data: &[u8], predicate: impl Fn(u8) -> bool) -> usize {
+    data.iter().filter(|byte| predicate(**byte)).count()
 }
 
 /// Which bytes `a85decode` skips rather than decoding.
@@ -1142,7 +1282,7 @@ fn codec_value_error(message: impl Into<String>) -> RunError {
 /// same index of `to` — CPython's `bytes.translate(bytes.maketrans(...))`.
 ///
 /// Later entries win, matching `maketrans` when `from` repeats a byte.
-fn translate(data: &mut [u8], from: &[u8], to: &[u8]) {
+fn translate(data: &mut [u8], from: &[u8], to: &[u8], tracker: &ResourceTracker) -> RunResult<()> {
     let mut table: [u8; 256] = [0; 256];
     for (i, slot) in table.iter_mut().enumerate() {
         *slot = u8::try_from(i).expect("index bounded by table length");
@@ -1150,9 +1290,13 @@ fn translate(data: &mut [u8], from: &[u8], to: &[u8]) {
     for (src, dst) in from.iter().zip(to) {
         table[usize::from(*src)] = *dst;
     }
-    for byte in data {
-        *byte = table[usize::from(*byte)];
+    for window in data.chunks_mut(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        for byte in window {
+            *byte = table[usize::from(*byte)];
+        }
     }
+    Ok(())
 }
 
 /// Borrows the bytes of an encoder input.

--- a/crates/monty/src/modules/binascii.rs
+++ b/crates/monty/src/modules/binascii.rs
@@ -16,6 +16,7 @@
 //! The byte-level codecs live in [`super::base64`], where they were written
 //! first; `binascii` re-exposes them under the names CPython puts them at.
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
@@ -29,8 +30,11 @@ use crate::{
     intern::StaticStrings,
     modules::{
         ModuleFunctions,
-        base64::{allocate_bytes, b64_decode, b64_encode, binascii_error, decode_input_described, encode_input},
+        base64::{
+            allocate_bytes, b64_decode, b64_encode_reserving, binascii_error, decode_input_described, encode_input,
+        },
     },
+    resource_checks::check_estimated_size,
     types::{Module, PyTrait},
     value::Value,
 };
@@ -149,7 +153,12 @@ fn call_hexlify(vm: &mut VM<'_>, args: ArgValues, name: &str) -> RunResult<Value
     defer_drop!(sep, vm);
 
     let separator = hex_separator(sep.as_ref(), vm)?;
-    let encoded = hex_encode(encode_input(data, vm)?.as_ref(), separator, bytes_per_sep);
+    let encoded = hex_encode(
+        encode_input(data, vm)?.as_ref(),
+        separator,
+        bytes_per_sep,
+        &vm.heap.tracker,
+    )?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
@@ -165,7 +174,10 @@ fn call_unhexlify(vm: &mut VM<'_>, args: ArgValues, name: &str) -> RunResult<Val
     };
     defer_drop!(hexstr, vm);
 
-    let decoded = hex_decode(decode_input_described(hexstr, vm, "bytes, buffer or ASCII string")?.as_ref())?;
+    let decoded = hex_decode(
+        decode_input_described(hexstr, vm, "bytes, buffer or ASCII string")?.as_ref(),
+        &vm.heap.tracker,
+    )?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -176,8 +188,11 @@ fn call_b2a_base64(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(data, vm);
     defer_drop!(newline, vm);
 
-    let mut encoded = b64_encode(encode_input(data, vm)?.as_ref());
-    if newline.py_bool(vm)? {
+    // Resolved before encoding so the newline is reserved with the rest, which
+    // is also where CPython's Argument Clinic `p` converter reads it.
+    let newline = newline.py_bool(vm)?;
+    let mut encoded = b64_encode_reserving(encode_input(data, vm)?.as_ref(), usize::from(newline), &vm.heap.tracker)?;
+    if newline {
         encoded.push(b'\n');
     }
     Ok(allocate_bytes(encoded, vm.heap))
@@ -194,6 +209,7 @@ fn call_a2b_base64(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let decoded = b64_decode(
         decode_input_described(data, vm, "bytes, buffer or ASCII string")?.as_ref(),
         strict,
+        &vm.heap.tracker,
     )?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
@@ -211,7 +227,7 @@ fn call_crc32(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         None => 0,
         Some(value) => wrapping_u32(value, vm)?,
     };
-    let checksum = crc32(encode_input(data, vm)?.as_ref(), seed);
+    let checksum = crc32(encode_input(data, vm)?.as_ref(), seed, &vm.heap.tracker)?;
     Ok(Value::Int(i64::from(checksum)))
 }
 
@@ -225,7 +241,7 @@ fn call_crc_hqx(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     // The `I` format takes the seed modulo 2**32, then the body narrows it to
     // the 16 bits the register holds — so `-1` and `0xffff` seed alike.
     let seed = u16::try_from(wrapping_u32(crc, vm)? & 0xffff).expect("masked below 2**16");
-    let checksum = crc_hqx(encode_input(data, vm)?.as_ref(), seed);
+    let checksum = crc_hqx(encode_input(data, vm)?.as_ref(), seed, &vm.heap.tracker)?;
     Ok(Value::Int(i64::from(checksum)))
 }
 
@@ -252,7 +268,10 @@ fn call_a2b_uu(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     };
     defer_drop!(data, vm);
 
-    let decoded = uu_decode(decode_input_described(data, vm, "bytes, buffer or ASCII string")?.as_ref())?;
+    let decoded = uu_decode(
+        decode_input_described(data, vm, "bytes, buffer or ASCII string")?.as_ref(),
+        &vm.heap.tracker,
+    )?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -275,12 +294,13 @@ fn call_b2a_qp(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         istext: istext.py_bool(vm)?,
         header: header.py_bool(vm)?,
     };
-    let encoded = qp_encode(encode_input(data, vm)?.as_ref(), options);
+    let encoded = qp_encode(encode_input(data, vm)?.as_ref(), options, &vm.heap.tracker)?;
     Ok(allocate_bytes(encoded, vm.heap))
 }
 
 /// `binascii.a2b_qp(data, header=False)` — quoted-printable decoding, which
-/// never fails: anything malformed is copied through verbatim.
+/// rejects nothing: anything malformed is copied through verbatim, so only a
+/// resource limit can end it.
 fn call_a2b_qp(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let A2bQpArgs { data, header } = A2bQpArgs::from_args(args, vm)?;
     defer_drop!(data, vm);
@@ -290,7 +310,8 @@ fn call_a2b_qp(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let decoded = qp_decode(
         decode_input_described(data, vm, "bytes, buffer or ASCII string")?.as_ref(),
         header,
-    );
+        &vm.heap.tracker,
+    )?;
     Ok(allocate_bytes(decoded, vm.heap))
 }
 
@@ -421,7 +442,9 @@ fn wrapping_u32(value: &Value, vm: &VM<'_>) -> RunResult<u32> {
 ///
 /// A positive `bytes_per_sep` groups from the right, so any short group leads;
 /// a negative one groups from the left. Zero, or no separator, means none.
-fn hex_encode(data: &[u8], sep: Option<u8>, bytes_per_sep: i32) -> Vec<u8> {
+fn hex_encode(data: &[u8], sep: Option<u8>, bytes_per_sep: i32, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    const WINDOW: usize = ResourceTracker::BYTE_LOOP_CHECK_INTERVAL;
+
     let group = match sep {
         Some(_) if bytes_per_sep != 0 && !data.is_empty() => usize::try_from(bytes_per_sep.unsigned_abs())
             .expect("u32 fits usize on supported targets")
@@ -440,28 +463,47 @@ fn hex_encode(data: &[u8], sep: Option<u8>, bytes_per_sep: i32) -> Vec<u8> {
         group
     };
 
-    let mut out = Vec::with_capacity(data.len() * 2 + data.len() / group);
-    for (index, byte) in data.iter().enumerate() {
-        if let Some(sep) = sep
-            && (index == lead || (index > lead && (index - lead) % group == 0))
-        {
-            out.push(sep);
+    let capacity = data.len() * 2 + data.len() / group;
+    check_estimated_size(capacity, tracker)?;
+    let mut out = Vec::with_capacity(capacity);
+    for (window_index, window) in data.chunks(WINDOW).enumerate() {
+        tracker.check_time()?;
+        let base = window_index * WINDOW;
+        for (offset, byte) in window.iter().enumerate() {
+            let index = base + offset;
+            if let Some(sep) = sep
+                && (index == lead || (index > lead && (index - lead).is_multiple_of(group)))
+            {
+                out.push(sep);
+            }
+            out.push(HEX_DIGITS[usize::from(byte >> 4)]);
+            out.push(HEX_DIGITS[usize::from(byte & 0x0f)]);
         }
-        out.push(HEX_DIGITS[usize::from(byte >> 4)]);
-        out.push(HEX_DIGITS[usize::from(byte & 0x0f)]);
     }
-    out
+    Ok(out)
 }
 
 /// Decodes hex of either case, CPython's `unhexlify`.
-fn hex_decode(data: &[u8]) -> RunResult<Vec<u8>> {
+///
+/// Written as a windowed loop rather than a `collect`: collecting into a
+/// `Result` erases the iterator's lower size hint, so the output would grow by
+/// doubling instead of being reserved once.
+fn hex_decode(data: &[u8], tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     if data.len().is_multiple_of(2) {
-        data.chunks(2)
-            .map(|pair| match (hex_digit(pair[0]), hex_digit(pair[1])) {
-                (Some(hi), Some(lo)) => Ok((hi << 4) | lo),
-                _ => Err(binascii_error("Non-hexadecimal digit found")),
-            })
-            .collect()
+        let mut out = Vec::with_capacity(data.len() / 2);
+        for window in data.chunks(ResourceTracker::poll_window(2)) {
+            tracker.check_time()?;
+            // Exact for the same reason as `b16_decode`: an even length and an
+            // even window leave no remainder, and the stride is what the
+            // compiler needs to widen the loop.
+            for pair in window.as_chunks::<2>().0 {
+                match (hex_digit(pair[0]), hex_digit(pair[1])) {
+                    (Some(hi), Some(lo)) => out.push((hi << 4) | lo),
+                    _ => return Err(binascii_error("Non-hexadecimal digit found")),
+                }
+            }
+        }
+        Ok(out)
     } else {
         Err(binascii_error("Odd-length string"))
     }
@@ -528,7 +570,7 @@ fn value_error(message: &'static str) -> RunError {
 ///
 /// The standard reflected polynomial (`0xedb88320`), computed a nibble at a
 /// time so the table stays 16 entries rather than 256.
-fn crc32(data: &[u8], seed: u32) -> u32 {
+fn crc32(data: &[u8], seed: u32, tracker: &ResourceTracker) -> RunResult<u32> {
     const NIBBLE_TABLE: [u32; 16] = [
         0x0000_0000,
         0x1db7_1064,
@@ -549,31 +591,40 @@ fn crc32(data: &[u8], seed: u32) -> u32 {
     ];
 
     let mut crc = !seed;
-    for byte in data {
-        crc ^= u32::from(*byte);
-        crc = (crc >> 4) ^ NIBBLE_TABLE[usize::try_from(crc & 0x0f).expect("nibble fits usize")];
-        crc = (crc >> 4) ^ NIBBLE_TABLE[usize::try_from(crc & 0x0f).expect("nibble fits usize")];
+    for window in data.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        for byte in window {
+            crc ^= u32::from(*byte);
+            crc = (crc >> 4) ^ NIBBLE_TABLE[usize::try_from(crc & 0x0f).expect("nibble fits usize")];
+            crc = (crc >> 4) ^ NIBBLE_TABLE[usize::try_from(crc & 0x0f).expect("nibble fits usize")];
+        }
     }
-    !crc
+    Ok(!crc)
 }
 
 /// Computes the CRC-16 of `data`, continuing from `seed`.
 ///
 /// CRC-16/XMODEM: polynomial `0x1021`, unreflected, no final xor — the
 /// checksum BinHex 4.0 carried, which `crc_hqx` outlived.
-fn crc_hqx(data: &[u8], seed: u16) -> u16 {
+fn crc_hqx(data: &[u8], seed: u16, tracker: &ResourceTracker) -> RunResult<u16> {
     let mut crc = seed;
-    for byte in data {
-        crc ^= u16::from(*byte) << 8;
-        for _ in 0..8 {
-            crc = if crc & 0x8000 == 0 {
-                crc << 1
-            } else {
-                (crc << 1) ^ 0x1021
-            };
+    // Eight shift rounds per byte make this the slowest loop in the module, so
+    // it polls the clock rather than running to completion inside one
+    // instruction and letting the pool's turn timeout kill the worker.
+    for window in data.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        for byte in window {
+            crc ^= u16::from(*byte) << 8;
+            for _ in 0..8 {
+                crc = if crc & 0x8000 == 0 {
+                    crc << 1
+                } else {
+                    (crc << 1) ^ 0x1021
+                };
+            }
         }
     }
-    crc
+    Ok(crc)
 }
 
 /// The most bytes one uuencoded line can hold, since the leading length byte
@@ -616,7 +667,7 @@ fn uu_encode(data: &[u8], backtick: bool) -> RunResult<Vec<u8>> {
 /// A line shorter than its length byte claims is zero-padded rather than
 /// rejected, matching CPython — only a character outside the alphabet, or
 /// non-whitespace left over once the promised bytes are decoded, is an error.
-fn uu_decode(data: &[u8]) -> RunResult<Vec<u8>> {
+fn uu_decode(data: &[u8], tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
     let Some((length_byte, mut rest)) = data.split_first() else {
         return Err(binascii_error("Missing length byte"));
     };
@@ -654,11 +705,15 @@ fn uu_decode(data: &[u8]) -> RunResult<Vec<u8>> {
         }
     }
 
-    if rest.iter().all(|byte| matches!(byte, b' ' | b'`' | b'\n' | b'\r')) {
-        Ok(out)
-    } else {
-        Err(binascii_error("Trailing garbage"))
+    // At most 63 bytes are ever decoded, but the check for what follows them
+    // walks the rest of the input however long it is.
+    for window in rest.chunks(ResourceTracker::BYTE_LOOP_CHECK_INTERVAL) {
+        tracker.check_time()?;
+        if window.iter().any(|byte| !matches!(byte, b' ' | b'`' | b'\n' | b'\r')) {
+            return Err(binascii_error("Trailing garbage"));
+        }
     }
+    Ok(out)
 }
 
 /// The column at which `b2a_qp` soft-wraps, CPython's `MAXLINESIZE`.
@@ -682,16 +737,19 @@ struct QpOptions {
 /// [`QP_MAX_LINE`]; which newline they use is decided once, up front, by
 /// whether the input's first line ends `\r\n` — so mixed endings are
 /// normalised to whichever came first, as CPython's own does.
-fn qp_encode(data: &[u8], options: QpOptions) -> Vec<u8> {
-    let crlf = data
-        .iter()
-        .position(|byte| *byte == b'\n')
-        .is_some_and(|index| index > 0 && data[index - 1] == b'\r');
+fn qp_encode(data: &[u8], options: QpOptions, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    let QpPlan { capacity, crlf } = qp_plan(data, options, tracker)?;
+    check_estimated_size(capacity, tracker)?;
 
-    let mut out = Vec::with_capacity(data.len());
+    let mut out = Vec::with_capacity(capacity);
     let mut linelen = 0;
     let mut index = 0;
+    let mut steps = 0;
     while index < data.len() {
+        // `index` jumps by two over a `\r\n`, so the clock is keyed on a
+        // separate counter that cannot skip a check interval.
+        tracker.check_time_every_bytes(steps)?;
+        steps += 1;
         let byte = data[index];
         if qp_needs_quoting(data, index, linelen, options) {
             // The escape is three columns wide and may not be split, so it
@@ -729,7 +787,67 @@ fn qp_encode(data: &[u8], options: QpOptions) -> Vec<u8> {
             index += 1;
         }
     }
-    out
+    Ok(out)
+}
+
+/// What one pass over the input tells [`qp_encode`] before it writes anything.
+struct QpPlan {
+    /// Upper bound on the encoded length, and the buffer reserved for it.
+    capacity: usize,
+    /// Whether the first line ends `\r\n`, which picks the newline used
+    /// throughout.
+    crlf: bool,
+}
+
+/// Measures `data` so [`qp_encode`] can reserve exactly once.
+///
+/// A flat bound of the 3.125 bytes per byte a fully escaped input reaches
+/// would reject plain text, which encodes to a little over its own length, at
+/// a third of the budget it needs. Counting what actually escapes costs one
+/// cheap pass and is honest both ways: nothing that would have fit is
+/// rejected, and the buffer never grows past what was preflighted.
+fn qp_plan(data: &[u8], options: QpOptions, tracker: &ResourceTracker) -> RunResult<QpPlan> {
+    const WINDOW: usize = ResourceTracker::BYTE_LOOP_CHECK_INTERVAL;
+
+    // The one position rule that can catch a byte the per-byte rules do not:
+    // a space or tab last in the input is quoted for being last.
+    let mut escaped = usize::from(matches!(data.last(), Some(b' ' | b'\t')));
+    let mut newlines = 0usize;
+    let mut first_newline = None;
+    // This runs ahead of the encode's own pass, so it is half of what a large
+    // input costs; polling per window leaves the counting loop free of both a
+    // check and an index.
+    for (window_index, window) in data.chunks(WINDOW).enumerate() {
+        tracker.check_time()?;
+        // Independent of `istext`, as CPython's own `memchr` for it is.
+        if first_newline.is_none()
+            && let Some(offset) = window.iter().position(|byte| *byte == b'\n')
+        {
+            first_newline = Some(window_index * WINDOW + offset);
+        }
+        for byte in window {
+            if options.istext && *byte == b'\n' {
+                newlines += 1;
+            } else if qp_always_quotes(*byte, options) || *byte == b'.' {
+                // `.` covers the leading-dot rule, whose line position this
+                // pass does not track, at two bytes for every dot in the input.
+                escaped += 1;
+            }
+        }
+    }
+
+    // One column per byte, three if it escapes; a literal newline costs two
+    // for a `\r\n` plus the two that quoting a space before it adds.
+    let body = data
+        .len()
+        .saturating_add(escaped.saturating_mul(2))
+        .saturating_add(newlines.saturating_mul(3));
+    // A soft break needs three bytes, and cannot fire before column 73.
+    let breaks = body / (QP_MAX_LINE - 3) + 1;
+    Ok(QpPlan {
+        capacity: body.saturating_add(breaks.saturating_mul(3)),
+        crlf: first_newline.is_some_and(|index| index > 0 && data[index - 1] == b'\r'),
+    })
 }
 
 /// Whether the byte at `index` has to be written as an `=XX` escape.
@@ -743,12 +861,18 @@ fn qp_needs_quoting(data: &[u8], index: usize, linelen: usize, options: QpOption
     let last = index + 1 == data.len();
     let leading_dot = byte == b'.' && linelen == 0 && matches!(data.get(index + 1), None | Some(b'\n' | b'\r' | b'\0'));
 
+    qp_always_quotes(byte, options) || leading_dot || (matches!(byte, b'\t' | b' ') && last)
+}
+
+/// The half of [`qp_needs_quoting`] that depends only on the byte.
+///
+/// Split out so [`qp_plan`] can count escapes without tracking line position,
+/// which leaves the two with one copy of the rules rather than two that drift.
+fn qp_always_quotes(byte: u8, options: QpOptions) -> bool {
     byte > 126
         || byte == b'='
         || (options.header && byte == b'_')
-        || leading_dot
         || (!options.istext && matches!(byte, b'\r' | b'\n'))
-        || (matches!(byte, b'\t' | b' ') && last)
         || (byte < 33 && byte != b'\r' && byte != b'\n' && (options.quotetabs || !matches!(byte, b'\t' | b' ')))
 }
 
@@ -770,12 +894,19 @@ fn qp_hex(byte: u8) -> [u8; 2] {
 
 /// Decodes quoted-printable.
 ///
-/// Never fails: a malformed escape is copied through as the literal text it
-/// was, which is what lets the format survive a mangled message.
-fn qp_decode(data: &[u8], header: bool) -> Vec<u8> {
+/// Rejects nothing: a malformed escape is copied through as the literal text
+/// it was, which is what lets the format survive a mangled message. The only
+/// error it can return is the clock poll's.
+fn qp_decode(data: &[u8], header: bool, tracker: &ResourceTracker) -> RunResult<Vec<u8>> {
+    // Output is never longer than the input, so only the clock needs watching.
     let mut out = Vec::with_capacity(data.len());
     let mut index = 0;
+    let mut steps = 0;
     while index < data.len() {
+        // A soft break can consume a whole line at once, so the clock is keyed
+        // on a step counter rather than on `index`.
+        tracker.check_time_every_bytes(steps)?;
+        steps += 1;
         match data[index] {
             b'=' => {
                 index += 1;
@@ -816,5 +947,5 @@ fn qp_decode(data: &[u8], header: bool) -> Vec<u8> {
             }
         }
     }
-    out
+    Ok(out)
 }

--- a/crates/monty/test_cases/base64__all.py
+++ b/crates/monty/test_cases/base64__all.py
@@ -381,6 +381,11 @@ assert base64.a85decode(b'BOu!rD]j7BEbo7') == b'hello world'
 assert base64.a85decode('BOu!rD]j7BEbo7') == b'hello world'
 assert base64.a85decode(b'z') == b'\x00\x00\x00\x00'
 assert base64.a85decode(b'y', foldspaces=True) == b'    '
+# a short form stands for a whole word, so a run of them decodes to four
+# times its own length
+assert base64.a85decode(b'zzz') == b'\x00' * 12
+assert base64.a85decode(b'yzy', foldspaces=True) == b'    \x00\x00\x00\x00    '
+assert base64.a85decode(b'z@:E_Wz') == b'\x00\x00\x00\x00abcd\x00\x00\x00\x00'
 assert base64.a85decode(b='!!!!!') == b'\x00\x00\x00\x00'
 assert base64.a85decode(base64.a85encode(every_byte)) == every_byte
 

--- a/crates/monty/test_cases/binascii__all.py
+++ b/crates/monty/test_cases/binascii__all.py
@@ -370,6 +370,11 @@ assert binascii.b2a_qp(b'  ', quotetabs=True) == b'=20=20'
 # istext=False makes newlines data rather than line structure
 assert binascii.b2a_qp(b'a\nb', istext=False) == b'a=0Ab'
 assert binascii.b2a_qp(b'\r\n', istext=False) == b'=0D=0A'
+# a soft break still follows the input's own line ending, which is picked from
+# the first newline whether or not that newline is line structure
+assert binascii.b2a_qp(b'a' * 80 + b'\r\n', istext=False) == b'a' * 75 + b'=\r\naaaaa=0D=0A'
+assert binascii.b2a_qp(b'a' * 80 + b'\r\n', istext=True) == b'a' * 75 + b'=\r\naaaaa\r\n'
+assert binascii.b2a_qp(b'a' * 80 + b'\n', istext=False) == b'a' * 75 + b'=\naaaaa=0A'
 # header mode writes a space as '_', so '_' itself has to be quoted
 assert binascii.b2a_qp(b'a b', header=True) == b'a_b'
 assert binascii.b2a_qp(b'a_b', header=True) == b'a=5Fb'

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1516,3 +1516,86 @@ fn timeout_in_a85decode_ignorechars() {
         "a85decode with large ignorechars",
     );
 }
+
+// === Native codec loops consult the clock as they run ===
+
+/// One case per loop shape in `binascii` and `base64`, with the fill each
+/// conversion needs to reach its own loop rather than an early error.
+///
+/// `binascii.b2a_uu` is absent deliberately: its input is capped at 45 bytes,
+/// so it has no loop long enough to need a poll.
+#[cfg(feature = "test-hooks")]
+const CODEC_CASES: [(&str, &str); 23] = [
+    ("b'a'", "binascii.hexlify(src)"),
+    ("b'a'", "binascii.unhexlify(src)"),
+    ("b'a'", "binascii.b2a_base64(src)"),
+    ("b'A'", "binascii.a2b_base64(src)"),
+    ("b'a'", "binascii.crc32(src, 0)"),
+    ("b'a'", "binascii.crc_hqx(src, 0)"),
+    ("b' '", "binascii.a2b_uu(b'!80' + src)"),
+    ("b'a'", "binascii.b2a_qp(src)"),
+    ("b'a'", "binascii.a2b_qp(src)"),
+    ("b'a'", "base64.b64encode(src)"),
+    ("b'A'", "base64.b64decode(src)"),
+    ("b'a'", "base64.urlsafe_b64encode(src)"),
+    ("b'a'", "base64.b32encode(src)"),
+    ("b'A'", "base64.b32decode(src)"),
+    ("b'a'", "base64.b32hexencode(src)"),
+    ("b'a'", "base64.b16encode(src)"),
+    ("b'A'", "base64.b16decode(src)"),
+    ("b'a'", "base64.b85encode(src)"),
+    ("b'0'", "base64.b85decode(src)"),
+    ("b'a'", "base64.a85encode(src)"),
+    ("b'!'", "base64.a85decode(src)"),
+    ("b'a'", "base64.encodebytes(src)"),
+    ("b'A'", "base64.decodebytes(src)"),
+];
+
+/// Clock polls a script makes, over and above building its input.
+///
+/// The same script runs twice, once without the conversion, so the difference
+/// is the conversion's own polling and nothing else — not the dispatch loop's
+/// checkpoint, and not the sequence repeat that builds `src`.
+#[cfg(feature = "test-hooks")]
+fn codec_polls(fill: &str, call: &str, size: usize) -> usize {
+    let run = |code: String| {
+        let ex = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+        let limits = ResourceLimits::default().max_duration(Duration::from_secs(60));
+        monty_types::reset_clock_polls();
+        ex.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout)
+            .unwrap_or_else(|err| panic!("{call}: should stay inside the budget, got {err}"));
+        monty_types::clock_polls()
+    };
+    let setup = format!("import binascii, base64\nsrc = {fill} * {size}\n");
+    run(format!("{setup}result = {call}\nNone\n")).saturating_sub(run(format!("{setup}None\n")))
+}
+
+/// Every conversion in the two modules must read the clock as it runs, so an
+/// exhausted budget ends it rather than the whole buffer being scanned inside
+/// one bytecode instruction.
+///
+/// Asserted as a poll count rather than as a timeout: a conversion fast enough
+/// to finish inside its budget returns the same value whether it polled or
+/// not, so a wall-clock assertion only holds while the machine is slow enough
+/// to make it hold. Counting separates the two on any machine, and reports the
+/// conversion that stopped polling rather than a timing failure somewhere in a
+/// pool.
+#[test]
+#[cfg(feature = "test-hooks")]
+fn native_codec_loops_poll_the_clock() {
+    // A megabyte is 256 windows at the 4KiB stride, and a handful of seconds
+    // for the slowest of these conversions in a debug build.
+    const SIZE: usize = 1024 * 1024;
+    // Half the windows the stride implies, which leaves room for a loop whose
+    // unit is a group rather than a byte while still failing loudly for one
+    // that polls once or not at all.
+    let floor = SIZE / monty_types::ResourceTracker::BYTE_LOOP_CHECK_INTERVAL / 2;
+
+    for (fill, call) in CODEC_CASES {
+        let polls = codec_polls(fill, call, SIZE);
+        assert!(
+            polls >= floor,
+            "{call}: polled the clock {polls} times over {SIZE} bytes, expected at least {floor}"
+        );
+    }
+}

--- a/docs/limitations/resource_limits.md
+++ b/docs/limitations/resource_limits.md
@@ -35,8 +35,11 @@ WebAssembly runtimes do.
     container, and string formatting with dynamic width or precision, for
     f-strings (`f"{v:>{w}}"`, `f"{v:.{p}f}"`), `str.format()`
     (`"{0:>{1}}".format(v, w)`, `"{0:.{1}f}".format(v, p)`) and `%`
-    formatting (`"%*d" % (w, v)`, `"%.*f" % (p, v)`). The pre-check
-    threshold is 100 KB:
+    formatting (`"%*d" % (w, v)`, `"%.*f" % (p, v)`), and every `binascii` and
+    `base64` conversion that can outgrow its input — including `base64.a85decode`,
+    where Ascii85's `z` and `y` each stand for a whole four-byte word. Each of
+    these reserves what it pre-checked, so the buffer never grows past it.
+    The pre-check threshold is 100 KB:
     estimates above that are checked against the remaining budget and rejected
     with `MemoryError` before allocation when they would exceed it.
 - `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with
@@ -199,10 +202,14 @@ indistinguishable from a stack overflow.
     **not** polled and run to completion however large the input: `in` with an
     integer probe (a single-byte scan) and `split()`/`rsplit()` left to their
     default `sep=None` (whitespace splitting).
-- `base64.a85decode()` polls the clock every 64th byte that matches no
-    Ascii85 digit and so reaches `ignorechars`. Each of those bytes is one
-    `in` test against the container, so a large explicit `ignorechars`
-    overshoots `max_duration` in proportion to its length.
+- Every `binascii` and `base64` conversion polls the clock once per 4KiB of
+    input rather than once per byte, so the overshoot is bounded at a window of
+    work rather than a whole buffer.
+    That covers `base64.a85decode()`, whose `ignorechars` arm costs an `in`
+    test against a Python container per byte, and so buys the most per window.
+    `binascii.b2a_qp()` and `binascii.a2b_qp()` step a byte at a time instead,
+    because a soft break can consume a whole line at once; they poll every
+    4096 steps.
 - The budget covers cumulative **execution time**, not wall-clock time:
     the clock runs only while the interpreter executes bytecode, and is
     paused while execution is suspended waiting on the host (external

--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -78,7 +78,8 @@ Size the limit with headroom, and use an OS or cgroup limit to bound the process
 Operations whose result size is predictable from their inputs are **pre-checked before allocating**, above a 100 KB
 threshold, including integer multiplication, division and `divmod`, left shift, integer power, sequence repeat
 (`'x' * n`), `str.replace` / `bytes.replace`, `re.sub`, the padding methods, deque rotation and slicing, materialising
-an iterator into a container, and f-string, `str.format()` or `%` formatting with a dynamic width or precision.
+an iterator into a container, f-string, `str.format()` or `%` formatting with a dynamic width or precision, and the
+`binascii` and `base64` conversions that can outgrow their input.
 So `'x' * 10**12` fails immediately rather than after consuming the machine's memory.
 
 A few integer operations carry their own caps regardless of `max_memory`:


### PR DESCRIPTION
Neither module read the clock or checked a size, so a conversion scanned its whole buffer inside one bytecode instruction — killing the worker rather than raising `TimeoutError`, or exiting the process rather than returning `MemoryError`.

Three kinds of check:

- **Clock polls**, on a 4KiB window so the inner loop keeps its unrolling. Quoted-printable can't be windowed and keeps a per-step test.
- **Size preflights** before allocating: the format's own ratio, or an exact count where a ratio would be wrong. Shrinking conversions need none.
- **Exact reservations** at the size preflighted, appended bytes included — a `Vec` that outgrows its reservation doubles.

Four needed care:

- **`a85decode`** expands, since `z` is a whole zero word, so it counts digits exactly.
- **`b2a_qp`** is sized from what escapes; a flat 3.125 bytes/byte bound rejects plain text.
- **`b2a_base64`** and **`a85encode(adobe=True)`** append to a buffer already filled to the byte, and reserve that too.

### Performance against main
- twelve of sixteen conversions are level 
- `unhexlify` is faster due to removing `collect` at the end of hex_decode.
- `b2a_qp`, `a85decode`, `a2b_qp` all slow - `b2a_qp`, `a85decode` slow from measuring the output before writing it & `a2b_qp` from a per-step clock test it can't window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nqjsa2ia5yP6ejfDWqx9WC



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The `binascii` and `base64` conversions now enforce resource limits while running, so an oversized input raises `TimeoutError` or `MemoryError` instead of killing the worker. Previously both modules skipped clock and memory checks, letting a conversion scan its whole buffer inside one bytecode instruction.

- Clock polls run per 4KiB window; `b2a_qp` and `a2b_qp` poll per step because a soft break can consume a whole line at once.
- Expanding conversions preflight output size before allocating: `a85decode` counts digits exactly (a `z` is a whole zero word), `b2a_qp` counts what escapes, and `b2a_base64` / `a85encode(adobe=True)` reserve the bytes they append.
- Twelve of sixteen conversions stay at parity; `unhexlify` is faster from dropping the trailing `collect`; `b2a_qp`, `a85decode`, and `a2b_qp` are slower.

<sup>Written for commit 7a224aef14ca4793ca79f798a3baaf874e53c911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

