### PR TITLE
Accept long ints across `pow()`, `round()` and the `math` module

### DIFF
--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -897,8 +897,10 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
         ("x = 1 << 3_000_000\nx / (x - 1)", 1_531_926),
         ("x = 1 << 3_000_000\nx / (x >> 100)", 1_531_908),
         // `math.factorial`, `comb` and `perm` preflight their product's size.
-        ("import math\nmath.factorial(2_000_000)", 5_284_900),
-        ("import math\nmath.comb(4_000_000, 2_000_000)", 5_534_966),
+        ("import math\nmath.factorial(2_000_000)", 10_535_476),
+        ("import math\nmath.comb(4_000_000, 2_000_000)", 11_035_608),
+        // `math.lcm` of two large coprime ints is a product, preflighted like `*`.
+        ("import math\nx = 1 << 2_000_000\nmath.lcm(x + 1, x - 1)", 1_285_845),
         ("('a' * 1000).replace('a', 'b' * 2000)", 2_034_769),
         // Bulk container clones: `+=` preflights the temp clone plus the target
         // growth, `+` preflights each side's clone.

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -896,6 +896,9 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
         // preflighted.
         ("x = 1 << 3_000_000\nx / (x - 1)", 1_531_926),
         ("x = 1 << 3_000_000\nx / (x >> 100)", 1_531_908),
+        // `math.factorial`, `comb` and `perm` preflight their product's size.
+        ("import math\nmath.factorial(2_000_000)", 5_284_900),
+        ("import math\nmath.comb(4_000_000, 2_000_000)", 5_534_966),
         ("('a' * 1000).replace('a', 'b' * 2000)", 2_034_769),
         // Bulk container clones: `+=` preflights the temp clone plus the target
         // growth, `+` preflights each side's clone.

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -898,7 +898,8 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
         ("x = 1 << 3_000_000\nx / (x >> 100)", 1_531_908),
         // `math.factorial`, `comb` and `perm` preflight their product's size.
         ("import math\nmath.factorial(2_000_000)", 10_535_476),
-        ("import math\nmath.comb(4_000_000, 2_000_000)", 11_035_608),
+        // A binomial is bounded by `2**n`, so `comb` needs a larger `n` to trip the check.
+        ("import math\nmath.comb(9_000_000, 4_500_000)", 2_285_542),
         ("import math\nmath.perm(4_000_000, 2_000_000)", 11_035_608),
         // `math.lcm` of two large coprime ints is a product, preflighted like `*`.
         ("import math\nx = 1 << 2_000_000\nmath.lcm(x + 1, x - 1)", 1_285_845),

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -899,6 +899,7 @@ fn large_allocations_are_rejected_before_the_hard_limit() {
         // `math.factorial`, `comb` and `perm` preflight their product's size.
         ("import math\nmath.factorial(2_000_000)", 10_535_476),
         ("import math\nmath.comb(4_000_000, 2_000_000)", 11_035_608),
+        ("import math\nmath.perm(4_000_000, 2_000_000)", 11_035_608),
         // `math.lcm` of two large coprime ints is a product, preflighted like `*`.
         ("import math\nx = 1 << 2_000_000\nmath.lcm(x + 1, x - 1)", 1_285_845),
         ("('a' * 1000).replace('a', 'b' * 2000)", 2_034_769),

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -6,7 +6,7 @@ use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     heap::HeapData,
     types::long_int::modular_pow,
     value::Value,
@@ -21,27 +21,40 @@ pub fn builtin_pow(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(base, vm);
     defer_drop!(exp, vm);
     defer_drop!(modulus, vm);
-    let base = normalize_bool(base);
-    let exp = normalize_bool(exp);
+    let int_base = normalize_bool(base);
+    let int_exp = normalize_bool(exp);
 
     match modulus {
         // `pow(base, exp)` is `base ** exp`: the operator already covers every numeric pairing.
-        Value::None => base.py_pow(exp, None, vm),
+        Value::None => int_base.py_pow(int_exp, None, vm),
         modulus => {
-            let modulus = normalize_bool(modulus);
-            let result = match base {
-                Value::Int(base) => modular_pow(&BigInt::from(*base), exp, modulus, vm.heap)?,
+            let int_modulus = normalize_bool(modulus);
+            let result = match int_base {
+                Value::Int(base) => modular_pow(&BigInt::from(*base), int_exp, int_modulus, vm.heap)?,
                 Value::Ref(id) if let HeapData::LongInt(base) = vm.heap.get(*id) => {
-                    modular_pow(base.inner(), exp, modulus, vm.heap)?
+                    modular_pow(base.inner(), int_exp, int_modulus, vm.heap)?
                 }
                 _ => None,
             };
             result.ok_or_else(|| {
-                SimpleException::new_msg(
-                    ExcType::TypeError,
-                    "pow() 3rd argument not allowed unless all arguments are integers",
-                )
-                .into()
+                // A float operand refuses the third argument outright, as `float.__pow__` does;
+                // any other mix is reported as an unsupported operand triple.
+                if [base, exp, modulus]
+                    .iter()
+                    .any(|value| matches!(value, Value::Float(_)))
+                {
+                    SimpleException::new_msg(
+                        ExcType::TypeError,
+                        "pow() 3rd argument not allowed unless all arguments are integers",
+                    )
+                    .into()
+                } else {
+                    ExcType::ternary_pow_type_error(
+                        base.py_type_name(vm),
+                        exp.py_type_name(vm),
+                        modulus.py_type_name(vm),
+                    )
+                }
             })
         }
     }

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -1,26 +1,21 @@
 //! Implementation of the pow() builtin function.
 
 use num_bigint::BigInt;
-use num_traits::{Signed, ToPrimitive, Zero};
 
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
-    heap::{Heap, HeapData},
-    resource_checks::check_pow_size,
-    types::{
-        LongInt, PyTrait,
-        long_int::{bigint_to_f64_checked, modular_pow},
-    },
-    value::{Value, float_pow},
+    exception_private::{ExcType, RunResult, SimpleException},
+    heap::HeapData,
+    types::long_int::modular_pow,
+    value::Value,
 };
 
 /// Implementation of the pow() builtin function.
 ///
-/// Returns base to the power exp. With three arguments, returns (base ** exp) % mod.
-/// Handles negative exponents by returning a float.
+/// Returns base to the power exp. With three arguments, returns (base ** exp) % mod,
+/// which is only defined for integers.
 pub fn builtin_pow(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let PowArgs { base, exp, modulus } = PowArgs::from_args(args, vm)?;
     defer_drop!(base, vm);
@@ -30,7 +25,8 @@ pub fn builtin_pow(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let exp = normalize_bool(exp);
 
     match modulus {
-        Value::None => two_arg_pow(base, exp, vm),
+        // `pow(base, exp)` is `base ** exp`: the operator already covers every numeric pairing.
+        Value::None => base.py_pow(exp, None, vm),
         modulus => {
             let modulus = normalize_bool(modulus);
             let result = match base {
@@ -83,185 +79,5 @@ fn normalize_bool(value: &Value) -> &Value {
         Value::Bool(false) => &FALSE_INT,
         Value::Bool(true) => &TRUE_INT,
         other => other,
-    }
-}
-
-fn checked_pow_i64(mut base: i64, mut exp: u32) -> Option<i64> {
-    let mut result: i64 = 1;
-
-    while exp > 0 {
-        if exp & 1 == 1 {
-            result = result.checked_mul(base)?;
-        }
-        exp >>= 1;
-        if exp > 0 {
-            base = base.checked_mul(base)?;
-        }
-    }
-
-    Some(result)
-}
-
-/// Implements two-argument pow with LongInt support.
-///
-/// On overflow, promotes to LongInt instead of returning an error.
-fn two_arg_pow(base: &Value, exp: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
-    match (base, exp) {
-        (Value::Int(b), Value::Int(e)) => int_pow_int(*b, *e, vm.heap),
-        (Value::Int(b), Value::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-            int_pow_longint(*b, li.inner(), vm.heap)
-        }
-        (Value::Ref(id), Value::Int(e)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-            longint_pow_int(li.inner(), *e, vm.heap)
-        }
-        (Value::Ref(id1), Value::Ref(id2))
-            if let HeapData::LongInt(b_li) = vm.heap.get(*id1)
-                && let HeapData::LongInt(e_li) = vm.heap.get(*id2) =>
-        {
-            longint_pow_longint(b_li.inner(), e_li.inner(), vm.heap)
-        }
-        (Value::Ref(id), Value::Float(e)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-            Ok(Value::Float(float_pow(li.to_f64_checked()?, *e)?))
-        }
-        (Value::Float(b), Value::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-            Ok(Value::Float(float_pow(*b, li.to_f64_checked()?)?))
-        }
-        (Value::Float(b), Value::Float(e)) => Ok(Value::Float(float_pow(*b, *e)?)),
-        (Value::Int(b), Value::Float(e)) => Ok(Value::Float(float_pow(*b as f64, *e)?)),
-        (Value::Float(b), Value::Int(e)) => Ok(Value::Float(float_pow(*b, *e as f64)?)),
-        _ => Err(ExcType::binary_type_error(
-            "** or pow()",
-            base.py_type(vm),
-            base.py_type_name(vm),
-            exp.py_type_name(vm),
-        )),
-    }
-}
-
-/// int ** int with LongInt promotion on overflow.
-fn int_pow_int(b: i64, e: i64, heap: &mut Heap) -> RunResult<Value> {
-    if e < 0 {
-        // Negative exponent: CPython hands off to `float_pow`
-        Ok(Value::Float(float_pow(b as f64, e as f64)?))
-    } else if let Ok(exp_u32) = u32::try_from(e) {
-        if let Some(v) = checked_pow_i64(b, exp_u32) {
-            Ok(Value::Int(v))
-        } else {
-            // Overflow - promote to LongInt
-            // Check size before computing to prevent DoS
-            check_pow_size(i64_bits(b), u64::from(exp_u32), &heap.tracker)?;
-            let bi = BigInt::from(b).pow(exp_u32);
-            Ok(LongInt::new(bi).into_value(heap))
-        }
-    } else {
-        // Exponent too large for u32 - use BigInt for result
-        // Safety: e >= 0 at this point
-        #[expect(clippy::cast_sign_loss)]
-        let exp_u64 = e as u64;
-        // Check size before computing to prevent DoS
-        check_pow_size(i64_bits(b), exp_u64, &heap.tracker)?;
-        let base_bi = BigInt::from(b);
-        let bi = bigint_pow_large(&base_bi, exp_u64)?;
-        Ok(LongInt::new(bi).into_value(heap))
-    }
-}
-
-/// int ** LongInt with LongInt result.
-fn int_pow_longint(b: i64, e: &BigInt, heap: &Heap) -> RunResult<Value> {
-    if e.is_negative() {
-        // CPython hands off to `float_pow`, converting the exponent before its zero-base check.
-        Ok(Value::Float(float_pow(b as f64, bigint_to_f64_checked(e)?)?))
-    } else if e.is_zero() {
-        // x ** 0 = 1 for all x (including 0 ** 0 = 1)
-        Ok(Value::Int(1))
-    } else if b == 0 {
-        Ok(Value::Int(0))
-    } else if b == 1 {
-        Ok(Value::Int(1))
-    } else if b == -1 {
-        // (-1) ** n = 1 if n is even, -1 if n is odd
-        let is_even = (e % 2i32).is_zero();
-        Ok(Value::Int(if is_even { 1 } else { -1 }))
-    } else if let Some(exp_u32) = e.to_u32() {
-        // Check size before computing to prevent DoS
-        check_pow_size(i64_bits(b), u64::from(exp_u32), &heap.tracker)?;
-        let bi = BigInt::from(b).pow(exp_u32);
-        Ok(LongInt::new(bi).into_value(heap))
-    } else {
-        // Exponent too large
-        Err(ExcType::overflow_exponent_too_large())
-    }
-}
-
-/// LongInt ** int with LongInt result.
-fn longint_pow_int(b: &BigInt, e: i64, heap: &Heap) -> RunResult<Value> {
-    if e < 0 {
-        // Negative exponent: CPython hands off to `float_pow`
-        Ok(Value::Float(float_pow(bigint_to_f64_checked(b)?, e as f64)?))
-    } else if let Ok(exp_u32) = u32::try_from(e) {
-        // Check size before computing to prevent DoS
-        check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;
-        let bi = b.pow(exp_u32);
-        Ok(LongInt::new(bi).into_value(heap))
-    } else {
-        // Exponent too large for u32
-        // Safety: e >= 0 at this point
-        #[expect(clippy::cast_sign_loss)]
-        let exp_u64 = e as u64;
-        // Check size before computing to prevent DoS
-        check_pow_size(b.bits(), exp_u64, &heap.tracker)?;
-        let bi = bigint_pow_large(b, exp_u64)?;
-        Ok(LongInt::new(bi).into_value(heap))
-    }
-}
-
-/// LongInt ** LongInt with LongInt result.
-fn longint_pow_longint(b: &BigInt, e: &BigInt, heap: &Heap) -> RunResult<Value> {
-    if e.is_negative() {
-        // Negative exponent: CPython hands off to `float_pow`
-        Ok(Value::Float(float_pow(
-            bigint_to_f64_checked(b)?,
-            bigint_to_f64_checked(e)?,
-        )?))
-    } else if let Some(exp_u32) = e.to_u32() {
-        // Check size before computing to prevent DoS
-        check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;
-        let bi = b.pow(exp_u32);
-        Ok(LongInt::new(bi).into_value(heap))
-    } else {
-        // Exponent too large
-        Err(ExcType::overflow_exponent_too_large())
-    }
-}
-
-/// BigInt power for large exponents (> u32::MAX).
-///
-/// This handles exponents that are too large for the standard pow function.
-/// For most bases, the result would be astronomically large, so we only handle
-/// special cases (0, 1, -1) and return an error for others.
-fn bigint_pow_large(base: &BigInt, exp: u64) -> RunResult<BigInt> {
-    if base.is_zero() {
-        Ok(BigInt::from(0))
-    } else if *base == BigInt::from(1) {
-        Ok(BigInt::from(1))
-    } else if *base == BigInt::from(-1) {
-        // (-1) ** n = 1 if n is even, -1 if n is odd
-        if exp.is_multiple_of(2) {
-            Ok(BigInt::from(1))
-        } else {
-            Ok(BigInt::from(-1))
-        }
-    } else {
-        // For any other base, exponent > u32::MAX would produce an astronomically large result
-        Err(ExcType::overflow_exponent_too_large())
-    }
-}
-
-/// Computes the number of significant bits in an i64.
-fn i64_bits(value: i64) -> u64 {
-    if value == 0 {
-        0
-    } else {
-        u64::from(64 - value.unsigned_abs().leading_zeros())
     }
 }

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -2,6 +2,7 @@
 
 use num_bigint::BigInt;
 use num_integer::Integer;
+use num_traits::Pow;
 
 use crate::{
     args::{ArgValues, FromArgs, is_long_int},
@@ -127,10 +128,10 @@ pub fn builtin_round(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 fn round_to_tens(n: &BigInt, k: u64, heap: &Heap) -> Value {
     // `10**k` exceeds `|n|` once `k` passes its decimal digit count, so the result is 0.
     let digit_bound = n.bits().saturating_mul(30_103) / 100_000 + 1;
-    let Some(k) = u32::try_from(k).ok().filter(|k| u64::from(*k) <= digit_bound) else {
+    if k > digit_bound {
         return Value::Int(0);
-    };
-    let factor = BigInt::from(10u8).pow(k);
+    }
+    let factor = Pow::pow(BigInt::from(10u8), k);
     let (quotient, remainder) = n.div_mod_floor(&factor);
     let twice_remainder = remainder << 1u32;
     let quotient = if twice_remainder > factor || (twice_remainder == factor && quotient.is_odd()) {

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -1,12 +1,14 @@
 //! Implementation of the round() builtin function.
 
 use num_bigint::BigInt;
+use num_integer::Integer;
 
 use crate::{
     args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
+    heap::Heap,
     types::LongInt,
     value::Value,
 };
@@ -104,6 +106,11 @@ pub fn builtin_round(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
                 LongInt::value_from_f64(bankers_round(*f), vm.heap)
             }
         }
+        _ if let Some(n) = number.as_long_int(vm) => match digits {
+            Some(d) if d < 0 => Ok(round_to_tens(n, d.unsigned_abs(), vm.heap)),
+            // Rounding to a whole number of places leaves an int unchanged.
+            _ => Ok(number.clone_with_heap(vm.heap)),
+        },
         _ => {
             let type_name = number.py_type_name(vm);
             Err(SimpleException::new_msg(
@@ -113,6 +120,25 @@ pub fn builtin_round(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
             .into())
         }
     }
+}
+
+/// Rounds an integer to the nearest multiple of `10**k`, half to even, exactly in integers
+/// like CPython's `int.__round__`.
+fn round_to_tens(n: &BigInt, k: u64, heap: &Heap) -> Value {
+    // `10**k` exceeds `|n|` once `k` passes its decimal digit count, so the result is 0.
+    let digit_bound = n.bits().saturating_mul(30_103) / 100_000 + 1;
+    let Some(k) = u32::try_from(k).ok().filter(|k| u64::from(*k) <= digit_bound) else {
+        return Value::Int(0);
+    };
+    let factor = BigInt::from(10u8).pow(k);
+    let (quotient, remainder) = n.div_mod_floor(&factor);
+    let twice_remainder = remainder << 1u32;
+    let quotient = if twice_remainder > factor || (twice_remainder == factor && quotient.is_odd()) {
+        quotient + 1
+    } else {
+        quotient
+    };
+    LongInt::new(quotient * factor).into_value(heap)
 }
 
 /// Implements banker's rounding (round half to even).

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1498,6 +1498,15 @@ pub(crate) trait ExcTypeExt: Sized {
     /// `can only concatenate {type} (not "{other}") to {type}`
     ///
     /// For other cases, uses the generic format:
+    /// `unsupported operand type(s) for ** or pow(): '{base}', '{exp}', '{mod}'` — three-argument
+    /// `pow()` with no float operand and a non-integer among them.
+    #[must_use]
+    fn ternary_pow_type_error(base: impl Display, exp: impl Display, modulus: impl Display) -> RunError {
+        Self::type_error(format!(
+            "unsupported operand type(s) for ** or pow(): '{base}', '{exp}', '{modulus}'"
+        ))
+    }
+
     /// `unsupported operand type(s) for {op}: '{left}' and '{right}'`
     #[must_use]
     fn binary_type_error(op: &str, lhs_type: Type, lhs_name: impl Display, rhs_name: impl Display) -> RunError {

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1492,14 +1492,8 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::OverflowError, "Python int too large to convert to C long").into()
     }
 
-    /// Creates a TypeError for unsupported binary operations.
-    ///
-    /// For `+` or `+=` with str/list on the left side, uses CPython's special format:
-    /// `can only concatenate {type} (not "{other}") to {type}`
-    ///
-    /// For other cases, uses the generic format:
-    /// `unsupported operand type(s) for ** or pow(): '{base}', '{exp}', '{mod}'` — three-argument
-    /// `pow()` with no float operand and a non-integer among them.
+    /// Creates the TypeError for three-argument `pow()` with a non-integer operand and no
+    /// float among them: `unsupported operand type(s) for ** or pow(): '{base}', '{exp}', '{modulus}'`.
     #[must_use]
     fn ternary_pow_type_error(base: impl Display, exp: impl Display, modulus: impl Display) -> RunError {
         Self::type_error(format!(
@@ -1507,6 +1501,12 @@ pub(crate) trait ExcTypeExt: Sized {
         ))
     }
 
+    /// Creates a TypeError for unsupported binary operations.
+    ///
+    /// For `+` or `+=` with str/list on the left side, uses CPython's special format:
+    /// `can only concatenate {type} (not "{other}") to {type}`
+    ///
+    /// For other cases, uses the generic format:
     /// `unsupported operand type(s) for {op}: '{left}' and '{right}'`
     #[must_use]
     fn binary_type_error(op: &str, lhs_type: Type, lhs_name: impl Display, rhs_name: impl Display) -> RunError {

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -25,8 +25,10 @@
 
 use std::f64::consts;
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
-use num_traits::ToPrimitive;
+use num_integer::Integer;
+use num_traits::{One, Signed, ToPrimitive, Zero};
 use smallvec::smallvec;
 
 use crate::{
@@ -34,10 +36,11 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    heap::{Heap, HeapData, HeapId},
+    heap::{HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    types::{LongInt, Module, allocate_tuple},
+    resource_checks::check_product_size,
+    types::{LongInt, Module, allocate_tuple, long_int::bigint_to_f64_checked},
     value::Value,
 };
 
@@ -369,6 +372,7 @@ fn math_floor(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         Value::Float(f) => LongInt::value_from_f64(f.floor(), vm.heap),
         Value::Int(n) => Ok(Value::Int(*n)),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
+        _ if value.as_long_int(vm).is_some() => Ok(value.clone_with_heap(vm.heap)),
         _ => Err(ExcType::type_error(format!(
             "must be real number, not {}",
             value.py_type_name(vm)
@@ -388,6 +392,7 @@ fn math_ceil(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         Value::Float(f) => LongInt::value_from_f64(f.ceil(), vm.heap),
         Value::Int(n) => Ok(Value::Int(*n)),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
+        _ if value.as_long_int(vm).is_some() => Ok(value.clone_with_heap(vm.heap)),
         _ => Err(ExcType::type_error(format!(
             "must be real number, not {}",
             value.py_type_name(vm)
@@ -406,6 +411,7 @@ fn math_trunc(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         Value::Float(f) => LongInt::value_from_f64(f.trunc(), vm.heap),
         Value::Int(n) => Ok(Value::Int(*n)),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
+        _ if value.as_long_int(vm).is_some() => Ok(value.clone_with_heap(vm.heap)),
         _ => Err(ExcType::type_error(format!(
             "type {} doesn't define __trunc__ method",
             value.py_type_name(vm)
@@ -441,14 +447,21 @@ fn math_isqrt(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.isqrt", vm.heap)?;
     defer_drop!(value, vm);
 
-    let n = value_to_int(value, vm)?;
-    if n < 0 {
-        return Err(SimpleException::new_msg(ExcType::ValueError, "isqrt() argument must be nonnegative").into());
+    let n = value_to_bigint(value, vm)?;
+    if n.is_negative() {
+        Err(SimpleException::new_msg(ExcType::ValueError, "isqrt() argument must be nonnegative").into())
+    } else if let Some(n) = n.to_i64() {
+        Ok(Value::Int(isqrt_i64(n)))
+    } else {
+        Ok(LongInt::new(BigInt::from(n.magnitude().sqrt())).into_value(vm.heap))
     }
-    if n == 0 {
-        return Ok(Value::Int(0));
-    }
+}
 
+/// Integer square root of a non-negative machine integer.
+fn isqrt_i64(n: i64) -> i64 {
+    if n == 0 {
+        return 0;
+    }
     // Integer square root via f64 estimate + correction.
     // For i64 inputs, f64 sqrt is accurate to within ±1, so we need to
     // correct both overshoot and undershoot. The cast truncates toward zero,
@@ -467,7 +480,7 @@ fn math_isqrt(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     while x < n / (x + 1) {
         x += 1;
     }
-    Ok(Value::Int(x))
+    x
 }
 
 /// `math.cbrt(x)` — returns the cube root of x.
@@ -551,35 +564,86 @@ fn math_expm1(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 ///
 /// With one argument, returns the natural logarithm (base e).
 /// With two arguments, returns `log(x) / log(base)`.
-/// Raises `ValueError` for non-positive inputs (CPython 3.14: "expected a positive input").
 fn math_log(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let (x_val, base_val) = args.get_one_two_args("math.log", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(base_val, vm);
 
-    let x = value_to_float(x_val, vm)?;
-    if x <= 0.0 {
-        return Err(SimpleException::new_msg(ExcType::ValueError, "expected a positive input").into());
-    }
-
+    let numerator = log_arg(x_val, f64::ln, vm)?;
     match base_val {
         Some(base_v) => {
-            let base = value_to_float(base_v, vm)?;
-            // base == 1.0 causes division by zero in log(x)/log(base), matching
-            // CPython which raises ZeroDivisionError for this case.
-            #[expect(
-                clippy::float_cmp,
-                reason = "exact comparison with 1.0 is intentional — log(1.0) is exactly 0.0"
-            )]
-            if base == 1.0 {
-                return Err(SimpleException::new_msg(ExcType::ZeroDivisionError, "division by zero").into());
+            // `log(1) == 0.0`, so a base of 1 divides by zero as in CPython.
+            let denominator = log_arg(base_v, f64::ln, vm)?;
+            if denominator == 0.0 {
+                Err(ExcType::zero_division().into())
+            } else {
+                Ok(Value::Float(numerator / denominator))
             }
-            if base <= 0.0 {
-                return Err(SimpleException::new_msg(ExcType::ValueError, "expected a positive input").into());
-            }
-            Ok(Value::Float(x.ln() / base.ln()))
         }
-        None => Ok(Value::Float(x.ln())),
+        None => Ok(Value::Float(numerator)),
+    }
+}
+
+/// Applies a logarithm to a `math` argument, after CPython's `loghelper`.
+///
+/// An int beyond the float range is split as `m * 2**e` with `m` in `[0.5, 1)`, so
+/// `math.log(10**400)` works where `float(10**400)` overflows. Non-positive inputs
+/// raise `ValueError`; only the float message names the offending value.
+#[expect(clippy::cast_precision_loss, reason = "the exponent is a bit count, far below 2**53")]
+fn log_arg(value: &Value, log: fn(f64) -> f64, vm: &VM<'_>) -> RunResult<f64> {
+    let positive_input_error = || SimpleException::new_msg(ExcType::ValueError, "expected a positive input").into();
+    match value {
+        Value::Int(n) if *n <= 0 => Err(positive_input_error()),
+        Value::Int(n) => Ok(log(*n as f64)),
+        Value::Bool(true) => Ok(log(1.0)),
+        Value::Bool(false) => Err(positive_input_error()),
+        _ => match value.as_long_int(vm) {
+            // A long int is never zero.
+            Some(n) if n.is_negative() => Err(positive_input_error()),
+            Some(n) => Ok(if let Some(x) = n.to_f64().filter(|x| x.is_finite()) {
+                log(x)
+            } else {
+                let (mantissa, exponent) = bigint_frexp(n);
+                log(mantissa) + log(2.0) * exponent as f64
+            }),
+            None => {
+                let x = value_to_float(value, vm)?;
+                if x <= 0.0 {
+                    Err(
+                        SimpleException::new_msg(ExcType::ValueError, format!("expected a positive input, got {x:?}"))
+                            .into(),
+                    )
+                } else {
+                    Ok(log(x))
+                }
+            }
+        },
+    }
+}
+
+/// Splits a positive integer into `m * 2**e` with `m` in `[0.5, 1)`, after `_PyLong_Frexp`.
+///
+/// `m` carries the integer's top bits correctly rounded to a float (a sticky bit stands in
+/// for everything below the top 64), so it is exact where `to_f64` would overflow.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "rounding the top 64 bits to a float is the point"
+)]
+fn bigint_frexp(n: &BigInt) -> (f64, i64) {
+    let bits = n.bits();
+    let shift = bits.saturating_sub(64);
+    let mut top = (n.magnitude() >> shift).to_u64().unwrap_or(u64::MAX);
+    // Any set bit below the top 64 breaks a rounding tie upward, as the full value would.
+    if n.trailing_zeros().unwrap_or(0) < shift {
+        top |= 1;
+    }
+    let mantissa = libm::ldexp(top as f64, -64);
+    let exponent = i64::try_from(bits).unwrap_or(i64::MAX);
+    // Rounding can carry the mantissa up to 1.0; renormalise as CPython does.
+    if mantissa >= 1.0 {
+        (0.5, exponent + 1)
+    } else {
+        (mantissa, exponent)
     }
 }
 
@@ -608,12 +672,7 @@ fn math_log2(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.log2", vm.heap)?;
     defer_drop!(value, vm);
 
-    let f = value_to_float(value, vm)?;
-    if f <= 0.0 {
-        Err(SimpleException::new_msg(ExcType::ValueError, "expected a positive input").into())
-    } else {
-        Ok(Value::Float(f.log2()))
-    }
+    Ok(Value::Float(log_arg(value, f64::log2, vm)?))
 }
 
 /// `math.log10(x)` — returns the base-10 logarithm of x.
@@ -624,12 +683,7 @@ fn math_log10(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.log10", vm.heap)?;
     defer_drop!(value, vm);
 
-    let f = value_to_float(value, vm)?;
-    if f <= 0.0 {
-        Err(SimpleException::new_msg(ExcType::ValueError, "expected a positive input").into())
-    } else {
-        Ok(Value::Float(f.log10()))
-    }
+    Ok(Value::Float(log_arg(value, f64::log10, vm)?))
 }
 
 // ==========================
@@ -977,38 +1031,43 @@ fn math_factorial(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.factorial", vm.heap)?;
     defer_drop!(value, vm);
 
-    let n = match value {
-        Value::Int(n) => *n,
-        Value::Bool(b) => i64::from(*b),
-        _ => {
-            return Err(ExcType::type_error(format!(
-                "'{}' object cannot be interpreted as an integer",
-                value.py_type_name(vm)
-            )));
-        }
-    };
+    let n = value_to_bigint(value, vm)?;
+    Ok(LongInt::new(factorial(&n, &vm.heap.tracker)?).into_value(vm.heap))
+}
 
-    if n < 0 {
+/// `n!` with CPython's argument errors, shared by `factorial` and one-argument `perm`.
+fn factorial(n: &BigInt, tracker: &ResourceTracker) -> RunResult<BigInt> {
+    if n.is_negative() {
         return Err(
             SimpleException::new_msg(ExcType::ValueError, "factorial() not defined for negative values").into(),
         );
     }
+    let Some(n) = n.to_i64() else {
+        return Err(SimpleException::new_msg(
+            ExcType::OverflowError,
+            "factorial() argument should not exceed 9223372036854775807",
+        )
+        .into());
+    };
+    let n = n.unsigned_abs();
+    check_product_size(n, u64::from(u64::BITS - n.leading_zeros()), tracker)?;
+    product_range(2, n, &mut 0, tracker)
+}
 
-    // Compute factorial iteratively
-    let mut result: i64 = 1;
-    for i in 2..=n {
-        match result.checked_mul(i) {
-            Some(v) => result = v,
-            None => {
-                // Overflow — for simplicity, return an error for very large factorials
-                // since we don't have LongInt factorial support yet
-                return Err(
-                    SimpleException::new_msg(ExcType::OverflowError, "int too large to convert to factorial").into(),
-                );
-            }
-        }
+/// Multiplies `lo..=hi` by binary splitting, so a big factorial combines factors of
+/// similar size rather than one at a time against a growing product.
+fn product_range(lo: u64, hi: u64, polls: &mut usize, tracker: &ResourceTracker) -> RunResult<BigInt> {
+    if lo > hi {
+        Ok(BigInt::one())
+    } else if hi - lo < 32 {
+        // Nothing here returns to the VM's dispatch checkpoint, so the loop polls the clock itself.
+        tracker.check_time_every(*polls)?;
+        *polls += 1;
+        Ok((lo..=hi).fold(BigInt::one(), |product, i| product * i))
+    } else {
+        let mid = lo + (hi - lo) / 2;
+        Ok(product_range(lo, mid, polls, tracker)? * product_range(mid + 1, hi, polls, tracker)?)
     }
-    Ok(Value::Int(result))
 }
 
 /// `math.gcd(*integers)` — returns the greatest common divisor of the arguments.
@@ -1020,13 +1079,12 @@ fn math_gcd(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("math.gcd", vm.heap)?;
     defer_drop_mut!(positional, vm);
 
-    let mut result: u64 = 0;
+    let mut result = BigInt::ZERO;
     for arg in positional.by_ref() {
         defer_drop!(arg, vm);
-        let n = value_to_int(arg, vm)?;
-        result = gcd(result, n.unsigned_abs());
+        result = result.gcd(&value_to_bigint(arg, vm)?);
     }
-    Ok(u64_to_value(result, vm.heap))
+    Ok(LongInt::new(result).into_value(vm.heap))
 }
 
 /// `math.lcm(*integers)` — returns the least common multiple of the arguments.
@@ -1038,21 +1096,16 @@ fn math_lcm(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("math.lcm", vm.heap)?;
     defer_drop_mut!(positional, vm);
 
-    let mut result: u64 = 1;
+    let mut result = BigInt::one();
     for arg in positional.by_ref() {
         defer_drop!(arg, vm);
-        let n = value_to_int(arg, vm)?;
-        let abs_n = n.unsigned_abs();
-        if abs_n == 0 {
-            return Ok(Value::Int(0));
+        let n = value_to_bigint(arg, vm)?;
+        // A zero anywhere makes the result zero, but every argument is still type-checked.
+        if !result.is_zero() {
+            result = result.lcm(&n);
         }
-        let g = gcd(result, abs_n);
-        // lcm(a, b) = |a| / gcd(a,b) * |b| — dividing first avoids intermediate overflow
-        result = (result / g)
-            .checked_mul(abs_n)
-            .ok_or_else(|| SimpleException::new_msg(ExcType::OverflowError, "integer overflow in lcm"))?;
     }
-    Ok(u64_to_value(result, vm.heap))
+    Ok(LongInt::new(result).into_value(vm.heap))
 }
 
 /// `math.comb(n, k)` — returns the number of ways to choose k items from n.
@@ -1063,47 +1116,47 @@ fn math_comb(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(n_val, vm);
     defer_drop!(k_val, vm);
 
-    let n = value_to_int(n_val, vm)?;
-    let k = value_to_int(k_val, vm)?;
+    let n = value_to_bigint(n_val, vm)?;
+    let k = value_to_bigint(k_val, vm)?;
 
-    if n < 0 {
+    if n.is_negative() {
         return Err(SimpleException::new_msg(ExcType::ValueError, "n must be a non-negative integer").into());
     }
-    if k < 0 {
+    if k.is_negative() {
         return Err(SimpleException::new_msg(ExcType::ValueError, "k must be a non-negative integer").into());
     }
     if k > n {
         return Ok(Value::Int(0));
     }
 
-    // Use the smaller of k and n-k for efficiency: C(n, k) = C(n, n-k)
-    let k = k.min(n - k);
-    let mut result: i64 = 1;
-    for i in 0..k {
-        // Use GCD reduction to keep intermediates small:
-        // result = result * (n - i) / (i + 1)
-        // By dividing both numerator and denominator by their GCD first,
-        // we reduce the chance of overflow in the multiplication step.
-        let mut numerator = n - i;
-        let mut denominator = i + 1;
-        #[expect(clippy::cast_sign_loss, reason = "both values are known non-negative at this point")]
-        let g = gcd(numerator as u64, denominator as u64).cast_signed();
-        numerator /= g;
-        denominator /= g;
-        // Also reduce against the running result
-        #[expect(clippy::cast_sign_loss, reason = "result and denominator are known non-negative")]
-        let g2 = gcd(result as u64, denominator as u64).cast_signed();
-        result /= g2;
-        denominator /= g2;
-        debug_assert!(denominator == 1, "denominator should be 1 after GCD reduction in comb");
-        match result.checked_mul(numerator) {
-            Some(v) => result = v,
-            None => {
-                return Err(SimpleException::new_msg(ExcType::OverflowError, "integer overflow in comb").into());
-            }
+    // C(n, k) == C(n, n - k): take the shorter product.
+    let n_minus_k = &n - &k;
+    let k = k.min(n_minus_k);
+    let Some(k) = k.to_i64() else {
+        return Err(SimpleException::new_msg(
+            ExcType::OverflowError,
+            "min(n - k, k) must not exceed 9223372036854775807",
+        )
+        .into());
+    };
+    let result = falling_product(&n, k.unsigned_abs(), true, &vm.heap.tracker)?;
+    Ok(LongInt::new(result).into_value(vm.heap))
+}
+
+/// `n * (n - 1) * ... * (n - k + 1)`, the `k`-permutation count; with `binomial` each
+/// step also divides by `i + 1`, so every partial product is the exact `C(n, i + 1)`.
+fn falling_product(n: &BigInt, k: u64, binomial: bool, tracker: &ResourceTracker) -> RunResult<BigInt> {
+    check_product_size(k, n.bits(), tracker)?;
+    let mut result = BigInt::one();
+    for (polls, i) in (0..k).enumerate() {
+        // Nothing here returns to the VM's dispatch checkpoint, so the loop polls the clock itself.
+        tracker.check_time_every(polls)?;
+        result *= n - i;
+        if binomial {
+            result /= i + 1;
         }
     }
-    Ok(Value::Int(result))
+    Ok(result)
 }
 
 /// `math.perm(n, k=None)` — returns the number of k-length permutations from n items.
@@ -1114,42 +1167,28 @@ fn math_perm(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let (n_val, k_val) = args.get_one_two_args("math.perm", vm.heap)?;
     defer_drop!(n_val, vm);
 
-    let n = value_to_int(n_val, vm)?;
-    let k_explicit = k_val.is_some();
-    let k = match k_val {
-        Some(kv) => {
-            defer_drop!(kv, vm);
-            value_to_int(kv, vm)?
-        }
-        None => n,
+    let n = value_to_bigint(n_val, vm)?;
+    // `perm(n)` is `n!`, argument errors included.
+    let Some(k_val) = k_val else {
+        return Ok(LongInt::new(factorial(&n, &vm.heap.tracker)?).into_value(vm.heap));
     };
+    defer_drop!(k_val, vm);
+    let k = value_to_bigint(k_val, vm)?;
 
-    if n < 0 {
-        // When called as perm(n) without k, CPython uses the factorial error message
-        let msg = if k_explicit {
-            "n must be a non-negative integer"
-        } else {
-            "factorial() not defined for negative values"
-        };
-        return Err(SimpleException::new_msg(ExcType::ValueError, msg).into());
+    if n.is_negative() {
+        return Err(SimpleException::new_msg(ExcType::ValueError, "n must be a non-negative integer").into());
     }
-    if k < 0 {
+    if k.is_negative() {
         return Err(SimpleException::new_msg(ExcType::ValueError, "k must be a non-negative integer").into());
     }
     if k > n {
         return Ok(Value::Int(0));
     }
-
-    let mut result: i64 = 1;
-    for i in 0..k {
-        match result.checked_mul(n - i) {
-            Some(v) => result = v,
-            None => {
-                return Err(SimpleException::new_msg(ExcType::OverflowError, "integer overflow in perm").into());
-            }
-        }
-    }
-    Ok(Value::Int(result))
+    let Some(k) = k.to_i64() else {
+        return Err(SimpleException::new_msg(ExcType::OverflowError, "k must not exceed 9223372036854775807").into());
+    };
+    let result = falling_product(&n, k.unsigned_abs(), false, &vm.heap.tracker)?;
+    Ok(LongInt::new(result).into_value(vm.heap))
 }
 
 // ==========================
@@ -1244,7 +1283,14 @@ fn math_ldexp(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(i_val, vm);
 
     let x = value_to_float(x_val, vm)?;
-    let i = value_to_int(i_val, vm)?;
+    // An exponent beyond `i64` saturates: the result overflows or underflows either way.
+    let i = match i_val {
+        Value::Int(i) => *i,
+        Value::Bool(b) => i64::from(*b),
+        _ => i_val
+            .long_int_to_i64_saturating(vm)
+            .ok_or_else(|| not_an_integer_error(i_val, vm))?,
+    };
 
     // Special cases: inf/nan/zero pass through regardless of exponent
     if x.is_nan() || x.is_infinite() || x == 0.0 {
@@ -1331,7 +1377,8 @@ fn math_erfc(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 
 /// Converts a `Value` to `f64`, raising `TypeError` if the value is not numeric.
 ///
-/// Accepts floats, integers (including big integers), and booleans. Other types raise a `TypeError`
+/// Accepts `Float`, `Int`, `Bool` and long ints, which convert like `float()` and so
+/// raise `OverflowError` beyond the float range. Other types raise a `TypeError`
 /// with a message matching CPython's format: "must be real number, not <type>".
 #[expect(
     clippy::cast_precision_loss,
@@ -1342,36 +1389,36 @@ fn value_to_float(value: &Value, vm: &VM<'_>) -> RunResult<f64> {
         Value::Float(f) => Ok(*f),
         Value::Int(n) => Ok(*n as f64),
         Value::Bool(b) => Ok(if *b { 1.0 } else { 0.0 }),
-        Value::InternLongInt(id) => vm
-            .interns
-            .get_long_int(*id)
-            .to_f64()
-            .filter(|f| f.is_finite())
-            .ok_or_else(ExcType::overflow_int_to_float),
-        Value::Ref(id) if let HeapData::LongInt(integer) = vm.heap.get(*id) => integer
-            .to_f64()
-            .filter(|f| f.is_finite())
-            .ok_or_else(ExcType::overflow_int_to_float),
-        _ => Err(ExcType::type_error(format!(
-            "must be real number, not {}",
-            value.py_type_name(vm)
-        ))),
+        _ => match value.as_long_int(vm) {
+            Some(n) => bigint_to_f64_checked(n),
+            None => Err(ExcType::type_error(format!(
+                "must be real number, not {}",
+                value.py_type_name(vm)
+            ))),
+        },
     }
 }
 
-/// Converts a `Value` to `i64`, raising `TypeError` if the value is not an integer.
+/// Converts a `Value` to an arbitrary-precision integer, raising `TypeError` otherwise.
 ///
-/// Accepts `Int` and `Bool` values. For other types, raises a `TypeError`
-/// with a message matching CPython's format.
-fn value_to_int(value: &Value, vm: &VM<'_>) -> RunResult<i64> {
+/// Accepts `Int`, `Bool` and long ints; the message matches CPython's `__index__` failure.
+fn value_to_bigint(value: &Value, vm: &VM<'_>) -> RunResult<BigInt> {
     match value {
-        Value::Int(n) => Ok(*n),
-        Value::Bool(b) => Ok(i64::from(*b)),
-        _ => Err(ExcType::type_error(format!(
-            "'{}' object cannot be interpreted as an integer",
-            value.py_type_name(vm)
-        ))),
+        Value::Int(n) => Ok(BigInt::from(*n)),
+        Value::Bool(b) => Ok(BigInt::from(*b)),
+        _ => value
+            .as_long_int(vm)
+            .cloned()
+            .ok_or_else(|| not_an_integer_error(value, vm)),
     }
+}
+
+/// The `TypeError` CPython raises when `__index__` is missing on a `math` argument.
+fn not_an_integer_error(value: &Value, vm: &VM<'_>) -> RunError {
+    ExcType::type_error(format!(
+        "'{}' object cannot be interpreted as an integer",
+        value.py_type_name(vm)
+    ))
 }
 
 /// Requires that a float is finite, raising ValueError if it's inf or nan.
@@ -1382,27 +1429,5 @@ fn require_finite(f: f64) -> RunResult<()> {
         Err(SimpleException::new_msg(ExcType::ValueError, format!("expected a finite input, got {f:?}")).into())
     } else {
         Ok(())
-    }
-}
-
-/// Euclidean GCD algorithm for unsigned 64-bit integers.
-fn gcd(mut a: u64, mut b: u64) -> u64 {
-    while b != 0 {
-        let t = b;
-        b = a % b;
-        a = t;
-    }
-    a
-}
-
-/// Converts a `u64` result to a `Value`, promoting to `LongInt` if it exceeds `i64::MAX`.
-///
-/// This is needed for operations like `gcd(i64::MIN, 0)` where the unsigned result
-/// (`2^63`) doesn't fit in a signed `i64`.
-fn u64_to_value(n: u64, heap: &mut Heap) -> Value {
-    if let Ok(signed) = i64::try_from(n) {
-        Value::Int(signed)
-    } else {
-        LongInt::new(BigInt::from(n)).into_value(heap)
     }
 }

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -1051,7 +1051,8 @@ fn factorial(n: &BigInt, tracker: &ResourceTracker) -> RunResult<BigInt> {
         .into());
     };
     let n = n.unsigned_abs();
-    check_product_size(n, u64::from(u64::BITS - n.leading_zeros()), tracker)?;
+    // `n!` has fewer than `n * bits(n)` bits.
+    check_product_size(n.saturating_mul(u64::from(u64::BITS - n.leading_zeros())), tracker)?;
     product_range(2, n, &mut 0, tracker)
 }
 
@@ -1108,10 +1109,13 @@ fn math_lcm(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         defer_drop!(arg, vm);
         let n = value_to_bigint(arg, vm)?;
         // A zero anywhere makes the result zero, but every argument is still type-checked.
-        if !result.is_zero() {
-            // `lcm` grows like a product, so it is preflighted like `*`.
-            check_mult_size(result.bits(), n.bits(), &vm.heap.tracker)?;
+        if !result.is_zero() && !n.is_zero() {
+            // `lcm` divides out the gcd, holding a quotient up to `result`'s size, then
+            // multiplies: preflight both like `*`.
+            check_mult_size(result.bits().saturating_mul(2), n.bits(), &vm.heap.tracker)?;
             result = result.lcm(&n);
+        } else {
+            result = BigInt::ZERO;
         }
     }
     Ok(LongInt::new(result).into_value(vm.heap))
@@ -1155,7 +1159,12 @@ fn math_comb(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 /// `n * (n - 1) * ... * (n - k + 1)`, the `k`-permutation count; with `binomial` each
 /// step also divides by `i + 1`, so every partial product is the exact `C(n, i + 1)`.
 fn falling_product(n: &BigInt, k: u64, binomial: bool, tracker: &ResourceTracker) -> RunResult<BigInt> {
-    check_product_size(k, n.bits(), tracker)?;
+    // The product has fewer than `k * bits(n)` bits; a binomial is also below `2**n`.
+    let mut result_bits = k.saturating_mul(n.bits());
+    if binomial && let Some(n) = n.to_u64() {
+        result_bits = result_bits.min(n);
+    }
+    check_product_size(result_bits, tracker)?;
     let mut result = BigInt::one();
     for (polls, i) in (0..k).enumerate() {
         // Nothing here returns to the VM's dispatch checkpoint, so the loop polls the clock itself.

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -39,7 +39,7 @@ use crate::{
     heap::{HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    resource_checks::check_product_size,
+    resource_checks::{check_mult_size, check_product_size},
     types::{LongInt, Module, allocate_tuple, long_int::bigint_to_f64_checked},
     value::Value,
 };
@@ -1066,7 +1066,13 @@ fn product_range(lo: u64, hi: u64, polls: &mut usize, tracker: &ResourceTracker)
         Ok((lo..=hi).fold(BigInt::one(), |product, i| product * i))
     } else {
         let mid = lo + (hi - lo) / 2;
-        Ok(product_range(lo, mid, polls, tracker)? * product_range(mid + 1, hi, polls, tracker)?)
+        let (low, high) = (
+            product_range(lo, mid, polls, tracker)?,
+            product_range(mid + 1, hi, polls, tracker)?,
+        );
+        // Combining two halves is where the expensive multiplications are, so each one polls.
+        tracker.check_time()?;
+        Ok(low * high)
     }
 }
 
@@ -1102,6 +1108,8 @@ fn math_lcm(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         let n = value_to_bigint(arg, vm)?;
         // A zero anywhere makes the result zero, but every argument is still type-checked.
         if !result.is_zero() {
+            // `lcm` grows like a product, so it is preflighted like `*`.
+            check_mult_size(result.bits(), n.bits(), &vm.heap.tracker)?;
             result = result.lcm(&n);
         }
     }

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -565,7 +565,8 @@ fn math_expm1(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 /// With one argument, returns the natural logarithm (base e).
 /// With two arguments, returns `log(x) / log(base)`.
 fn math_log(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
-    let (x_val, base_val) = args.get_one_two_args("math.log", vm.heap)?;
+    // CPython's arity errors name the bare function: `log expected at most 2 arguments, got 3`.
+    let (x_val, base_val) = args.get_one_two_args("log", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(base_val, vm);
 
@@ -1172,7 +1173,8 @@ fn falling_product(n: &BigInt, k: u64, binomial: bool, tracker: &ResourceTracker
 /// Both arguments must be non-negative integers. When `k` is omitted, defaults to `n`
 /// (i.e., `perm(n)` returns `n!`), matching CPython behavior.
 fn math_perm(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
-    let (n_val, k_val) = args.get_one_two_args("math.perm", vm.heap)?;
+    // CPython's arity errors name the bare function: `perm expected at most 2 arguments, got 3`.
+    let (n_val, k_val) = args.get_one_two_args("perm", vm.heap)?;
     defer_drop!(n_val, vm);
 
     let n = value_to_bigint(n_val, vm)?;

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -33,8 +33,12 @@ pub fn check_pow_size(base_bits: u64, exponent: u64, tracker: &ResourceTracker) 
 
 /// Pre-checks that a product of `terms` integers of at most `term_bits` bits each won't
 /// exceed resource limits — the bound used by `math.factorial`, `comb` and `perm`.
+///
+/// The estimate is doubled because the last multiplication holds its operands, which
+/// together are about the result's size, alongside the result itself.
 pub fn check_product_size(terms: u64, term_bits: u64, tracker: &ResourceTracker) -> Result<(), ResourceError> {
-    check_estimated_size(estimate_bits_to_bytes(terms.saturating_mul(term_bits)), tracker)
+    let result_bytes = estimate_bits_to_bytes(terms.saturating_mul(term_bits));
+    check_estimated_size(result_bytes.saturating_mul(2), tracker)
 }
 
 /// Pre-checks that an integer multiplication won't exceed resource limits.

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -31,14 +31,13 @@ pub fn check_pow_size(base_bits: u64, exponent: u64, tracker: &ResourceTracker) 
     check_estimated_size(result_bytes.saturating_mul(4), tracker)
 }
 
-/// Pre-checks that a product of `terms` integers of at most `term_bits` bits each won't
-/// exceed resource limits — the bound used by `math.factorial`, `comb` and `perm`.
+/// Pre-checks that an integer product of at most `result_bits` bits won't exceed resource
+/// limits — used by `math.factorial`, `comb` and `perm`, which each bound their own result.
 ///
 /// The estimate is doubled because the last multiplication holds its operands, which
 /// together are about the result's size, alongside the result itself.
-pub fn check_product_size(terms: u64, term_bits: u64, tracker: &ResourceTracker) -> Result<(), ResourceError> {
-    let result_bytes = estimate_bits_to_bytes(terms.saturating_mul(term_bits));
-    check_estimated_size(result_bytes.saturating_mul(2), tracker)
+pub fn check_product_size(result_bits: u64, tracker: &ResourceTracker) -> Result<(), ResourceError> {
+    check_estimated_size(estimate_bits_to_bytes(result_bits).saturating_mul(2), tracker)
 }
 
 /// Pre-checks that an integer multiplication won't exceed resource limits.

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -31,6 +31,12 @@ pub fn check_pow_size(base_bits: u64, exponent: u64, tracker: &ResourceTracker) 
     check_estimated_size(result_bytes.saturating_mul(4), tracker)
 }
 
+/// Pre-checks that a product of `terms` integers of at most `term_bits` bits each won't
+/// exceed resource limits — the bound used by `math.factorial`, `comb` and `perm`.
+pub fn check_product_size(terms: u64, term_bits: u64, tracker: &ResourceTracker) -> Result<(), ResourceError> {
+    check_estimated_size(estimate_bits_to_bytes(terms.saturating_mul(term_bits)), tracker)
+}
+
 /// Pre-checks that an integer multiplication won't exceed resource limits.
 ///
 /// The result of multiplying two numbers has at most `a_bits + b_bits` bits.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1899,6 +1899,20 @@ impl Value {
         }
     }
 
+    /// Borrows the arbitrary-precision value of a `LongInt`-valued int (interned
+    /// or heap-allocated). `None` for every other value, `Int`/`Bool` included,
+    /// so callers keep their own fast paths for those.
+    pub(crate) fn as_long_int<'a>(&self, vm: &'a VM<'_>) -> Option<&'a BigInt> {
+        match self {
+            Self::InternLongInt(id) => Some(vm.interns.get_long_int(*id)),
+            Self::Ref(id) => match vm.heap.get(*id) {
+                HeapData::LongInt(li) => Some(li.inner()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Performs Python `+` with reflected-operation fallback.
     pub(crate) fn py_add(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
         if let Some(result) = self.py_add_result(other, vm)? {

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -53,6 +53,17 @@ assert round(10**400, -400) == 10**400
 assert round(10**400, -401) == 0
 assert round(5 * 10**399, -400) == 0
 assert round(15 * 10**399, -400) == 2 * 10**400
+assert round(-big) == -big
+assert round(big, True) == big
+assert round(big, -1) == 1180591620717411303420
+assert round(big + 5, -1) == 1180591620717411303430
+assert round(big + 15, -1) == 1180591620717411303440
+assert round(-big - 5, -1) == -1180591620717411303430
+assert round(-(10**30) - 15 * 10**10, -11) == -(10**30) - 2 * 10**11
+assert round(10**30, -30) == 10**30
+assert round(5 * 10**29, -30) == 0
+assert round(-5 * 10**29, -30) == 0
+assert round(15 * 10**29, -30) == 2 * 10**30
 try:
     round(big, 2.0)
     assert False, 'expected TypeError'
@@ -232,3 +243,58 @@ try:
 except ZeroDivisionError:
     threw = True
 assert threw
+
+# pow() is the ** operator: every numeric pairing, including long ints and bools
+big = 2**70
+assert pow(2, 100) == 1267650600228229401496703205376
+assert pow(2, 63) == 9223372036854775808
+assert pow(-2, 63) == -9223372036854775808
+assert pow(big, 2) == 1393796574908163946345982392040522594123776
+assert pow(1, big) == 1
+assert pow(-1, big) == 1
+assert pow(-1, big + 1) == -1
+assert pow(0, big) == 0
+assert pow(big, 0) == 1
+assert pow(big, -2) == 7.174648137343064e-43
+assert pow(False, 0) == 1
+assert pow(True, 2.5) == 1.0
+assert pow(2.5, True) == 2.5
+assert pow(2, 3, None) == 8
+
+# modular pow with every integer representation
+assert pow(2, 3, 5) == 3
+assert pow(2, 3, -5) == -2
+assert pow(-2, 3, 5) == 2
+assert pow(big, 2, 7) == 4
+assert pow(2, big, 7) == 2
+assert pow(2, 3, big) == 8
+assert pow(big, big, big - 1) == 1
+assert pow(True, 3, 2) == 1
+try:
+    pow(2, 3, 0)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'pow() 3rd argument cannot be 0'
+
+# a float anywhere rejects the third argument; other types are an unsupported operand
+for compute in [lambda: pow(2.0, 3, 5), lambda: pow(2, 3.0, 5), lambda: pow(2, 3, 5.0), lambda: pow(2.0, 'a', 3)]:
+    try:
+        compute()
+        assert False, 'expected TypeError'
+    except TypeError as e:
+        assert str(e) == 'pow() 3rd argument not allowed unless all arguments are integers'
+for compute, message in [
+    (lambda: pow('a', 2), "unsupported operand type(s) for ** or pow(): 'str' and 'int'"),
+    (lambda: pow(2, 'a'), "unsupported operand type(s) for ** or pow(): 'int' and 'str'"),
+    (lambda: pow('a', 2, 3), "unsupported operand type(s) for ** or pow(): 'str', 'int', 'int'"),
+    (lambda: pow(2, 3, 'a'), "unsupported operand type(s) for ** or pow(): 'int', 'int', 'str'"),
+    (lambda: pow(True, 2, 'a'), "unsupported operand type(s) for ** or pow(): 'bool', 'int', 'str'"),
+    (lambda: pow(2), "pow() missing required argument 'exp' (pos 2)"),
+    (lambda: pow(), "pow() missing required argument 'base' (pos 1)"),
+    (lambda: pow(2, 3, 4, 5), 'pow() takes at most 3 arguments (4 given)'),
+]:
+    try:
+        compute()
+        assert False, 'expected TypeError'
+    except TypeError as e:
+        assert str(e) == message

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -33,6 +33,31 @@ assert round(number=3.14159, ndigits=2) == 3.14
 assert round(ndigits=2, number=3.14159) == 3.14
 assert repr(round(-0.4, 0)) == '-0.0'
 assert repr(round(-0.5, 0)) == '-0.0'
+
+# round() on a long int rounds exactly, half to even, like `int.__round__`
+big = 2**70
+assert round(big) == big
+assert round(big, 2) == big
+assert round(big, None) == big
+assert round(big, big) == big
+assert round(big, -2) == 1180591620717411303400
+assert round(big, -5) == 1180591620717411300000
+assert round(-big, -5) == -1180591620717411300000
+assert round(big, -21) == 10**21
+assert round(big, -22) == 0
+assert round(10**30 + 5 * 10**10, -11) == 10**30
+assert round(10**30 + 15 * 10**10, -11) == 10**30 + 2 * 10**11
+assert round(-(10**30) - 5 * 10**10, -11) == -(10**30)
+assert round(10**400, -399) == 10**400
+assert round(10**400, -400) == 10**400
+assert round(10**400, -401) == 0
+assert round(5 * 10**399, -400) == 0
+assert round(15 * 10**399, -400) == 2 * 10**400
+try:
+    round(big, 2.0)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'float' object cannot be interpreted as an integer"
 assert round(1234, -2) == 1200
 assert round(1250, -2) == 1200
 assert round(1350, -2) == 1400

--- a/crates/monty/test_cases/math__module.py
+++ b/crates/monty/test_cases/math__module.py
@@ -1442,3 +1442,142 @@ assert math.erf(5.0) == 0.9999999999984626
 # erfc in range 3 (1.25 ≤ |x| < 2.857): exercises RA/SA coefficients
 erfc_2 = math.erfc(2.0)
 assert math.isclose(erfc_2, 0.004677734981047266, rel_tol=1e-12)
+
+# ==========================================================
+# Long int arguments
+# ==========================================================
+
+# === Real-number functions convert a long int the way float() does ===
+big = 2**70
+huge = 10**400
+assert math.sqrt(big) == 34359738368.0
+assert math.fabs(-big) == 1.1805916207174113e21
+assert math.copysign(1, -big) == -1.0
+assert math.isclose(big, big + 1)
+assert math.fmod(big, 3.0) == 1.0
+assert math.pow(big, 2) == 1.393796574908164e42
+assert math.degrees(big) == 6.764291719561731e22
+assert math.ldexp(big, 1) == 2.3611832414348226e21
+assert math.floor(big) == big
+assert math.ceil(-big) == -big
+assert math.trunc(big) == big
+for compute in [lambda: math.sqrt(huge), lambda: math.log1p(huge), lambda: math.pow(huge, 0)]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) == 'int too large to convert to float'
+
+# === Logarithms of ints beyond the float range ===
+assert math.log(big) == 48.520302639196174
+assert math.log(huge) == 921.0340371976182
+assert math.log(huge, 10) == 399.99999999999994
+assert math.log(huge, huge) == 1.0
+assert math.log(2, huge) == 0.000752574989159953
+assert math.log2(huge) == 1328.771237954945
+assert math.log10(huge) == 400.0
+assert math.log2(2**1023) == 1023.0
+assert math.log2(2**1024) == 1024.0
+assert math.log2(2**1024 + 1) == 1024.0
+assert math.log2(2**1100 - 1) == 1100.0
+assert math.log(2**1100 - 1) == 762.4618986159398
+assert math.log10(2**1100 - 1) == 331.1329952303793
+# Values chosen so fused and unfused `log(m) + log(2) * e` agree (see limitations/math.md).
+assert math.log(7**500) == 972.9550745276566
+assert math.log2(3**700) == 1109.4737505048092
+assert math.log10(3**700) == 333.9848783037637
+for compute in [lambda: math.log(-huge), lambda: math.log(10, -huge), lambda: math.log2(-5), lambda: math.log(0)]:
+    try:
+        compute()
+        assert False, 'expected ValueError'
+    except ValueError as e:
+        assert str(e) == 'expected a positive input'
+# A float argument names the offending value.
+for compute, message in [
+    (lambda: math.log(0.0), 'expected a positive input, got 0.0'),
+    (lambda: math.log2(0.0), 'expected a positive input, got 0.0'),
+    (lambda: math.log10(-1.0), 'expected a positive input, got -1.0'),
+    (lambda: math.log(float('-inf')), 'expected a positive input, got -inf'),
+    (lambda: math.log(10, 0.0), 'expected a positive input, got 0.0'),
+]:
+    try:
+        compute()
+        assert False, 'expected ValueError'
+    except ValueError as e:
+        assert str(e) == message
+
+# === Integer functions accept and return long ints ===
+assert math.isqrt(big) == 34359738368
+assert math.isqrt(huge) == 10**200
+assert math.isqrt(huge + 1) == 10**200
+assert math.isqrt(huge - 1) == 10**200 - 1
+try:
+    math.isqrt(-big)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'isqrt() argument must be nonnegative'
+
+assert math.gcd(big, 2**40) == 2**40
+assert math.gcd(big * 3, big * 5) == big
+assert math.gcd(big) == big
+assert math.gcd(-big, -big) == big
+assert math.gcd(big, 0) == big
+assert math.lcm(big, 3) == 3541774862152233910272
+assert math.lcm(2**40, 3**30) == 226379693794030958489370624
+assert math.lcm(2**62, 3) == 3 * 2**62
+assert math.lcm(-big, 3) == 3541774862152233910272
+assert math.lcm(big, 0) == 0
+try:
+    math.lcm(0, 2.0)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'float' object cannot be interpreted as an integer"
+
+assert math.factorial(21) == 51090942171709440000
+assert math.factorial(30) == 265252859812191058636308480000000
+assert len(str(math.factorial(1000))) == 2568
+try:
+    math.factorial(big)
+    assert False, 'expected OverflowError'
+except OverflowError as e:
+    assert str(e) == 'factorial() argument should not exceed 9223372036854775807'
+try:
+    math.factorial(-big)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'factorial() not defined for negative values'
+
+assert math.comb(100, 50) == 100891344545564193334812497256
+assert math.comb(big, 2) == 696898287454081973172400900209902591410176
+assert math.comb(big, big) == 1
+assert math.comb(big, big - 1) == big
+assert math.comb(5, big) == 0
+assert len(str(math.comb(1000, 500))) == 300
+for compute, exc_type, message in [
+    (lambda: math.comb(big, big // 2), OverflowError, 'min(n - k, k) must not exceed 9223372036854775807'),
+    (lambda: math.comb(-big, 1), ValueError, 'n must be a non-negative integer'),
+    (lambda: math.comb(5, -big), ValueError, 'k must be a non-negative integer'),
+    (lambda: math.perm(big, big // 2), OverflowError, 'k must not exceed 9223372036854775807'),
+    (lambda: math.perm(big), OverflowError, 'factorial() argument should not exceed 9223372036854775807'),
+    (lambda: math.perm(-big), ValueError, 'factorial() not defined for negative values'),
+]:
+    try:
+        compute()
+        assert False, 'expected an exception'
+    except exc_type as e:
+        assert str(e) == message
+assert math.perm(30) == 265252859812191058636308480000000
+assert math.perm(30, 20) == 73096577329197271449600000
+assert math.perm(big, 2) == 1393796574908163946344801800419805182820352
+assert math.perm(5, big) == 0
+assert len(str(math.perm(1000, 500))) == 1434
+
+# === ldexp saturates a long int exponent ===
+assert math.ldexp(1.0, -big) == 0.0
+assert math.ldexp(0.0, big) == 0.0
+assert math.ldexp(float('inf'), big) == float('inf')
+try:
+    math.ldexp(1.0, big)
+    assert False, 'expected OverflowError'
+except OverflowError as e:
+    assert str(e) == 'math range error'

--- a/crates/monty/test_cases/math__module.py
+++ b/crates/monty/test_cases/math__module.py
@@ -1459,9 +1459,25 @@ assert math.pow(big, 2) == 1.393796574908164e42
 assert math.degrees(big) == 6.764291719561731e22
 assert math.ldexp(big, 1) == 2.3611832414348226e21
 assert math.floor(big) == big
+assert math.floor(-big) == -big
 assert math.ceil(-big) == -big
 assert math.trunc(big) == big
-for compute in [lambda: math.sqrt(huge), lambda: math.log1p(huge), lambda: math.pow(huge, 0)]:
+assert math.cbrt(big) == 10568983.798516532
+assert math.exp(-big) == 0.0
+assert math.atan(big) == 1.5707963267948966
+assert math.hypot(big, 1) == 1.1805916207174113e21
+assert math.modf(big) == (0.0, 1.1805916207174113e21)
+assert math.frexp(big) == (0.5, 71)
+assert math.remainder(big, 3) == 1.0
+assert not math.isnan(big)
+for compute in [
+    lambda: math.sqrt(huge),
+    lambda: math.log1p(huge),
+    lambda: math.pow(huge, 0),
+    lambda: math.gamma(huge),
+    lambda: math.sin(huge),
+    lambda: math.isfinite(huge),
+]:
     try:
         compute()
         assert False, 'expected OverflowError'
@@ -1470,8 +1486,11 @@ for compute in [lambda: math.sqrt(huge), lambda: math.log1p(huge), lambda: math.
 
 # === Logarithms of ints beyond the float range ===
 assert math.log(big) == 48.520302639196174
+assert math.log2(big) == 70.0
+assert math.log10(big) == 21.072099696478684
 assert math.log(huge) == 921.0340371976182
 assert math.log(huge, 10) == 399.99999999999994
+assert math.log(huge, 2) == 1328.7712379549448
 assert math.log(huge, huge) == 1.0
 assert math.log(2, huge) == 0.000752574989159953
 assert math.log2(huge) == 1328.771237954945
@@ -1486,7 +1505,30 @@ assert math.log10(2**1100 - 1) == 331.1329952303793
 assert math.log(7**500) == 972.9550745276566
 assert math.log2(3**700) == 1109.4737505048092
 assert math.log10(3**700) == 333.9848783037637
-for compute in [lambda: math.log(-huge), lambda: math.log(10, -huge), lambda: math.log2(-5), lambda: math.log(0)]:
+for compute, message in [
+    (lambda: math.log(), 'log expected at least 1 argument, got 0'),
+    (lambda: math.log(2, 10, 3), 'log expected at most 2 arguments, got 3'),
+    (lambda: math.perm(), 'perm expected at least 1 argument, got 0'),
+    (lambda: math.perm(1, 2, 3), 'perm expected at most 2 arguments, got 3'),
+]:
+    try:
+        compute()
+        assert False, 'expected TypeError'
+    except TypeError as e:
+        assert str(e) == message
+for compute in [lambda: math.log(huge, 1), lambda: math.log(huge, True)]:
+    try:
+        compute()
+        assert False, 'expected ZeroDivisionError'
+    except ZeroDivisionError as e:
+        assert str(e) == 'division by zero'
+for compute in [
+    lambda: math.log(-huge),
+    lambda: math.log(10, -huge),
+    lambda: math.log2(-5),
+    lambda: math.log(0),
+    lambda: math.log(False),
+]:
     try:
         compute()
         assert False, 'expected ValueError'
@@ -1511,6 +1553,12 @@ assert math.isqrt(big) == 34359738368
 assert math.isqrt(huge) == 10**200
 assert math.isqrt(huge + 1) == 10**200
 assert math.isqrt(huge - 1) == 10**200 - 1
+# The machine-int fast path ends at 2**63; the big path starts there.
+assert math.isqrt(2**63 - 1) == 3037000499
+assert math.isqrt(2**63) == 3037000499
+assert math.isqrt(2**64) == 4294967296
+assert math.isqrt(2**128 - 1) == 18446744073709551615
+assert math.isqrt(2**200) == 2**100
 try:
     math.isqrt(-big)
     assert False, 'expected ValueError'
@@ -1522,25 +1570,40 @@ assert math.gcd(big * 3, big * 5) == big
 assert math.gcd(big) == big
 assert math.gcd(-big, -big) == big
 assert math.gcd(big, 0) == big
+assert math.gcd(0, big) == big
+try:
+    math.gcd(big, 2.0)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'float' object cannot be interpreted as an integer"
+assert math.lcm(big) == big
+assert math.lcm(-big) == big
 assert math.lcm(big, 3) == 3541774862152233910272
 assert math.lcm(2**40, 3**30) == 226379693794030958489370624
 assert math.lcm(2**62, 3) == 3 * 2**62
 assert math.lcm(-big, 3) == 3541774862152233910272
 assert math.lcm(big, 0) == 0
-try:
-    math.lcm(0, 2.0)
-    assert False, 'expected TypeError'
-except TypeError as e:
-    assert str(e) == "'float' object cannot be interpreted as an integer"
+for compute in [lambda: math.lcm(0, 2.0), lambda: math.lcm(big, 0, 2.0)]:
+    try:
+        compute()
+        assert False, 'expected TypeError'
+    except TypeError as e:
+        assert str(e) == "'float' object cannot be interpreted as an integer"
 
 assert math.factorial(21) == 51090942171709440000
 assert math.factorial(30) == 265252859812191058636308480000000
 assert len(str(math.factorial(1000))) == 2568
-try:
-    math.factorial(big)
-    assert False, 'expected OverflowError'
-except OverflowError as e:
-    assert str(e) == 'factorial() argument should not exceed 9223372036854775807'
+# CPython's limit is C `long`, which is 32 bits on Windows; Monty always uses the 64-bit limit.
+FACTORIAL_LIMIT_MESSAGES = {
+    'factorial() argument should not exceed 9223372036854775807',
+    'factorial() argument should not exceed 2147483647',
+}
+for compute in [lambda: math.factorial(big), lambda: math.factorial(2**63), lambda: math.perm(big)]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) in FACTORIAL_LIMIT_MESSAGES
 try:
     math.factorial(-big)
     assert False, 'expected ValueError'
@@ -1558,8 +1621,9 @@ for compute, exc_type, message in [
     (lambda: math.comb(-big, 1), ValueError, 'n must be a non-negative integer'),
     (lambda: math.comb(5, -big), ValueError, 'k must be a non-negative integer'),
     (lambda: math.perm(big, big // 2), OverflowError, 'k must not exceed 9223372036854775807'),
-    (lambda: math.perm(big), OverflowError, 'factorial() argument should not exceed 9223372036854775807'),
     (lambda: math.perm(-big), ValueError, 'factorial() not defined for negative values'),
+    (lambda: math.comb(3.0, 1), TypeError, "'float' object cannot be interpreted as an integer"),
+    (lambda: math.perm(3, 1.0), TypeError, "'float' object cannot be interpreted as an integer"),
 ]:
     try:
         compute()
@@ -1567,17 +1631,32 @@ for compute, exc_type, message in [
     except exc_type as e:
         assert str(e) == message
 assert math.perm(30) == 265252859812191058636308480000000
+assert math.perm(25) == 15511210043330985984000000
 assert math.perm(30, 20) == 73096577329197271449600000
 assert math.perm(big, 2) == 1393796574908163946344801800419805182820352
 assert math.perm(5, big) == 0
 assert len(str(math.perm(1000, 500))) == 1434
+# Small and boundary arguments on the big-int paths.
+assert math.comb(50, 25) == 126410606437752
+assert math.comb(big, 0) == 1
+assert math.perm(big, 0) == 1
+assert math.perm(big, 1) == big
+assert math.comb(0, 0) == 1
+assert math.comb(True, True) == 1
+assert math.comb(2**63, 1) == 2**63
+assert math.perm(2**63, 1) == 2**63
+assert math.comb(2**63, 2) == 42535295865117307928310139910543638528
+assert math.perm(2**63, 2) == 85070591730234615856620279821087277056
 
 # === ldexp saturates a long int exponent ===
 assert math.ldexp(1.0, -big) == 0.0
+assert math.ldexp(1.0, -(2**31)) == 0.0
 assert math.ldexp(0.0, big) == 0.0
 assert math.ldexp(float('inf'), big) == float('inf')
-try:
-    math.ldexp(1.0, big)
-    assert False, 'expected OverflowError'
-except OverflowError as e:
-    assert str(e) == 'math range error'
+assert math.ldexp(big, -70) == 1.0
+for compute in [lambda: math.ldexp(1.0, big), lambda: math.ldexp(1.0, 2**31), lambda: math.ldexp(True, big)]:
+    try:
+        compute()
+        assert False, 'expected OverflowError'
+    except OverflowError as e:
+        assert str(e) == 'math range error'

--- a/crates/monty/test_cases/math__module.py
+++ b/crates/monty/test_cases/math__module.py
@@ -1462,7 +1462,8 @@ assert math.floor(big) == big
 assert math.floor(-big) == -big
 assert math.ceil(-big) == -big
 assert math.trunc(big) == big
-assert math.cbrt(big) == 10568983.798516532
+# `cbrt` differs across libms in the last bit, so this one is checked with a tolerance.
+assert math.isclose(math.cbrt(big), 10568983.798516532, rel_tol=1e-15)
 assert math.exp(-big) == 0.0
 assert math.atan(big) == 1.5707963267948966
 assert math.hypot(big, 1) == 1.1805916207174113e21
@@ -1583,6 +1584,8 @@ assert math.lcm(2**40, 3**30) == 226379693794030958489370624
 assert math.lcm(2**62, 3) == 3 * 2**62
 assert math.lcm(-big, 3) == 3541774862152233910272
 assert math.lcm(big, 0) == 0
+assert math.lcm(big, 0, big) == 0
+assert math.lcm(huge, 0) == 0
 for compute in [lambda: math.lcm(0, 2.0), lambda: math.lcm(big, 0, 2.0)]:
     try:
         compute()

--- a/crates/monty/tests/math_module.rs
+++ b/crates/monty/tests/math_module.rs
@@ -7,57 +7,17 @@ fn run_expr(code: &str) -> MontyObject {
     ex.run_no_limits(vec![]).unwrap()
 }
 
-/// Helper to run Python code that is expected to raise an exception.
-/// Returns the exception message string.
-fn run_expect_error(code: &str) -> String {
-    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
-    let err = ex.run_no_limits(vec![]).unwrap_err();
-    err.to_string()
-}
-
 // ==========================
-// Overflow tests (i64-specific)
+// comb near the i64 limit
 // ==========================
 
-/// `math.factorial(21)` overflows i64 (21! = 51090942171709440000 > i64::MAX).
-/// Monty raises OverflowError since it doesn't have big integer support.
-#[test]
-fn factorial_i64_overflow() {
-    let msg = run_expect_error("import math\nmath.factorial(21)");
-    assert!(
-        msg.contains("OverflowError"),
-        "Expected OverflowError for factorial(21), got: {msg}"
-    );
-}
-
-/// `math.comb(66, 33)` fits in i64 (7219428434016265740) thanks to GCD reduction
-/// that avoids intermediate overflow. Verify it computes the correct value.
+/// `math.comb(66, 33)` is the largest central binomial that fits an `i64`
+/// (7219428434016265740); the result must demote back to a machine int.
 #[test]
 fn comb_large_but_fits_i64() {
     let result = run_expr("import math\nmath.comb(66, 33)");
     let v: i64 = (&result).try_into().unwrap();
     assert_eq!(v, 7_219_428_434_016_265_740);
-}
-
-/// `math.comb(68, 34)` overflows i64 even with GCD reduction
-/// (68C34 = 28048800420600 * ... > i64::MAX).
-#[test]
-fn comb_i64_overflow() {
-    let msg = run_expect_error("import math\nmath.comb(68, 34)");
-    assert!(
-        msg.contains("OverflowError"),
-        "Expected OverflowError for comb(68, 34), got: {msg}"
-    );
-}
-
-/// `math.perm(21, 21)` overflows i64 (same as 21! which exceeds i64::MAX).
-#[test]
-fn perm_i64_overflow() {
-    let msg = run_expect_error("import math\nmath.perm(21, 21)");
-    assert!(
-        msg.contains("OverflowError"),
-        "Expected OverflowError for perm(21, 21), got: {msg}"
-    );
 }
 
 // ==========================

--- a/docs/limitations/math.md
+++ b/docs/limitations/math.md
@@ -24,5 +24,10 @@ below.
 
 - Real-number arguments accept floats, integers of any size, and booleans, but do not call user-defined `__float__` or
     `__index__` methods.
-- `factorial`, `comb`, and `perm` raise `OverflowError` for results exceeding the signed 64-bit integer range.
-    `prod` and integer-only `sumprod` support arbitrary-size integer results.
+- `math.log`, `log2` and `log10` of an int beyond the float range compute
+    `log(m) + log(2) * e` from the int's leading bits, as CPython does. Monty
+    never fuses that multiply-add, so the result can differ from CPython by one
+    unit in the last place on builds whose C compiler emits a fused
+    multiply-add (CPython on Apple Silicon does; Linux x86-64 and Windows
+    builds do not). For example `math.log(3**700)` is `769.0286020676768` in
+    Monty and `769.0286020676767` in CPython on macOS arm64.

--- a/docs/limitations/math.md
+++ b/docs/limitations/math.md
@@ -24,6 +24,9 @@ below.
 
 - Real-number arguments accept floats, integers of any size, and booleans, but do not call user-defined `__float__` or
     `__index__` methods.
+- `math.factorial(n)` and `math.perm(n)` accept `n` up to `2**63 - 1` everywhere and
+    report that limit in their `OverflowError`. CPython's limit is C `long`, so on
+    Windows it is `2**31 - 1` and the message says `should not exceed 2147483647`.
 - `math.log`, `log2` and `log10` of an int beyond the float range compute
     `log(m) + log(2) * e` from the int's leading bits, as CPython does. Monty
     never fuses that multiply-add, so the result can differ from CPython by one

--- a/docs/limitations/resource_limits.md
+++ b/docs/limitations/resource_limits.md
@@ -30,7 +30,8 @@ WebAssembly runtimes do.
     are **pre-checked** before allocating: integer multiplication, left
     shift, integer power, sequence repeat (`'x' * n`), replacement
     (`str.replace`, `bytes.replace`), `re.sub`, padding (`str.ljust`, `str.center`,
-    `str.zfill`, `bytes.ljust`, …), integer division and `divmod`, deque
+    `str.zfill`, `bytes.ljust`, …), integer division and `divmod`,
+    `math.factorial`, `math.comb` and `math.perm`, deque
     rotation, slicing and repeat, materialising an iterator into a
     container, and string formatting with dynamic width or precision, for
     f-strings (`f"{v:>{w}}"`, `f"{v:.{p}f}"`), `str.format()`


### PR DESCRIPTION
`pow(base, exp)` now delegates to the `**` operator instead of carrying its own copies of the int and long-int cases, so the two can no longer drift.

`round()` on a long int returns it unchanged for a non-negative `ndigits` and otherwise rounds exactly, half to even, like `int.__round__`.

The `math` module treated every long int as a type error. Real-number functions now convert it the way `float()` does, `log`, `log2` and `log10` work beyond the float range from the int's leading bits, and `isqrt`, `gcd`, `lcm`, `factorial`, `comb` and `perm` take and return ints of any size with CPython's argument errors. `factorial`, `comb` and `perm` were also failing on results past 64 bits, which no limitations page recorded; their results are now preflighted against the memory limit and the loops poll the clock.


Claude-Session: https://claude.ai/code/session_01T7vqm7JFwc59geVGAf3tUo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `pow()`, `round()`, and the `math` module handle long ints like CPython does, and removes the 64-bit result cap on `factorial`, `comb`, and `perm`.

**Builtins**
- `pow(base, exp)` delegates to `**`, so its int and long-int paths can't drift.
- Three-argument `pow()` now matches CPython's errors: a float operand gets the "3rd argument not allowed" message, other non-integer types an unsupported-operand TypeError.
- `round()` returns a long int unchanged for non-negative `ndigits` and otherwise rounds exactly, half to even.

**Math module**
- Real-number functions convert long ints like `float()`, raising `OverflowError` past the float range; `floor`, `ceil`, and `trunc` return them unchanged.
- `log`, `log2`, and `log10` work beyond the float range from the int's leading bits.
- `isqrt`, `gcd`, `lcm`, `factorial`, `comb`, and `perm` accept long ints, with CPython's errors for arguments beyond the machine-int range; `factorial` and `perm` always use the 64-bit limit, where CPython's follows C `long`.
- `factorial`, `comb`, and `perm` preflight their result size and poll the clock; `lcm` preflights each step like `*`.

<sup>Written for commit 422862820434c89e9cebc9df993444cce3695c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

