### PR TITLE
Move examples-only Python deps out of the dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,16 @@ dev = [
     "mdformat-tables>=1.0.0",
     "mdformat-mkdocs>=5.2.1",
     "mdformat-frontmatter>=2.1.2",
+    "httpx2>=2.12.0",
+    "websockets>=14",
+]
+# used only by `examples/`; a default group so `uv run` installs them, while CI's `--only-dev` skips them
+examples = [
     "duckdb>=1.0.0",
-    "httpx>=0.28.1",
     "playwright>=1.58.0",
     "beautifulsoup4>=4.14.3",
     "logfire>=4.25.0",
-    "devtools>=0.12.2",
     "pydantic-ai-slim[anthropic,openai]>=1.63.0",
-    "websockets>=14",
 ]
 docs = [
     "mkdocs>=1.6.1",
@@ -56,6 +58,7 @@ extend-exclude = [
 [tool.uv]
 # this is a monorepo without a root package
 package = false
+default-groups = ["dev", "examples"]
 # https://docs.astral.sh/uv/reference/settings/#exclude-newer
 # make sure to use relative durations:
 exclude-newer = "7 days"

--- a/scripts/codecov_diff.py
+++ b/scripts/codecov_diff.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from typing import Any
 
-import httpx
+import httpx2
 
 CODECOV_GRAPHQL_URL = 'https://api.codecov.io/graphql/gh'
 
@@ -178,7 +178,7 @@ def get_pr_from_gh() -> int | None:
 
 def graphql_request(query: str, variables: dict[str, Any]) -> dict[str, Any]:
     """Make a GraphQL request to Codecov API."""
-    with httpx.Client(timeout=30.0) as client:
+    with httpx2.Client(timeout=30.0) as client:
         response = client.post(
             CODECOV_GRAPHQL_URL,
             json={'query': query, 'variables': variables},

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.15' and sys_platform != 'emscripten') or (python_full_version < '3.12' and sys_platform == 'emscripten')",
 ]
 
 [options]
@@ -339,20 +340,6 @@ wheels = [
 ]
 
 [[package]]
-name = "devtools"
-version = "0.12.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/75/b78198620640d394bc435c17bb49db18419afdd6cfa3ed8bcfe14034ec80/devtools-0.12.2.tar.gz", hash = "sha256:efceab184cb35e3a11fa8e602cc4fadacaa2e859e920fc6f87bf130b69885507", size = 75005, upload-time = "2023-09-03T16:57:00.679Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/ae/afb1487556e2dc827a17097aac8158a25b433a345386f0e249f6d2694ccb/devtools-0.12.2-py3-none-any.whl", hash = "sha256:c366e3de1df4cdd635f1ad8cbcd3af01a384d7abda71900e68d43b04eb6aaca7", size = 19411, upload-time = "2023-09-03T16:56:59.049Z" },
-]
-
-[[package]]
 name = "dirty-equals"
 version = "0.11"
 source = { registry = "https://pypi.org/simple" }
@@ -597,6 +584,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -612,12 +612,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1244,19 +1270,13 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
-    { name = "beautifulsoup4" },
-    { name = "devtools" },
-    { name = "duckdb" },
-    { name = "httpx" },
-    { name = "logfire" },
+    { name = "httpx2" },
     { name = "maturin" },
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
     { name = "mdformat-mkdocs" },
     { name = "mdformat-tables" },
     { name = "mypy" },
-    { name = "playwright" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
     { name = "ruff" },
     { name = "websockets" },
 ]
@@ -1265,25 +1285,26 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+examples = [
+    { name = "beautifulsoup4" },
+    { name = "duckdb" },
+    { name = "logfire" },
+    { name = "playwright" },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
+]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.34.0" },
-    { name = "beautifulsoup4", specifier = ">=4.14.3" },
-    { name = "devtools", specifier = ">=0.12.2" },
-    { name = "duckdb", specifier = ">=1.0.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "logfire", specifier = ">=4.25.0" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "maturin", specifier = ">=1.15.0,<2.0" },
     { name = "mdformat", specifier = ">=0.7.22" },
     { name = "mdformat-frontmatter", specifier = ">=2.1.2" },
     { name = "mdformat-mkdocs", specifier = ">=5.2.1" },
     { name = "mdformat-tables", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=2.1.0" },
-    { name = "playwright", specifier = ">=1.58.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], specifier = ">=1.63.0" },
     { name = "ruff", specifier = ">=0.14.7" },
     { name = "websockets", specifier = ">=14" },
 ]
@@ -1291,6 +1312,13 @@ docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.7.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30" },
+]
+examples = [
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
+    { name = "duckdb", specifier = ">=1.0.0" },
+    { name = "logfire", specifier = ">=4.25.0" },
+    { name = "playwright", specifier = ">=1.58.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], specifier = ">=1.63.0" },
 ]
 
 [[package]]
@@ -2365,6 +2393,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`uv sync --all-packages --only-dev` in CI (e.g. [this run](https://github.com/pydantic/monty/actions/runs/34705642460/job/103585069483?pr=834)) was spending minutes building duckdb from source, but duckdb, playwright, beautifulsoup4, logfire and pydantic-ai-slim are only imported under `examples/`.

- Move those five packages into a new `examples` dependency group. It is a uv default group, so `uv run python examples/...` from the example READMEs still installs them, while `--only-dev` (all three CI sync sites and `make install-py`) skips them. No workflow changes needed.
- Drop `devtools`, which nothing in the repo imports.
- Replace `httpx` with `httpx2` in `scripts/codecov_diff.py`, the only direct user; httpx2's changelog states the package rename is the only public API change.

Verified with `uv export`: the default group set contains duckdb, the `--only-dev` set does not. `make lint-py` passes and the codecov script runs under `uv run --only-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YaWfJTmrjFDFP2ZdXeCos


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves example-only dependencies out of the dev group so CI's `uv sync --only-dev` no longer spends minutes building duckdb from source. `duckdb`, `playwright`, `beautifulsoup4`, `logfire`, and `pydantic-ai-slim` now live in a new `examples` group, which is a uv default group, so `uv run python examples/...` still installs them. Also drops `devtools`, which nothing imports, and replaces `httpx` with `httpx2` in `scripts/codecov_diff.py`, the only direct user; `httpx2`'s changelog states the rename is the only public API change.

Verified with `uv export` that the default group set contains duckdb and the `--only-dev` set does not.

<sup>Written for commit cefa1c52498c4fca294156b713db51bb7c5962f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

