### PR TITLE
Add a watchdog for the CPython side of test cases and deflake `lookup__mutation.py`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -709,6 +709,7 @@ All these markers must be at the start of comment lines to be recognized.
 - Run `make lint-py` after adding tests
 - Use `make complete-tests` to fill in blank expectations
 - Regression tests run via `datatest-stable` harness in `crates/monty-datatest/src/main.rs`, use `make test-cases` to run them
+- The CPython side of each case runs under a 30s watchdog (`CpythonWatchdog` in the harness): a hanging case fails on its own instead of stalling the whole run, and one stuck in C code aborts the run naming the test
 
 ### Rust integration tests and `insta` snapshots
 

--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -13,9 +13,10 @@ use std::{
     fs::{self, canonicalize},
     panic::{self, AssertUnwindSafe},
     path::{Path, PathBuf},
-    str,
+    process, str,
     sync::{
-        LazyLock, Mutex, OnceLock, PoisonError,
+        Arc, LazyLock, Mutex, OnceLock, PoisonError,
+        atomic::{AtomicBool, Ordering},
         mpsc::{self, RecvTimeoutError},
     },
     thread,
@@ -2045,32 +2046,31 @@ fn wrap_code_for_async(code: &str, need_return_value: bool) -> (String, Option<S
 /// file's globals before execution.
 ///
 /// When `async_mode` is true, code is wrapped in an async context before execution.
-fn run_traceback_script(path: &Path, iter_mode: bool, async_mode: bool) -> String {
+fn run_traceback_script(path: &Path, test_name: &str, iter_mode: bool, async_mode: bool) -> String {
     // Serialize CPython work across the whole process; see [`CPYTHON_TEST_LOCK`].
     let _cpython_guard = CPYTHON_TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
     Python::attach(|py| {
         let _recursion_guard = RecursionLimitGuard::new(py);
+        let _watchdog = CpythonWatchdog::arm(py, test_name);
         let run_traceback = import_run_traceback(py);
 
         // Get absolute path for the test file
         let abs_path = path.canonicalize().expect("Failed to get absolute path");
         let path_str = abs_path.to_str().expect("Invalid UTF-8 in path");
 
-        // Call run_file_and_get_traceback with the recursion limit, iter_mode, and async_mode flags
-        let result = run_traceback
-            .call_method1(
-                "run_file_and_get_traceback",
-                (path_str, TEST_RECURSION_LIMIT, iter_mode, async_mode),
-            )
-            .expect("Failed to call run_file_and_get_traceback");
-
-        // Handle None return (no exception raised)
-        if result.is_none() {
-            String::new()
-        } else {
-            result
+        // Call run_file_and_get_traceback with the recursion limit, iter_mode, and async_mode flags.
+        // Only `CPythonTestTimeout` escapes the script's own `except BaseException`; its
+        // traceback becomes the actual output so the case fails naming the watchdog.
+        match run_traceback.call_method1(
+            "run_file_and_get_traceback",
+            (path_str, TEST_RECURSION_LIMIT, iter_mode, async_mode),
+        ) {
+            Err(err) => format_traceback(py, &err),
+            // None means no exception was raised
+            Ok(result) if result.is_none() => String::new(),
+            Ok(result) => result
                 .extract()
-                .expect("Failed to extract string from return value of run_file_and_get_traceback")
+                .expect("Failed to extract string from return value of run_file_and_get_traceback"),
         }
     })
 }
@@ -2103,6 +2103,78 @@ fn format_traceback(py: Python<'_>, exc: &PyErr) -> String {
 /// user code execution, and any post-mortem formatting. Monty's runner is
 /// not affected and continues to run concurrently with other Monty cases.
 static CPYTHON_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Soft deadline for the CPython side of one fixture; the slowest legitimate
+/// case takes well under a second, so reaching this means a hang.
+const CPYTHON_SOFT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Extra time an interrupted case gets before the whole run is aborted.
+const CPYTHON_HARD_GRACE: Duration = Duration::from_secs(30);
+
+/// Watchdog for the CPython side of one fixture, armed inside `Python::attach`.
+///
+/// CPython cases hold [`CPYTHON_TEST_LOCK`], so one case that never returns
+/// (an unbounded dict-probe restart, say) stalls every worker thread until CI
+/// kills the job without naming a test. Past [`CPYTHON_SOFT_TIMEOUT`] the
+/// watchdog raises `CPythonTestTimeout` in the test thread (delivered at its
+/// next bytecode boundary) so only that case fails; a thread stuck in C code
+/// never gets there, so after [`CPYTHON_HARD_GRACE`] more the process exits,
+/// naming the test.
+struct CpythonWatchdog {
+    /// Set while still attached, so a late interrupt cannot land on the next
+    /// case run by the same OS thread.
+    finished: Arc<AtomicBool>,
+    /// Dropping the sender wakes the watchdog thread, which then exits.
+    _alive: mpsc::Sender<()>,
+}
+
+impl CpythonWatchdog {
+    /// Start watching the attached thread's run of `test_name`; keep the guard alive until it ends.
+    fn arm(py: Python<'_>, test_name: &str) -> Self {
+        let thread_ident: u64 = py
+            .import("threading")
+            .and_then(|threading| threading.call_method0("get_ident"))
+            .and_then(|ident| ident.extract())
+            .expect("Failed to read threading.get_ident()");
+        let finished = Arc::new(AtomicBool::new(false));
+        let (alive, rx) = mpsc::channel::<()>();
+        let test_name = test_name.to_owned();
+        let interrupt_flag = Arc::clone(&finished);
+        thread::spawn(move || {
+            if !matches!(rx.recv_timeout(CPYTHON_SOFT_TIMEOUT), Err(RecvTimeoutError::Timeout)) {
+                return;
+            }
+            eprintln!("watchdog: CPython side of {test_name} exceeded {CPYTHON_SOFT_TIMEOUT:?}, interrupting it");
+            // Attaching blocks while the test thread holds the GIL inside C code, so
+            // interrupt from yet another thread and keep the hard deadline ticking here.
+            thread::spawn(move || {
+                Python::attach(|py| {
+                    if !interrupt_flag.load(Ordering::SeqCst) {
+                        import_script(py, "cpython_watchdog")
+                            .call_method1("interrupt_thread", (thread_ident,))
+                            .expect("Failed to call cpython_watchdog.interrupt_thread");
+                    }
+                });
+            });
+            if !matches!(rx.recv_timeout(CPYTHON_HARD_GRACE), Err(RecvTimeoutError::Timeout)) {
+                return;
+            }
+            eprintln!(
+                "watchdog: CPython side of {test_name} still running {CPYTHON_HARD_GRACE:?} after being interrupted, aborting the test run"
+            );
+            process::exit(1);
+        });
+        Self {
+            finished,
+            _alive: alive,
+        }
+    }
+}
+
+impl Drop for CpythonWatchdog {
+    fn drop(&mut self) {
+        self.finished.store(true, Ordering::SeqCst);
+    }
+}
 
 /// RAII guard that snapshots `sys.getrecursionlimit()` on construction and
 /// restores it on drop.
@@ -2138,15 +2210,21 @@ impl Drop for RecursionLimitGuard<'_> {
 
 /// Import the run_traceback module
 fn import_run_traceback(py: Python<'_>) -> Bound<'_, PyModule> {
-    // Add scripts directory to sys.path (binary is expected to be run from project root)
+    import_script(py, "run_traceback")
+}
+
+/// Import a helper module from the repo's `scripts/` directory, putting that
+/// directory on `sys.path` first so the binary works from any cwd.
+fn import_script<'py>(py: Python<'py>, name: &str) -> Bound<'py, PyModule> {
     let sys = py.import("sys").expect("Failed to import sys");
     let sys_path = sys.getattr("path").expect("Failed to get sys.path");
-    sys_path
-        .call_method1("insert", (0, SCRIPTS_DIR))
-        .expect("Failed to add scripts to sys.path");
-
-    // Import the run_traceback module
-    py.import("run_traceback").expect("Failed to import run_traceback")
+    if !sys_path.contains(SCRIPTS_DIR).expect("Failed to search sys.path") {
+        sys_path
+            .call_method1("insert", (0, SCRIPTS_DIR))
+            .expect("Failed to add scripts to sys.path");
+    }
+    py.import(name)
+        .unwrap_or_else(|err| panic!("Failed to import scripts/{name}.py: {err}"))
 }
 
 /// Import `test_fixtures` (lazily, cached by pyo3) and return the module.
@@ -2157,12 +2235,7 @@ fn import_run_traceback(py: Python<'_>) -> Bound<'_, PyModule> {
 /// `os.environ` monkey-patch) before any test thread races on it; later
 /// calls return the cached `sys.modules` entry.
 fn import_shared_test_globals(py: Python<'_>) -> Bound<'_, PyModule> {
-    let sys = py.import("sys").expect("Failed to import sys");
-    let sys_path = sys.getattr("path").expect("Failed to get sys.path");
-    sys_path
-        .call_method1("insert", (0, SCRIPTS_DIR))
-        .expect("Failed to add scripts to sys.path");
-    py.import("test_fixtures").expect("Failed to import test_fixtures")
+    import_script(py, "test_fixtures")
 }
 
 /// Result from CPython execution - either a value to compare, or an early return.
@@ -2213,7 +2286,7 @@ fn try_run_cpython_test(
 
     // Traceback tests use the external script for reliable caret line support
     if let Expectation::Traceback(expected) = expectation {
-        let result = run_traceback_script(path, iter_mode, async_mode);
+        let result = run_traceback_script(path, &test_name, iter_mode, async_mode);
         if result != *expected {
             return Err(TestFailure {
                 test_name,
@@ -2256,6 +2329,7 @@ fn try_run_cpython_test(
     let _cpython_guard = CPYTHON_TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
     let result: CpythonResult = Python::attach(|py| {
         let _recursion_guard = RecursionLimitGuard::new(py);
+        let _watchdog = CpythonWatchdog::arm(py, &test_name);
         // Execute statements at module level
         let globals = PyDict::new(py);
 

--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -16,7 +16,6 @@ use std::{
     process, str,
     sync::{
         Arc, LazyLock, Mutex, OnceLock, PoisonError,
-        atomic::{AtomicBool, Ordering},
         mpsc::{self, RecvTimeoutError},
     },
     thread,
@@ -2046,12 +2045,17 @@ fn wrap_code_for_async(code: &str, need_return_value: bool) -> (String, Option<S
 /// file's globals before execution.
 ///
 /// When `async_mode` is true, code is wrapped in an async context before execution.
-fn run_traceback_script(path: &Path, test_name: &str, iter_mode: bool, async_mode: bool) -> String {
+fn run_traceback_script(
+    path: &Path,
+    test_name: &str,
+    iter_mode: bool,
+    async_mode: bool,
+) -> Result<String, TestFailure> {
     // Serialize CPython work across the whole process; see [`CPYTHON_TEST_LOCK`].
     let _cpython_guard = CPYTHON_TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
-    Python::attach(|py| {
+    let watchdog = CpythonWatchdog::arm(test_name);
+    let traceback = Python::attach(|py| {
         let _recursion_guard = RecursionLimitGuard::new(py);
-        let _watchdog = CpythonWatchdog::arm(py, test_name);
         let run_traceback = import_run_traceback(py);
 
         // Get absolute path for the test file
@@ -2072,7 +2076,8 @@ fn run_traceback_script(path: &Path, test_name: &str, iter_mode: bool, async_mod
                 .extract()
                 .expect("Failed to extract string from return value of run_file_and_get_traceback"),
         }
-    })
+    });
+    watchdog.check(test_name).map(|()| traceback)
 }
 
 fn format_traceback(py: Python<'_>, exc: &PyErr) -> String {
@@ -2110,35 +2115,49 @@ const CPYTHON_SOFT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Extra time an interrupted case gets before the whole run is aborted.
 const CPYTHON_HARD_GRACE: Duration = Duration::from_secs(30);
 
-/// Watchdog for the CPython side of one fixture, armed inside `Python::attach`.
+/// Where a fixture's CPython run stands, shared by its thread and the watchdog.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WatchdogState {
+    /// The fixture is still running.
+    Running,
+    /// The watchdog raised `CPythonTestTimeout` in the fixture's thread.
+    Interrupted,
+    /// The fixture returned; an interrupt must no longer be raised.
+    Finished,
+}
+
+/// Watchdog for the CPython side of one fixture, armed before `Python::attach`.
 ///
 /// CPython cases hold [`CPYTHON_TEST_LOCK`], so one case that never returns
 /// (an unbounded dict-probe restart, say) stalls every worker thread until CI
 /// kills the job without naming a test. Past [`CPYTHON_SOFT_TIMEOUT`] the
 /// watchdog raises `CPythonTestTimeout` in the test thread (delivered at its
-/// next bytecode boundary) so only that case fails; a thread stuck in C code
-/// never gets there, so after [`CPYTHON_HARD_GRACE`] more the process exits,
-/// naming the test.
+/// next bytecode boundary) and the case fails through [`Self::check`] even if
+/// the fixture catches it; a thread stuck in C code never gets there, so after
+/// [`CPYTHON_HARD_GRACE`] more the process exits, naming the test.
 struct CpythonWatchdog {
-    /// Set while still attached, so a late interrupt cannot land on the next
-    /// case run by the same OS thread.
-    finished: Arc<AtomicBool>,
+    /// Checked and advanced under one lock, so an interrupt is never raised
+    /// after the fixture finished and cannot land on this thread's next case.
+    state: Arc<Mutex<WatchdogState>>,
+    /// `threading.get_ident()` of the fixture's thread, the interrupt's target.
+    thread_ident: u64,
     /// Dropping the sender wakes the watchdog thread, which then exits.
     _alive: mpsc::Sender<()>,
 }
 
 impl CpythonWatchdog {
-    /// Start watching the attached thread's run of `test_name`; keep the guard alive until it ends.
-    fn arm(py: Python<'_>, test_name: &str) -> Self {
-        let thread_ident: u64 = py
-            .import("threading")
-            .and_then(|threading| threading.call_method0("get_ident"))
-            .and_then(|ident| ident.extract())
-            .expect("Failed to read threading.get_ident()");
-        let finished = Arc::new(AtomicBool::new(false));
+    /// Start watching the current thread's run of `test_name`; keep the guard alive until it ends.
+    fn arm(test_name: &str) -> Self {
+        let thread_ident: u64 = Python::attach(|py| {
+            py.import("threading")
+                .and_then(|threading| threading.call_method0("get_ident"))
+                .and_then(|ident| ident.extract())
+        })
+        .expect("Failed to read threading.get_ident()");
+        let state = Arc::new(Mutex::new(WatchdogState::Running));
         let (alive, rx) = mpsc::channel::<()>();
         let test_name = test_name.to_owned();
-        let interrupt_flag = Arc::clone(&finished);
+        let interrupt_state = Arc::clone(&state);
         thread::spawn(move || {
             if !matches!(rx.recv_timeout(CPYTHON_SOFT_TIMEOUT), Err(RecvTimeoutError::Timeout)) {
                 return;
@@ -2148,10 +2167,12 @@ impl CpythonWatchdog {
             // interrupt from yet another thread and keep the hard deadline ticking here.
             thread::spawn(move || {
                 Python::attach(|py| {
-                    if !interrupt_flag.load(Ordering::SeqCst) {
+                    let mut state = interrupt_state.lock().unwrap_or_else(PoisonError::into_inner);
+                    if *state == WatchdogState::Running {
                         import_script(py, "cpython_watchdog")
                             .call_method1("interrupt_thread", (thread_ident,))
                             .expect("Failed to call cpython_watchdog.interrupt_thread");
+                        *state = WatchdogState::Interrupted;
                     }
                 });
             });
@@ -2164,15 +2185,37 @@ impl CpythonWatchdog {
             process::exit(1);
         });
         Self {
-            finished,
+            state,
+            thread_ident,
             _alive: alive,
+        }
+    }
+
+    /// Fail the case if the watchdog interrupted the run. Checked once the run
+    /// returns, because a fixture's `except BaseException` can swallow the interrupt.
+    fn check(&self, test_name: &str) -> Result<(), TestFailure> {
+        if *self.state.lock().unwrap_or_else(PoisonError::into_inner) == WatchdogState::Interrupted {
+            Err(TestFailure {
+                test_name: test_name.to_owned(),
+                kind: "CPython watchdog".to_owned(),
+                expected: format!("completion within {CPYTHON_SOFT_TIMEOUT:?}"),
+                actual: "interrupted by the watchdog".to_owned(),
+            })
+        } else {
+            Ok(())
         }
     }
 }
 
 impl Drop for CpythonWatchdog {
     fn drop(&mut self) {
-        self.finished.store(true, Ordering::SeqCst);
+        // Released before attaching: the interrupting thread takes the lock while attached.
+        *self.state.lock().unwrap_or_else(PoisonError::into_inner) = WatchdogState::Finished;
+        // An interrupt raised but not yet delivered would surface in this thread's
+        // next case; if it lands inside this very call, the error is that delivery.
+        Python::attach(|py| {
+            let _ = import_script(py, "cpython_watchdog").call_method1("clear_pending", (self.thread_ident,));
+        });
     }
 }
 
@@ -2218,7 +2261,9 @@ fn import_run_traceback(py: Python<'_>) -> Bound<'_, PyModule> {
 fn import_script<'py>(py: Python<'py>, name: &str) -> Bound<'py, PyModule> {
     let sys = py.import("sys").expect("Failed to import sys");
     let sys_path = sys.getattr("path").expect("Failed to get sys.path");
-    if !sys_path.contains(SCRIPTS_DIR).expect("Failed to search sys.path") {
+    // First, not merely present: a same-named module earlier on the path must not shadow ours.
+    let first: Option<String> = sys_path.get_item(0).ok().and_then(|entry| entry.extract().ok());
+    if first.as_deref() != Some(SCRIPTS_DIR) {
         sys_path
             .call_method1("insert", (0, SCRIPTS_DIR))
             .expect("Failed to add scripts to sys.path");
@@ -2286,7 +2331,7 @@ fn try_run_cpython_test(
 
     // Traceback tests use the external script for reliable caret line support
     if let Expectation::Traceback(expected) = expectation {
-        let result = run_traceback_script(path, &test_name, iter_mode, async_mode);
+        let result = run_traceback_script(path, &test_name, iter_mode, async_mode)?;
         if result != *expected {
             return Err(TestFailure {
                 test_name,
@@ -2327,9 +2372,9 @@ fn try_run_cpython_test(
 
     // Serialize CPython work across the whole process; see [`CPYTHON_TEST_LOCK`].
     let _cpython_guard = CPYTHON_TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let watchdog = CpythonWatchdog::arm(&test_name);
     let result: CpythonResult = Python::attach(|py| {
         let _recursion_guard = RecursionLimitGuard::new(py);
-        let _watchdog = CpythonWatchdog::arm(py, &test_name);
         // Execute statements at module level
         let globals = PyDict::new(py);
 
@@ -2449,6 +2494,7 @@ fn try_run_cpython_test(
         }
     });
 
+    watchdog.check(&test_name)?;
     match result {
         CpythonResult::Value(actual) => {
             let expected = expectation.expected_value();

--- a/crates/monty-pool/src/telemetry/tracing.rs
+++ b/crates/monty-pool/src/telemetry/tracing.rs
@@ -962,6 +962,8 @@ fn print_stream(stream: i32) -> &'static str {
 // recording is a side effect of the worker, not part of the pool's public API
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, PoisonError};
+
     use logfire::{Logfire, config::AdvancedOptions, set_local_logfire};
     use monty_proto::{WireFunctionCall, pb, pb::os_call::Call};
     use monty_types::MontyObject;
@@ -972,6 +974,17 @@ mod tests {
     };
 
     use super::{ATTR_SIZE_LIMIT, Recorder, bytes_attr, render_ext_result};
+
+    /// Every subscriber these tests install, held for the life of the process.
+    ///
+    /// `set_local_logfire` registers the subscriber with tracing-core, which
+    /// upgrades that weak registration inside its dispatcher read lock whenever
+    /// callsite interest is rebuilt and drops the temporary handle there. If that
+    /// were the last reference, the OpenTelemetry meter provider's destructor
+    /// would log through a callsite that takes the same lock again, and with
+    /// another test's `set_local_logfire` queued for the write lock the whole
+    /// test binary deadlocks. One extra reference keeps the drop out of that loop.
+    static INSTALLED: Mutex<Vec<Logfire>> = Mutex::new(Vec::new());
 
     /// A local logfire capturing spans and logs in memory instead of exporting.
     fn test_logfire() -> (Logfire, InMemorySpanExporter, InMemoryLogExporter) {
@@ -984,6 +997,10 @@ mod tests {
             .with_advanced_options(AdvancedOptions::default().with_log_processor(SimpleLogProcessor::new(logs.clone())))
             .finish()
             .unwrap();
+        INSTALLED
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(logfire.clone());
         (logfire, spans, logs)
     }
 

--- a/crates/monty-pool/tests/metrics.rs
+++ b/crates/monty-pool/tests/metrics.rs
@@ -13,7 +13,7 @@ use std::{
     future::ready,
     path::{Path, PathBuf},
     process::Command,
-    sync::{Arc, Mutex, Once},
+    sync::{Arc, Mutex, Once, PoisonError},
     time::Duration,
 };
 
@@ -87,6 +87,18 @@ impl TelemetryAdapter for BatchCapture {
     }
 }
 
+/// Every provider these tests hand to a pool, held for the life of the process.
+///
+/// The pool installs the provider's subscriber with `set_local_logfire` on
+/// every turn, which registers it with tracing-core. tracing-core upgrades that
+/// weak registration inside its dispatcher read lock whenever callsite interest
+/// is rebuilt and drops the temporary handle there; if that were the last
+/// reference, the OpenTelemetry meter provider's destructor would log through
+/// a callsite that takes the same lock again, and with another test's turn
+/// queued for the write lock the whole test binary deadlocks. One extra
+/// reference keeps the drop out of that loop.
+static INSTALLED: Mutex<Vec<Logfire>> = Mutex::new(Vec::new());
+
 impl Capture {
     /// Builds a local provider and its Monty metrics handle.
     fn new() -> (Metrics, Arc<Self>) {
@@ -99,6 +111,10 @@ impl Capture {
             ))
             .finish()
             .unwrap();
+        INSTALLED
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(logfire.clone());
         let metrics = Metrics::for_logfire(logfire.clone());
         (metrics, Arc::new(Self { logfire, exporter }))
     }

--- a/crates/monty/test_cases/lookup__mutation.py
+++ b/crates/monty/test_cases/lookup__mutation.py
@@ -4,6 +4,11 @@ from collections import deque
 # `__eq__` methods that may mutate the container being searched. CPython
 # restarts dict/set probes, clamps `list.remove`, and raises for deque;
 # Monty matches (see issue #729 — these previously panicked the worker).
+#
+# The clearing `__eq__` classes below mutate once per instance. Their refill
+# puts int 1, which shares the key's hash, back in the table, so the restarted
+# probe compares the key again; if that compare mutated too, CPython's restart
+# loop would end only when the rebuilt table reused the freed table's address.
 
 
 # === dict: `in` with a clearing __eq__ restarts the probe (issue #729 repro) ===
@@ -11,13 +16,18 @@ D = {}
 
 
 class DictClearer:
+    def __init__(self):
+        self.cleared = False
+
     def __hash__(self):
         return 1
 
     def __eq__(self, other):
-        D.clear()
-        for i in range(3000):
-            D[i] = i
+        if not self.cleared:
+            self.cleared = True
+            D.clear()
+            for i in range(3000):
+                D[i] = i
         return False
 
 
@@ -33,13 +43,18 @@ D2 = {}
 
 
 class DictClearer2:
+    def __init__(self):
+        self.cleared = False
+
     def __hash__(self):
         return 1
 
     def __eq__(self, other):
-        D2.clear()
-        for i in range(100):
-            D2[i] = i
+        if not self.cleared:
+            self.cleared = True
+            D2.clear()
+            for i in range(100):
+                D2[i] = i
         return False
 
 
@@ -55,13 +70,18 @@ D3 = {}
 
 
 class DictClearer3:
+    def __init__(self):
+        self.cleared = False
+
     def __hash__(self):
         return 1
 
     def __eq__(self, other):
-        D3.clear()
-        for i in range(100):
-            D3[i] = i
+        if not self.cleared:
+            self.cleared = True
+            D3.clear()
+            for i in range(100):
+                D3[i] = i
         return False
 
 
@@ -82,13 +102,18 @@ D4 = {}
 
 
 class DictClearer4:
+    def __init__(self):
+        self.cleared = False
+
     def __hash__(self):
         return 1
 
     def __eq__(self, other):
-        D4.clear()
-        for i in range(100):
-            D4[i] = i
+        if not self.cleared:
+            self.cleared = True
+            D4.clear()
+            for i in range(100):
+                D4[i] = i
         return False
 
 
@@ -266,13 +291,18 @@ S = set()
 
 
 class SetClearer:
+    def __init__(self):
+        self.cleared = False
+
     def __hash__(self):
         return 1
 
     def __eq__(self, other):
-        S.clear()
-        for i in range(100):
-            S.add(i)
+        if not self.cleared:
+            self.cleared = True
+            S.clear()
+            for i in range(100):
+                S.add(i)
         return False
 
 
@@ -292,13 +322,18 @@ S2 = set()
 
 
 class SetClearer2:
+    def __init__(self):
+        self.cleared = False
+
     def __hash__(self):
         return 1
 
     def __eq__(self, other):
-        S2.clear()
-        for i in range(100):
-            S2.add(i)
+        if not self.cleared:
+            self.cleared = True
+            S2.clear()
+            for i in range(100):
+                S2.add(i)
         return False
 
 

--- a/scripts/cpython_watchdog.py
+++ b/scripts/cpython_watchdog.py
@@ -31,3 +31,8 @@ def interrupt_thread(thread_ident: int) -> bool:
         ctypes.c_ulong(thread_ident), ctypes.py_object(CPythonTestTimeout)
     )
     return found == 1
+
+
+def clear_pending(thread_ident: int) -> None:
+    """Discard an interrupt raised in thread `thread_ident` that it has not delivered yet."""
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_ulong(thread_ident), None)

--- a/scripts/cpython_watchdog.py
+++ b/scripts/cpython_watchdog.py
@@ -1,0 +1,33 @@
+"""Interrupt support for the monty-datatest CPython watchdog.
+
+The Rust harness calls `interrupt_thread` from a helper thread once the CPython
+side of a fixture has run past its deadline; see `CpythonWatchdog` in
+`crates/monty-datatest/src/main.rs`.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+
+class CPythonTestTimeout(BaseException):
+    """Raised asynchronously in a test thread that exceeded the watchdog deadline.
+
+    A `BaseException` so a fixture's own `except Exception` cannot swallow it.
+    """
+
+    def __str__(self) -> str:
+        return 'CPython side of the test exceeded the monty-datatest watchdog deadline'
+
+
+def interrupt_thread(thread_ident: int) -> bool:
+    """Raise `CPythonTestTimeout` in thread `thread_ident` at its next bytecode boundary.
+
+    Returns whether a matching thread state was found. A thread stuck in C code
+    that never returns to the eval loop cannot be interrupted this way; the Rust
+    watchdog then exits the process instead.
+    """
+    found = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_ulong(thread_ident), ctypes.py_object(CPythonTestTimeout)
+    )
+    return found == 1

--- a/scripts/run_traceback.py
+++ b/scripts/run_traceback.py
@@ -14,6 +14,7 @@ import tempfile
 import traceback
 from threading import Lock
 
+from cpython_watchdog import CPythonTestTimeout
 from test_fixtures import exported_globals
 
 lock = Lock()
@@ -87,6 +88,8 @@ def run_file_and_get_traceback(
                 runpy.run_path(file_path, init_globals=exported_globals, run_name='__main__')
             except SystemExit:
                 pass  # don't error on ctrl+c
+            except CPythonTestTimeout:
+                raise  # the harness reports the watchdog interrupt itself
             except BaseException as e:
                 # Format the traceback
                 stack = traceback.format_exception(type(e), e, e.__traceback__)


### PR DESCRIPTION
CPython cases run under a process-wide mutex, so one case that never returns stalls every worker thread until CI kills the job without naming a test. Each CPython run now arms a `CpythonWatchdog`: after 30s it raises `CPythonTestTimeout` in the test thread through `PyThreadState_SetAsyncExc` so only that case fails, and if the thread is stuck in C code and never reaches a bytecode boundary, 30s later the process exits naming the test. A fixture that catches the interrupt still fails, and an interrupt that was raised but not yet delivered is cleared when the run ends, so it cannot land on the next case.

`lookup__mutation.py` was the case that hung: its clearing `__eq__` refilled the table with int 1, which shares the key's hash, so CPython's restarted probe called `__eq__` again and mutated again. That loop only ended when the rebuilt keys table happened to reuse the freed table's address. The clearing classes now mutate once per instance, which terminates deterministically.

## `monty-pool` telemetry tests deadlock

A separate intermittent hang, seen on the Windows job and reproduced locally about once in thirty runs with eight test threads. Every thread ended up waiting on tracing-core's dispatcher `RwLock`:

1. A test's `set_local_logfire` takes the read lock and rebuilds callsite interest.
2. In that loop tracing-core upgrades each registered subscriber's weak reference and drops the temporary handle. One of those was the last reference to a subscriber of a test that had just finished.
3. Dropping it runs OpenTelemetry's meter-provider destructor, which logs through a callsite that had not been hit before, so registering it takes the same read lock again on the same thread.
4. Another test's `set_local_logfire` is queued for the write lock. The std `RwLock` prefers writers, so the recursive read never returns and everyone queues behind it.

The real defects are upstream (tracing-core drops subscriber handles under its lock, opentelemetry logs from a destructor). The test helpers now keep one reference to every subscriber they register for the life of the process, so no subscriber is ever dropped inside that loop. Applied to the tracing unit tests and to the metrics integration test, whose pool registers the subscriber on every turn. 300 runs at eight threads no longer hang, against 4 hangs in 120 before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iKBes69v15uKMb9wYwD6i

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a watchdog for the CPython side of datatest cases so a hanging test fails on its own instead of stalling the whole run, even when the fixture catches the interrupt. Also deflakes `lookup__mutation.py`, where the clearing `__eq__` could loop forever, and fixes an intermittent hang in `monty-pool`'s telemetry tests.

- After 30 seconds, the watchdog raises `CPythonTestTimeout` in the test thread via `PyThreadState_SetAsyncExc`, so only that case fails.
- A test stuck in C code never reaches a bytecode boundary, so the process exits 30 seconds later naming the test.
- A fixture that swallows the `CPythonTestTimeout` still fails as a `CPython watchdog` case; undelivered interrupts are cleared when the run ends so a late one can't hit another case.
- `import_script` now requires the `scripts` directory first on `sys.path` so a same-named module can't shadow ours.
- The clearing `__eq__` classes in `lookup__mutation.py` now mutate once per instance, which terminates deterministically.
- Any CPython-side test that legitimately takes longer than 30 seconds will now fail.
- The telemetry tests keep each installed `Logfire` subscriber alive for the process lifetime, so a subscriber can't be dropped while tracing-core holds its dispatcher lock.

<sup>Written for commit f1bdd7394f239a33d03028bfa5812c4b16b2f50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


