### PR TITLE
Make the `examples` dependency group opt-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,8 @@ generate-api-docs: ## Generate the Rust API reference into docs/api/rust/ (gitig
 lint-py: dev-py ## Lint Python code with ruff
 	uv run ruff format --check
 	uv run ruff check
-	uv run basedpyright
+	# basedpyright type-checks examples/, so it needs that group's packages installed
+	uv run --group examples basedpyright
 	# mypy-stubtest requires a build of the python package, hence dev-py
 	uv run -m mypy.stubtest pydantic_monty._monty --ignore-disjoint-bases
 

--- a/examples/sql_playground/README.md
+++ b/examples/sql_playground/README.md
@@ -16,5 +16,5 @@ Data is from <https://github.com/mafudge/datasets>.
 ## To run
 
 ```bash
-uv run python examples/sql_playground/main.py
+uv run --group examples python examples/sql_playground/main.py
 ```

--- a/examples/web_scraper/README.md
+++ b/examples/web_scraper/README.md
@@ -11,5 +11,5 @@ Look at `example_code.py` for an example of the kind of code sonnet 4.5 will gen
 Run the example with
 
 ```bash
-uv run python -m examples.web_scraper.main
+uv run --group examples python -m examples.web_scraper.main
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     "httpx2>=2.12.0",
     "websockets>=14",
 ]
-# used only by `examples/`; opt in with `uv run --group examples ...` so CI and `make dev-py` never install them
+# used only by `examples/`; opt in with `uv run --group examples ...`, `make dev-py` skips it, `make lint-py` needs it
 examples = [
     "duckdb>=1.0.0",
     "playwright>=1.58.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     "httpx2>=2.12.0",
     "websockets>=14",
 ]
-# used only by `examples/`; a default group so `uv run` installs them, while CI's `--only-dev` skips them
+# used only by `examples/`; opt in with `uv run --group examples ...` so CI and `make dev-py` never install them
 examples = [
     "duckdb>=1.0.0",
     "playwright>=1.58.0",
@@ -58,7 +58,6 @@ extend-exclude = [
 [tool.uv]
 # this is a monorepo without a root package
 package = false
-default-groups = ["dev", "examples"]
 # https://docs.astral.sh/uv/reference/settings/#exclude-newer
 # make sure to use relative durations:
 exclude-newer = "7 days"


### PR DESCRIPTION
Follow-up to #849. `make dev-py` runs `uv run maturin develop`, and `uv run` syncs uv's default groups, so having `examples` in `default-groups` still built duckdb from source on every dev install.

- Remove `default-groups` from `[tool.uv]`, so only `dev` is installed by `uv run` / `uv sync` / `make dev-py`.
- `examples/sql_playground` and `examples/web_scraper` are the only examples importing packages from the group; their READMEs now use `uv run --group examples python ...`. The `classes` and `expense_analysis` examples only need `pydantic_monty` and are unchanged.

Verified with `uv export`: the default set has no duckdb, `--group examples` does. `uv lock` is unchanged and `make lint-md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YaWfJTmrjFDFP2ZdXeCos

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `examples` dependency group opt-in so `make dev-py` no longer builds duckdb from source on every dev install.

- Removes `examples` from `default-groups` in `[tool.uv]`, so `uv run` and `uv sync` only install `dev`.
- Updates `examples/sql_playground` and `examples/web_scraper` READMEs to use `uv run --group examples ...`; other examples are unaffected.
- Makes `make lint-py` run basedpyright with `uv run --group examples`, since it type-checks `examples/`.

<sup>Written for commit 210af80ecda81d7f43a6c8d9462bdedaa989c882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

